### PR TITLE
Add virtual machines data source

### DIFF
--- a/netbox/data_source_netbox_virtual_machines.go
+++ b/netbox/data_source_netbox_virtual_machines.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"log"
 	"regexp"
 )
 
@@ -254,7 +253,6 @@ func dataSourceNetboxVirtualMachineRead(d *schema.ResourceData, m interface{}) e
 
 		mapping["vm_id"] = v.ID
 
-		log.Printf("Map %#v", mapping)
 		s = append(s, mapping)
 	}
 

--- a/netbox/data_source_netbox_virtual_machines.go
+++ b/netbox/data_source_netbox_virtual_machines.go
@@ -1,0 +1,232 @@
+package netbox
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/virtualization"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"log"
+)
+
+func dataSourceNetboxVirtualMachine() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNetboxVirtualMachineRead,
+		Schema: map[string]*schema.Schema{
+			"search": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type:     schema.TypeString,
+				},
+			},
+			"vms": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cluster_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"comments": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"config_context": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"custom_fields": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+						"disk_size_gb": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"local_context_data": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"memory_mb": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"platform_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"primary_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"primary_ip4": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"primary_ip6": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"role_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"site_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tag_ids": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeInt,
+							},
+						},
+						"tenant_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"vcpus": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"vm_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceNetboxVirtualMachineRead(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	params := virtualization.NewVirtualizationVirtualMachinesListParams()
+
+	if search, ok := d.GetOk("search"); ok {
+		var searchParams = search.(map[string]interface{})
+		for k, v := range searchParams {
+			switch k {
+			case "cluster_id":
+				var clusterString = v.(string)
+				params.ClusterID = &clusterString
+			case "cluster_group":
+				var clusterGroupString = v.(string)
+				params.ClusterGroup = &clusterGroupString
+			case "name":
+				var nameString = v.(string)
+				params.Name = &nameString
+			case "region":
+				var siteString = v.(string)
+				params.Site = &siteString
+			case "role":
+				var roleString = v.(string)
+				params.Role = &roleString
+			case "site":
+				var siteString = v.(string)
+				params.Site = &siteString
+			default:
+				return fmt.Errorf("'%s' is not a supported search parameter", k)
+			}
+		}
+	}
+
+	res, err := api.Virtualization.VirtualizationVirtualMachinesList(params, nil)
+	if err != nil {
+		return err
+	}
+
+	if *res.GetPayload().Count == int64(0) {
+		return errors.New("no result")
+	}
+
+	var s []map[string]interface{}
+	for _, v := range res.GetPayload().Results {
+		var mapping = make(map[string]interface{})
+		if v.Cluster != nil {
+			mapping["cluster_id"] = v.Cluster.ID
+		}
+		if v.Comments != "" {
+			mapping["comments"] = v.Comments
+		}
+		if v.ConfigContext != nil {
+			if configContext, err := json.Marshal(v.ConfigContext); err == nil {
+				mapping["config_context"] = string(configContext)
+			}
+		}
+		if v.CustomFields != nil {
+			mapping["custom_fields"] = v.CustomFields
+		}
+		if v.Disk != nil {
+			mapping["disk_size_gb"] = *v.Disk
+		}
+		if v.LocalContextData != nil {
+			if localContextData, err := json.Marshal(v.LocalContextData); err == nil {
+				mapping["local_context_data"] = string(localContextData)
+			}
+		}
+		if v.Memory != nil {
+			mapping["memory_mb"] = *v.Memory
+		}
+		if v.Name != nil {
+			mapping["name"] = *v.Name
+		}
+		if v.Platform != nil {
+			mapping["platform_id"] = v.Platform.ID
+		}
+		if v.PrimaryIP != nil {
+			mapping["primary_ip"] = v.PrimaryIP.Address
+		}
+		if v.PrimaryIp4 != nil {
+			mapping["primary_ip4"] = v.PrimaryIp4.Address
+		}
+		if v.PrimaryIp6 != nil {
+			mapping["primary_ip6"] = v.PrimaryIp6.Address
+		}
+		if v.Role != nil {
+			mapping["role_id"] = v.Role.ID
+		}
+		if v.Site != nil {
+			mapping["site_id"] = v.Site.ID
+		}
+		if v.Status != nil {
+			mapping["status"] = v.Status.Value
+		}
+		if v.Tags != nil {
+			var tags []int64
+			for _, t := range v.Tags {
+				tags = append(tags, t.ID)
+			}
+			mapping["tag_ids"] = tags
+		}
+		if v.Tenant != nil {
+			mapping["tenant_id"] = v.Tenant.ID
+		}
+		if v.Vcpus != nil {
+			mapping["vcpus"] = *v.Vcpus
+		}
+
+		mapping["vm_id"] = v.ID
+
+		log.Printf("Map %#v", mapping)
+		s = append(s, mapping)
+	}
+
+	d.SetId(resource.UniqueId())
+	return d.Set("vms", s)
+}

