### PR TITLE
add description attribute to tag resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/davecgh/go-spew v1.1.1
-	github.com/fbreckle/go-netbox v0.0.0-20211108152602-6c9cea679011
+	github.com/fbreckle/go-netbox v0.0.0-20211223172728-2da47c1929a7
 	github.com/go-openapi/runtime v0.19.32-0.20210924162202-f7fb72beda3a
 	github.com/goware/urlx v0.3.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fbreckle/go-netbox v0.0.0-20211108152602-6c9cea679011 h1:zLAI0IiM54qujyB4MJd4o1nz5dID+AqQCLu/Zmn93W0=
-github.com/fbreckle/go-netbox v0.0.0-20211108152602-6c9cea679011/go.mod h1:Nf2bxylehF4ROF+s2paaRCKLIeYcUb2+NK1R/nOsE0o=
+github.com/fbreckle/go-netbox v0.0.0-20211223172728-2da47c1929a7 h1:21foc44CmZKU+6BzkaWZBLjd8t5/Z9q//AF/r9rwRrY=
+github.com/fbreckle/go-netbox v0.0.0-20211223172728-2da47c1929a7/go.mod h1:Nf2bxylehF4ROF+s2paaRCKLIeYcUb2+NK1R/nOsE0o=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=

--- a/netbox/data_source_netbox_tag.go
+++ b/netbox/data_source_netbox_tag.go
@@ -21,6 +21,10 @@ func dataSourceNetboxTag() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -50,5 +54,6 @@ func dataSourceNetboxTagRead(d *schema.ResourceData, m interface{}) error {
 	d.SetId(strconv.FormatInt(result.ID, 10))
 	d.Set("name", result.Name)
 	d.Set("slug", result.Slug)
+	d.Set("description", result.Description)
 	return nil
 }

--- a/netbox/resource_netbox_tag.go
+++ b/netbox/resource_netbox_tag.go
@@ -34,6 +34,10 @@ func resourceNetboxTag() *schema.Resource {
 				Default:      "9e9e9e",
 				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[0-9a-f]{6}$"), "Must be hex color string"),
 			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"tags": &schema.Schema{
 				Type: schema.TypeSet,
 				Elem: &schema.Schema{
@@ -64,11 +68,13 @@ func resourceNetboxTagCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	color := d.Get("color_hex").(string)
+	description := d.Get("description").(string)
 	params := extras.NewExtrasTagsCreateParams().WithData(
 		&models.Tag{
-			Name:  &name,
-			Slug:  &slug,
-			Color: color,
+			Name:        &name,
+			Slug:        &slug,
+			Color:       color,
+			Description: description,
 		},
 	)
 
@@ -102,6 +108,7 @@ func resourceNetboxTagRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("name", res.GetPayload().Name)
 	d.Set("slug", res.GetPayload().Slug)
 	d.Set("color_hex", res.GetPayload().Color)
+	d.Set("description", res.GetPayload().Description)
 	return nil
 }
 
@@ -113,6 +120,7 @@ func resourceNetboxTagUpdate(d *schema.ResourceData, m interface{}) error {
 
 	name := d.Get("name").(string)
 	color := d.Get("color_hex").(string)
+	description := d.Get("description").(string)
 
 	slugValue, slugOk := d.GetOk("slug")
 	var slug string
@@ -126,6 +134,7 @@ func resourceNetboxTagUpdate(d *schema.ResourceData, m interface{}) error {
 	data.Slug = &slug
 	data.Name = &name
 	data.Color = color
+	data.Description = description
 
 	params := extras.NewExtrasTagsUpdateParams().WithID(id).WithData(&data)
 

--- a/netbox/resource_netbox_tag_test.go
+++ b/netbox/resource_netbox_tag_test.go
@@ -26,11 +26,13 @@ resource "netbox_tag" "test" {
   name = "%s"
   slug = "%s"
   color_hex = "112233"
+  description = "This is a test"
 }`, testName, randomSlug),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_tag.test", "name", testName),
 					resource.TestCheckResourceAttr("netbox_tag.test", "slug", randomSlug),
 					resource.TestCheckResourceAttr("netbox_tag.test", "color_hex", "112233"),
+					resource.TestCheckResourceAttr("netbox_tag.test", "description", "This is a test"),
 				),
 			},
 			{


### PR DESCRIPTION
This PR adds the `description` attribute to the `netbox_tag` resource.

Example:
```terraform
resource "netbox_tag" "tf_managed" {
  name        = "Managed by Terraform"
  slug        = "managed-by-terraform"
  description = "Terraform provider: github.com/e-breuninger/terraform-provider-netbox"
}
```

I have tested it against a Netbox instance (not yet with the acceptance tests) and I noticed that the description can be set and updated, but not removed. It seems that the Netbox API ignores the empty field.