### PR TITLE
Validate against Netbox 3.1.3 and update failing test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0 (Jan 3, 2022)
+
+FEATURES
+
+* provider: Now supports NetBox v3.1.3
+
 ## 1.0.2 Ho-Ho-Ho (Dec 24, 2021)
 
 ENHANCEMENTS

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,7 +8,7 @@ default: testacc
 # Run acceptance tests
 .PHONY: testacc
 testacc: 
-	@NETBOX_VERSION=v3.0.9 sh -c "'$(CURDIR)/docker/start.sh' $(NETBOX_SERVER_URL)"
+	@NETBOX_VERSION=v3.1.3 sh -c "'$(CURDIR)/docker/start.sh' $(NETBOX_SERVER_URL)"
 	TF_ACC=1 NETBOX_SERVER_URL=$(NETBOX_SERVER_URL) NETBOX_API_TOKEN=0123456789abcdef0123456789abcdef01234567 go test -v -cover $(TEST)
 
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Netbox often makes API-breaking changes even in non-major releases. We aim to al
 
 Provider version | Netbox version
 --- | ---
+v1.1.x | v3.1.3
 v1.0.x | v3.0.9
 v0.3.x | v2.11.12
 v0.2.x | v2.10.10

--- a/netbox/provider.go
+++ b/netbox/provider.go
@@ -94,7 +94,7 @@ func providerConfigure(ctx context.Context, data *schema.ResourceData) (interfac
 	res, _ := netboxClient.(*client.NetBoxAPI).Status.StatusList(req, nil)
 	netboxVersion := res.GetPayload().(map[string]interface{})["netbox-version"]
 
-	supportedVersion := "3.0.9"
+	supportedVersion := "3.1.3"
 
 	if netboxVersion != supportedVersion {
 

--- a/netbox/resource_netbox_available_prefix_test.go
+++ b/netbox/resource_netbox_available_prefix_test.go
@@ -140,7 +140,7 @@ resource "netbox_available_prefix" "test3" {
 					resource.TestCheckResourceAttr("netbox_available_prefix.test1", "prefix", expectedPrefixes[0]),
 					resource.TestCheckResourceAttr("netbox_available_prefix.test2", "prefix", expectedPrefixes[1]),
 				),
-				ExpectError: regexp.MustCompile(".*unexpected success response.*"),
+				ExpectError: regexp.MustCompile(".*Insufficient space is available.*"),
 			},
 		},
 	})


### PR DESCRIPTION
Validated against Netbox 3.1.3.  One test was failing due to changed error message language.  Updated minor version to reflect new NetBox API version.