--- a/netbox/data_source_netbox_virtual_machines.go
+++ b/netbox/data_source_netbox_virtual_machines.go
@@ -132,8 +132,8 @@ func dataSourceNetboxVirtualMachineRead(d *schema.ResourceData, m interface{}) e
 				var nameString = v.(string)
 				params.Name = &nameString
 			case "region":
-				var siteString = v.(string)
-				params.Site = &siteString
+				var regionString = v.(string)
+				params.Region = &regionString
 			case "role":
 				var roleString = v.(string)
 				params.Role = &roleString

--- a/netbox/data_source_netbox_virtual_machines_test.go
+++ b/netbox/data_source_netbox_virtual_machines_test.go
@@ -40,9 +40,7 @@ func TestAccNetboxVirtualMachinesDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.1.name", "netbox_virtual_machine.test1", "name"),
 					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.2.name", "netbox_virtual_machine.test2", "name"),
 					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.3.name", "netbox_virtual_machine.test3", "name"),
-
-
-				),
+					),
 			},
 			{
 				Config: dependencies + testAccNetboxVirtualMachineDataSourceNameRegex,
@@ -59,15 +57,15 @@ func TestAccNetboxVirtualMachinesDataSource_basic(t *testing.T) {
 func testAccNetboxVirtualMachineDataSourceDependencies(testName string) string {
 	return testAccNetboxVirtualMachineFullDependencies(testName) + fmt.Sprintf(`
 resource "netbox_virtual_machine" "test0" {
-	name = "%[1]s_0"
-	cluster_id = netbox_cluster.test.id
-	comments = "thisisacomment"
-	memory_mb = 1024
-	disk_size_gb = 256
-	tenant_id = netbox_tenant.test.id
-	role_id = netbox_device_role.test.id
-	platform_id = netbox_platform.test.id
-	vcpus = 4
+  name = "%[1]s_0"
+  cluster_id = netbox_cluster.test.id
+  comments = "thisisacomment"
+  memory_mb = 1024
+  disk_size_gb = 256
+  tenant_id = netbox_tenant.test.id
+  role_id = netbox_device_role.test.id
+  platform_id = netbox_platform.test.id
+  vcpus = 4
 }
 
 resource "netbox_virtual_machine" "test1" {
@@ -91,7 +89,7 @@ const testAccNetboxVirtualMachineDataSourceFilterCluster = `
 data "netbox_virtual_machines" "test" {
   filter {
     name  = "cluster_id"
-	value = netbox_cluster.test.id
+    value = netbox_cluster.test.id
   }
 }`
 

--- a/netbox/data_source_netbox_virtual_machines_test.go
+++ b/netbox/data_source_netbox_virtual_machines_test.go
@@ -1,0 +1,111 @@
+package netbox
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccNetboxVirtualMachinesDataSource_basic(t *testing.T) {
+
+	testSlug := "vm_ds_basic"
+	testName := testAccGetTestName(testSlug)
+	dependencies := testAccNetboxVirtualMachineDataSourceDependencies(testName)
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dependencies,
+			},
+			{
+				Config: dependencies + testAccNetboxVirtualMachineDataSourceFilterName(testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_virtual_machines.test", "vms.#", "1"),
+					resource.TestCheckResourceAttr("data.netbox_virtual_machines.test", "vms.0.name", testName+"_0"),
+					resource.TestCheckResourceAttr("data.netbox_virtual_machines.test", "vms.0.vcpus", "4"),
+					resource.TestCheckResourceAttr("data.netbox_virtual_machines.test", "vms.0.memory_mb", "1024"),
+					resource.TestCheckResourceAttr("data.netbox_virtual_machines.test", "vms.0.disk_size_gb", "256"),
+					resource.TestCheckResourceAttr("data.netbox_virtual_machines.test", "vms.0.comments", "thisisacomment"),
+					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.0.tenant_id", "netbox_tenant.test", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.0.role_id", "netbox_device_role.test", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.0.platform_id", "netbox_platform.test", "id"),
+				),
+			},
+			{
+				Config: dependencies + testAccNetboxVirtualMachineDataSourceFilterCluster,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_virtual_machines.test", "vms.#", "4"),
+					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.0.cluster_id", "netbox_cluster.test", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.0.name", "netbox_virtual_machine.test0", "name"),
+					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.1.name", "netbox_virtual_machine.test1", "name"),
+					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.2.name", "netbox_virtual_machine.test2", "name"),
+					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.3.name", "netbox_virtual_machine.test3", "name"),
+
+
+				),
+			},
+			{
+				Config: dependencies + testAccNetboxVirtualMachineDataSourceNameRegex,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_virtual_machines.test", "vms.#", "2"),
+					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.0.name", "netbox_virtual_machine.test2", "name"),
+					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.1.name", "netbox_virtual_machine.test3", "name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetboxVirtualMachineDataSourceDependencies(testName string) string {
+	return testAccNetboxVirtualMachineFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_virtual_machine" "test0" {
+	name = "%[1]s_0"
+	cluster_id = netbox_cluster.test.id
+	comments = "thisisacomment"
+	memory_mb = 1024
+	disk_size_gb = 256
+	tenant_id = netbox_tenant.test.id
+	role_id = netbox_device_role.test.id
+	platform_id = netbox_platform.test.id
+	vcpus = 4
+}
+
+resource "netbox_virtual_machine" "test1" {
+  name = "%[1]s_1"
+  cluster_id = netbox_cluster.test.id
+}
+
+resource "netbox_virtual_machine" "test2" {
+  name = "%[1]s_2_regex"
+  cluster_id = netbox_cluster.test.id
+}
+
+resource "netbox_virtual_machine" "test3" {
+  name = "%[1]s_3_regex"
+  cluster_id = netbox_cluster.test.id
+}
+`, testName)
+}
+
+const testAccNetboxVirtualMachineDataSourceFilterCluster = `
+data "netbox_virtual_machines" "test" {
+  filter {
+    name  = "cluster_id"
+	value = netbox_cluster.test.id
+  }
+}`
+
+func testAccNetboxVirtualMachineDataSourceFilterName(testName string) string {
+	return fmt.Sprintf(`
+data "netbox_virtual_machines" "test" {
+  filter {
+    name  = "name"
+    value = "%[1]s_0"
+  }
+}`, testName)
+}
+
+const testAccNetboxVirtualMachineDataSourceNameRegex = `
+data "netbox_virtual_machines" "test" {
+  name_regex = "test.*_regex"
+}`

--- a/netbox/provider.go
+++ b/netbox/provider.go
@@ -21,11 +21,12 @@ func Provider() *schema.Provider {
 			"netbox_tag":             resourceNetboxTag(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"netbox_cluster":     dataSourceNetboxCluster(),
-			"netbox_tenant":      dataSourceNetboxTenant(),
-			"netbox_platform":    dataSourceNetboxPlatform(),
-			"netbox_device_role": dataSourceNetboxDeviceRole(),
-			"netbox_tag":         dataSourceNetboxTag(),
+			"netbox_cluster":          dataSourceNetboxCluster(),
+			"netbox_tenant":           dataSourceNetboxTenant(),
+			"netbox_platform":         dataSourceNetboxPlatform(),
+			"netbox_device_role":      dataSourceNetboxDeviceRole(),
+			"netbox_tag":              dataSourceNetboxTag(),
+			"netbox_virtual_machines": dataSourceNetboxVirtualMachine(),
 		},
 		Schema: map[string]*schema.Schema{
 			"server_url": {


### PR DESCRIPTION
Add 'virtual machines' as a data source.

I'm using this provider to extract information from Netbox, and use that to configure a RHEV/oVirt virtualisation platform - this was a necessary addition.

If someone provides docs about your test data set, I'm happy to add tests for this PR.