### PR TITLE
fix(netbox_prefix): attributes are not properly read

### DIFF
--- a/netbox/resource_netbox_prefix.go
+++ b/netbox/resource_netbox_prefix.go
@@ -95,6 +95,13 @@ func resourceNetboxPrefixRead(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("description", res.GetPayload().Description)
 	d.Set("is_pool", res.GetPayload().IsPool)
+	if res.GetPayload().Status != nil {
+		d.Set("status", res.GetPayload().Status.Value)
+	}
+	if res.GetPayload().Prefix != nil {
+		d.Set("prefix", res.GetPayload().Prefix)
+	}
+	d.Set("tags", getTagListFromNestedTagList(res.GetPayload().Tags))
 	// FIGURE OUT NESTED VRF AND NESTED VLAN (from maybe interfaces?)
 
 	return nil

--- a/netbox/resource_netbox_prefix_test.go
+++ b/netbox/resource_netbox_prefix_test.go
@@ -1,0 +1,124 @@
+package netbox
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"testing"
+
+	"github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/ipam"
+	"github.com/fbreckle/go-netbox/netbox/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func testAccNetboxPrefixFullDependencies(testName string) string {
+	return fmt.Sprintf(`
+resource "netbox_tag" "test" {
+  name = "%[1]s"
+}
+`, testName)
+}
+
+func TestAccNetboxPrefix_basic(t *testing.T) {
+
+	testPrefix := "1.1.1.0/25"
+	testSlug := "prefix"
+	testDesc := "test prefix"
+	testName := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxPrefixFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_prefix" "test" {
+  prefix = "%s"
+  description = "%s"
+  status = "active"
+  tags = [netbox_tag.test.name]
+}`, testPrefix, testDesc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_prefix.test", "prefix", testPrefix),
+					resource.TestCheckResourceAttr("netbox_prefix.test", "status", "active"),
+					resource.TestCheckResourceAttr("netbox_prefix.test", "description", testDesc),
+					resource.TestCheckResourceAttr("netbox_prefix.test", "tags.#", "1"),
+					resource.TestCheckResourceAttr("netbox_prefix.test", "tags.0", testName),
+				),
+			},
+			{
+				Config: testAccNetboxPrefixFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_prefix" "test" {
+  prefix = "%s"
+  description = "%s"
+  status = "provoke_error"
+  tags = [netbox_tag.test.name]
+}`, testPrefix, testDesc),
+				ExpectError: regexp.MustCompile("expected status to be one of .*"),
+			},
+			{
+				Config: testAccNetboxPrefixFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_prefix" "test" {
+  prefix = "%s"
+  description = "%s"
+  status = "deprecated"
+  tags = [netbox_tag.test.name]
+}`, testPrefix, testDesc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_prefix.test", "prefix", testPrefix),
+					resource.TestCheckResourceAttr("netbox_prefix.test", "status", "deprecated"),
+				),
+			},
+			{
+				Config: testAccNetboxPrefixFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_prefix" "test" {
+  prefix = "%s"
+  description = "%s 2"
+  status = "active"
+  tags = [netbox_tag.test.name]
+}`, testPrefix, testDesc),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_prefix.test", "prefix", testPrefix),
+					resource.TestCheckResourceAttr("netbox_prefix.test", "status", "active"),
+					resource.TestCheckResourceAttr("netbox_prefix.test", "description", fmt.Sprintf("%s 2", testDesc)),
+					resource.TestCheckResourceAttr("netbox_prefix.test", "tags.#", "1"),
+					resource.TestCheckResourceAttr("netbox_prefix.test", "tags.0", testName),
+				),
+			},
+			{
+				ResourceName:      "netbox_prefix.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func init() {
+	resource.AddTestSweepers("netbox_prefix", &resource.Sweeper{
+		Name:         "netbox_prefix",
+		Dependencies: []string{},
+		F: func(region string) error {
+			m, err := sharedClientForRegion(region)
+			if err != nil {
+				return fmt.Errorf("Error getting client: %s", err)
+			}
+			api := m.(*client.NetBoxAPI)
+			params := ipam.NewIpamPrefixesListParams()
+			res, err := api.Ipam.IpamPrefixesList(params, nil)
+			if err != nil {
+				return err
+			}
+			for _, prefix := range res.GetPayload().Results {
+				if len(prefix.Tags) > 0 && (prefix.Tags[0] == &models.NestedTag{Name: strToPtr("acctest"), Slug: strToPtr("acctest")}) {
+					deleteParams := ipam.NewIpamPrefixesDeleteParams().WithID(prefix.ID)
+					_, err := api.Ipam.IpamPrefixesDelete(deleteParams, nil)
+					if err != nil {
+						return err
+					}
+					log.Print("[DEBUG] Deleted a prefix")
+				}
+			}
+			return nil
+		},
+	})
+}


### PR DESCRIPTION
Hi,

After importing the resources, terraform plan want to update prefix, status and tags altough there are already set on netbox.

```
$ terraform import netbox_prefix.ip_10_47_3_0 2                                                                                                                               
netbox_prefix.ip_10_47_3_0: Importing from ID "2"...                                                                                                                                                                                          
netbox_prefix.ip_10_47_3_0: Import prepared!                                                                                                                                                                                                  
  Prepared netbox_prefix for import                                                                                                                                                                                                           
netbox_prefix.ip_10_47_3_0: Refreshing state... [id=2]                                                                                                                                                                                        
                                                                                                                                                                                                                                              
Import successful!                                                                                                                                                                                                                            
                                                                                                                                                                                                                                              
The resources that were imported are shown above. These resources are now in your Terraform state and will henceforth be managed by Terraform.
$ terraform plan
...
netbox_prefix.ip_10_47_3_0: Refreshing state... [id=2]
...

Terraform will perform the following actions:

  # netbox_prefix.ip_10_47_3_0 will be updated in-place
  ~ resource "netbox_prefix" "ip_10_47_3_0" {
      + description = "srr1dc2-is-gw-adm-vip"
        id          = "2"
      + prefix      = "10.47.3.0/24"
      + status      = "active"
      + tags        = [
          + "prefix_mobility_fabric",
        ]
        # (1 unchanged attribute hidden)

```

Expected plan should be empty.