### PR TITLE
Honor Sub-Paths in netbox URL

### DIFF
--- a/netbox/client.go
+++ b/netbox/client.go
@@ -44,7 +44,7 @@ func (cfg *Config) Client() (interface{}, error) {
 		InsecureSkipVerify: cfg.AllowInsecureHttps,
 	}
 	client, _ := httptransport.TLSClient(clientOpts)
-	transport := httptransport.NewWithClient(parsedURL.Host, netboxclient.DefaultBasePath, desiredRuntimeClientSchemes, client)
+	transport := httptransport.NewWithClient(parsedURL.Host, parsedURL.Path + netboxclient.DefaultBasePath, desiredRuntimeClientSchemes, client)
 	transport.DefaultAuthentication = httptransport.APIKeyAuth("Authorization", "header", fmt.Sprintf("Token %v", cfg.APIToken))
 	transport.SetLogger(log.StandardLogger())
 	netboxClient := netboxclient.New(transport, nil)


### PR DESCRIPTION
If netbox runs on a sub-Path (https://my.host.name/netbox/), this path has to be handed over to the netbox client module in order to successfully connect to the netbox instance.