### PR TITLE
Add basic custom fields support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ website/node_modules
 
 website/vendor
 
+terraform-provider-netbox
+
 # Test exclusions
 !command/test-fixtures/**/*.tfstate
 !command/test-fixtures/**/.terraform/

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,15 +1,15 @@
 terraform {
   required_providers {
     netbox = {
-      source = "e-breuninger/netbox"
-      version = ">=0.0.2"
+      source  = "e-breuninger/netbox"
+      version = ">=0.0.3"
     }
   }
 }
 
 provider "netbox" {
-    server_url           = "https://netboxdemo.com/"
-    api_token            = " 72830d67beff4ae178b94d8f781842408df8069d"
+  server_url = "https://netboxdemo.com/"
+  api_token  = " 72830d67beff4ae178b94d8f781842408df8069d"
 }
 
 resource "netbox_device_role" "testdevicerole" {
@@ -45,6 +45,10 @@ resource "netbox_virtual_machine" "testvm" {
   tenant_id    = netbox_tenant.testtenant.id
   platform_id  = netbox_platform.testplatform.id
   role_id      = netbox_device_role.testdevicerole.id
+  # NOTE: Custom fields have to be created in the API first
+  #  custom_fields = {
+  #    "custom_field_name" = "custom field value"
+  #  }
 }
 
 resource "netbox_interface" "testinterface" {

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"github.com/e-breuninger/terraform-provider-netbox/netbox"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-        "github.com/e-breuninger/terraform-provider-netbox/netbox"
 )
 
 func main() {

--- a/netbox/resource_netbox_virtual_machine.go
+++ b/netbox/resource_netbox_virtual_machine.go
@@ -55,6 +55,12 @@ func resourceNetboxVirtualMachine() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"custom_fields": &schema.Schema{
+                                Type:     schema.TypeMap,
+                                Optional: true,
+                                Elem:     &schema.Schema{Type: schema.TypeString},
+				Description: "Note: Only text custom fields are supported at the moment.",
+                        },
 			"tags": &schema.Schema{
 				Type: schema.TypeSet,
 				Elem: &schema.Schema{
@@ -243,6 +249,7 @@ func resourceNetboxVirtualMachineRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("memory_mb", res.GetPayload().Memory)
 	d.Set("disk_size_gb", res.GetPayload().Disk)
 	d.Set("tags", res.GetPayload().Tags)
+	d.Set("custom_fields", res.GetPayload().CustomFields)
 	return diags
 }
 
@@ -316,6 +323,7 @@ func resourceNetboxVirtualMachineUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	data.Tags = getTagListFromResourceDataSet(d.Get("tags"))
+	data.CustomFields = d.Get("custom_fields").(map[string]interface{})
 
 	//	interfaceValue := d.Get("interface").(*schema.Set).List()
 	//	log.Printf("[FABI] WERT %v\n", interfaceValue)


### PR DESCRIPTION
This PR implements a simple version of custom fields.
Note that using custom fields has some consequences:
- only text custom fields are supported
- all custom fields should be set in the terraform configuration, else we get repeating diffs. This might be solvable with some non-trivial additional logic, which is out of scope for this PR.