### PR TITLE
Add VRF data source and support for vrf_id in netbox_ip_address res…

### DIFF
--- a/netbox/data_source_netbox_vrf.go
+++ b/netbox/data_source_netbox_vrf.go
@@ -1,0 +1,47 @@
+package netbox
+
+import (
+	"errors"
+	"github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/ipam"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"strconv"
+)
+
+func dataSourceNetboxVrf() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNetboxVrfRead,
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceNetboxVrfRead(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	name := d.Get("name").(string)
+	params := ipam.NewIpamVrfsListParams()
+	params.Name = &name
+	limit := int64(2) // Limit of 2 is enough
+	params.Limit = &limit
+
+	res, err := api.Ipam.IpamVrfsList(params, nil)
+	if err != nil {
+		return err
+	}
+
+	if *res.GetPayload().Count > int64(1) {
+		return errors.New("More than one result. Specify a more narrow filter")
+	}
+	if *res.GetPayload().Count == int64(0) {
+		return errors.New("No result")
+	}
+	result := res.GetPayload().Results[0]
+	d.SetId(strconv.FormatInt(result.ID, 10))
+	d.Set("name", result.Name)
+	return nil
+}

--- a/netbox/data_source_netbox_vrf_test.go
+++ b/netbox/data_source_netbox_vrf_test.go
@@ -1,0 +1,33 @@
+package netbox
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"testing"
+)
+
+func TestAccNetboxVrfDataSource_basic(t *testing.T) {
+
+	testSlug := "tnt_ds_basic"
+	testName := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_vrf" "test" {
+  name = "%[1]s"
+}
+
+data "netbox_vrf" "test" {
+  depends_on = [netbox_vrf.test]
+  name = "%[1]s"
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("data.netbox_vrf.test", "id", "netbox_vrf.test", "id"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}

--- a/netbox/data_source_netbox_vrf_test.go
+++ b/netbox/data_source_netbox_vrf_test.go
@@ -15,7 +15,7 @@ func TestAccNetboxVrfDataSource_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
-resource "netbox_vrf" "test" {
+resource"netbox_vrf" "test" {
   name = "%[1]s"
 }
 

--- a/netbox/provider.go
+++ b/netbox/provider.go
@@ -23,6 +23,7 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"netbox_cluster":          dataSourceNetboxCluster(),
 			"netbox_tenant":           dataSourceNetboxTenant(),
+			"netbox_vrf":              dataSourceNetboxVrf(),
 			"netbox_platform":         dataSourceNetboxPlatform(),
 			"netbox_device_role":      dataSourceNetboxDeviceRole(),
 			"netbox_tag":              dataSourceNetboxTag(),

--- a/netbox/provider.go
+++ b/netbox/provider.go
@@ -12,6 +12,7 @@ func Provider() *schema.Provider {
 			"netbox_cluster_type":    resourceNetboxClusterType(),
 			"netbox_cluster":         resourceNetboxCluster(),
 			"netbox_tenant":          resourceNetboxTenant(),
+			"netbox_vrf":             resourceNetboxVrf(),
 			"netbox_ip_address":      resourceNetboxIPAddress(),
 			"netbox_interface":       resourceNetboxInterface(),
 			"netbox_service":         resourceNetboxService(),

--- a/netbox/resource_netbox_ip_address.go
+++ b/netbox/resource_netbox_ip_address.go
@@ -28,6 +28,10 @@ func resourceNetboxIPAddress() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"vrf_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"tenant_id": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -108,6 +112,12 @@ func resourceNetboxIPAddressRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("interface_id", nil)
 	}
 
+  if res.GetPayload().Vrf != nil {
+		d.Set("vrf_id", res.GetPayload().Vrf.ID)
+	} else {
+		d.Set("vrf_id", nil)
+	}
+
 	if res.GetPayload().Tenant != nil {
 		d.Set("tenant_id", res.GetPayload().Tenant.ID)
 	} else {
@@ -149,6 +159,10 @@ func resourceNetboxIPAddressUpdate(d *schema.ResourceData, m interface{}) error 
 		// The other possible type is dcim.interface for devices
 		data.AssignedObjectType = "virtualization.vminterface"
 		data.AssignedObjectID = int64ToPtr(int64(interfaceID.(int)))
+	}
+
+	if vrfID, ok := d.GetOk("vrf_id"); ok {
+		data.Vrf = int64ToPtr(int64(vrfID.(int)))
 	}
 
 	if tenantID, ok := d.GetOk("tenant_id"); ok {

--- a/netbox/resource_netbox_ip_address_test.go
+++ b/netbox/resource_netbox_ip_address_test.go
@@ -21,6 +21,10 @@ resource "netbox_tenant" "test" {
   name = "%[1]s"
 }
 
+resource "netbox_vrf" "test" {
+  name = "%[1]s"
+}
+
 resource "netbox_cluster_type" "test" {
   name = "%[1]s"
 }
@@ -64,6 +68,7 @@ resource "netbox_ip_address" "test" {
 					resource.TestCheckResourceAttr("netbox_ip_address.test", "tags.#", "1"),
 					resource.TestCheckResourceAttr("netbox_ip_address.test", "tags.0", testName),
 					resource.TestCheckResourceAttr("netbox_ip_address.test", "tenant_id", "0"),
+					resource.TestCheckResourceAttr("netbox_ip_address.test", "vrf_id", "0"),
 				),
 			},
 			{
@@ -73,12 +78,14 @@ resource "netbox_ip_address" "test" {
   interface_id = netbox_interface.test.id
   status = "reserved"
   tenant_id = netbox_tenant.test.id
+  vrf_id = netbox_tenant.test.id
   tags = [netbox_tag.test.name]
 }`, testIP),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_ip_address.test", "ip_address", testIP),
 					resource.TestCheckResourceAttr("netbox_ip_address.test", "status", "reserved"),
 					resource.TestCheckResourceAttrPair("netbox_ip_address.test", "tenant_id", "netbox_tenant.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_ip_address.test", "vrf_id", "netbox_vrf.test", "id"),
 				),
 			},
 			{
@@ -93,6 +100,7 @@ resource "netbox_ip_address" "test" {
 					resource.TestCheckResourceAttr("netbox_ip_address.test", "ip_address", testIP),
 					resource.TestCheckResourceAttr("netbox_ip_address.test", "status", "dhcp"),
 					resource.TestCheckResourceAttr("netbox_ip_address.test", "tenant_id", "0"),
+					resource.TestCheckResourceAttr("netbox_ip_address.test", "vrf_id", "0"),
 				),
 			},
 			{

--- a/netbox/resource_netbox_ip_address_test.go
+++ b/netbox/resource_netbox_ip_address_test.go
@@ -78,7 +78,7 @@ resource "netbox_ip_address" "test" {
   interface_id = netbox_interface.test.id
   status = "reserved"
   tenant_id = netbox_tenant.test.id
-  vrf_id = netbox_tenant.test.id
+  vrf_id = netbox_vrf.test.id
   tags = [netbox_tag.test.name]
 }`, testIP),
 				Check: resource.ComposeTestCheckFunc(

--- a/netbox/resource_netbox_vrf.go
+++ b/netbox/resource_netbox_vrf.go
@@ -1,0 +1,117 @@
+package netbox
+
+import (
+	"github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/ipam"
+	"github.com/fbreckle/go-netbox/netbox/models"
+	"github.com/go-openapi/runtime"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"strconv"
+)
+
+func resourceNetboxVrf() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetboxVrfCreate,
+		Read:   resourceNetboxVrfRead,
+		Update: resourceNetboxVrfUpdate,
+		Delete: resourceNetboxVrfDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"tags": &schema.Schema{
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional: true,
+				Set:      schema.HashString,
+			},
+		},
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+	}
+}
+
+func resourceNetboxVrfCreate(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	name := d.Get("name").(string)
+
+	tags, _ := getNestedTagListFromResourceDataSet(api, d.Get("tags"))
+
+	params := ipam.NewIpamVrfsCreateParams().WithData(
+		&models.WritableVRF{
+			Name: &name,
+			Tags: tags,
+		},
+	)
+
+	res, err := api.Ipam.IpamVrfsCreate(params, nil)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.FormatInt(res.GetPayload().ID, 10))
+
+	return resourceNetboxVrfRead(d, m)
+}
+
+func resourceNetboxVrfRead(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	params := ipam.NewIpamVrfsReadParams().WithID(id)
+
+	res, err := api.Ipam.IpamVrfsRead(params, nil)
+	if err != nil {
+		errorcode := err.(*runtime.APIError).Response.(runtime.ClientResponse).Code()
+		if errorcode == 404 {
+			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("name", res.GetPayload().Name)
+	return nil
+}
+
+func resourceNetboxVrfUpdate(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	data := models.WritableVRF{}
+
+	name := d.Get("name").(string)
+
+	tags, _ := getNestedTagListFromResourceDataSet(api, d.Get("tags"))
+
+	data.Name = &name
+	data.Tags = tags
+
+	params := ipam.NewIpamVrfsPartialUpdateParams().WithID(id).WithData(&data)
+
+	_, err := api.Ipam.IpamVrfsPartialUpdate(params, nil)
+	if err != nil {
+		return err
+	}
+
+	return resourceNetboxVrfRead(d, m)
+}
+
+func resourceNetboxVrfDelete(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	params := ipam.NewIpamVrfsDeleteParams().WithID(id)
+
+	_, err := api.Ipam.IpamVrfsDelete(params, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/netbox/resource_netbox_vrf_test.go
+++ b/netbox/resource_netbox_vrf_test.go
@@ -1,0 +1,122 @@
+package netbox
+
+import (
+	"fmt"
+	"github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/ipam"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"log"
+	"strings"
+	"testing"
+)
+
+func testAccNetboxVrfTagDependencies(testName string) string {
+	return fmt.Sprintf(`
+resource "netbox_tag" "test_a" {
+  name = "%[1]sa"
+}
+
+resource "netbox_tag" "test_b" {
+  name = "%[1]sb"
+}
+`, testName)
+}
+
+func TestAccNetboxVrf_basic(t *testing.T) {
+
+	testName := "vrf_basic"
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_vrf" "test" {
+  name = "%s"
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_vrf.test", "name", testName),
+				),
+			},
+			{
+				ResourceName:      "netbox_vrf.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccNetboxVrf_tags(t *testing.T) {
+
+	testName := "vrf_tag"
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxTenantTagDependencies(testName) + fmt.Sprintf(`
+resource "netbox_vrf" "test_tags" {
+  name = "%[1]s"
+  tags = ["%[1]sa"]
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_vrf.test_tags", "name", testName),
+					resource.TestCheckResourceAttr("netbox_vrf.test_tags", "tags.#", "1"),
+					resource.TestCheckResourceAttr("netbox_vrf.test_tags", "tags.0", testName+"a"),
+				),
+			},
+			{
+				Config: testAccNetboxVrfTagDependencies(testName) + fmt.Sprintf(`
+resource "netbox_vrf" "test_tags" {
+  name = "%[1]s"
+  tags = ["%[1]sa", "%[1]sb"]
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_vrf.test_tags", "tags.#", "2"),
+					resource.TestCheckResourceAttr("netbox_vrf.test_tags", "tags.0", testName+"a"),
+					resource.TestCheckResourceAttr("netbox_vrf.test_tags", "tags.1", testName+"b"),
+				),
+			},
+			{
+				Config: testAccNetboxVrfTagDependencies(testName) + fmt.Sprintf(`
+resource "netbox_vrf" "test_tags" {
+  name = "%s"
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_vrf.test_tags", "tags.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func init() {
+	resource.AddTestSweepers("netbox_vrf", &resource.Sweeper{
+		Name:         "netbox_vrf",
+		Dependencies: []string{},
+		F: func(region string) error {
+			m, err := sharedClientForRegion(region)
+			if err != nil {
+				return fmt.Errorf("Error getting client: %s", err)
+			}
+			api := m.(*client.NetBoxAPI)
+			params := ipam.NewIpamVrfsListParams()
+			res, err := api.Ipam.IpamVrfsList(params, nil)
+			if err != nil {
+				return err
+			}
+			for _, vrf := range res.GetPayload().Results {
+				if strings.HasPrefix(*vrf.Name, testPrefix) {
+					deleteParams := ipam.NewIpamVrfsDeleteParams().WithID(vrf.ID)
+					_, err := api.Ipam.IpamVrfsDelete(deleteParams, nil)
+					if err != nil {
+						return err
+					}
+					log.Print("[DEBUG] Deleted a vrf")
+				}
+			}
+			return nil
+		},
+	})
+}


### PR DESCRIPTION
Add a new "netbox_vrf" data source and support for "vrf_id" in the "netbox_ip_address" resource.

The data source allows for looking up vrf_id by name, which can then be passed to a "netbox_ip_address" resource in order to support linking an IP to a VRF in netbox.

I'm definitely not a golang developer (first timer!) so I just used the existing data sources and resources from this project as a reference guide/template. Also, I really have no clue if I got the tests right but "make test" doesn't seem to complain. 