### PR TITLE
Support mark_utilized in available_prefix resource

### DIFF
--- a/netbox/data_source_netbox_prefix.go
+++ b/netbox/data_source_netbox_prefix.go
@@ -14,11 +14,11 @@ func dataSourceNetboxPrefix() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceNetboxPrefixRead,
 		Schema: map[string]*schema.Schema{
-			"id": &schema.Schema{
+			"id": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"cidr": &schema.Schema{
+			"cidr": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.IsCIDR,

--- a/netbox/resource_netbox_available_prefix.go
+++ b/netbox/resource_netbox_available_prefix.go
@@ -49,6 +49,10 @@ func resourceNetboxAvailablePrefix() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"mark_utilized": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"vrf_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -57,15 +61,15 @@ func resourceNetboxAvailablePrefix() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"site_id": &schema.Schema{
+			"site_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"vlan_id": &schema.Schema{
+			"vlan_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"role_id": &schema.Schema{
+			"role_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},

--- a/netbox/resource_netbox_available_prefix_test.go
+++ b/netbox/resource_netbox_available_prefix_test.go
@@ -50,6 +50,7 @@ resource "netbox_available_prefix" "test" {
   description = "%s"
   status = "active"
   tags = [netbox_tag.test.name]
+  mark_utilized = true
 }`, testPrefixLength, testDesc),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "prefix", expectedPrefix),
@@ -57,6 +58,7 @@ resource "netbox_available_prefix" "test" {
 					resource.TestCheckResourceAttr(resourceName, "description", testDesc),
 					resource.TestCheckResourceAttr(resourceName, "tags.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.0", testName),
+					resource.TestCheckResourceAttr(resourceName, "mark_utilized", "true"),
 				),
 			},
 			{

--- a/netbox/resource_netbox_prefix.go
+++ b/netbox/resource_netbox_prefix.go
@@ -18,17 +18,17 @@ func resourceNetboxPrefix() *schema.Resource {
 		Delete: resourceNetboxPrefixDelete,
 
 		Schema: map[string]*schema.Schema{
-			"prefix": &schema.Schema{
+			"prefix": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.IsCIDR,
 			},
-			"status": &schema.Schema{
+			"status": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{"active", "reserved", "deprecated", "container"}, false),
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -36,27 +36,31 @@ func resourceNetboxPrefix() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"vrf_id": &schema.Schema{
+			"mark_utilized": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"vrf_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"tenant_id": &schema.Schema{
+			"tenant_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"site_id": &schema.Schema{
+			"site_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"vlan_id": &schema.Schema{
+			"vlan_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"role_id": &schema.Schema{
+			"role_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"tags": &schema.Schema{
+			"tags": {
 				Type: schema.TypeSet,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -115,6 +119,7 @@ func resourceNetboxPrefixRead(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("description", res.GetPayload().Description)
 	d.Set("is_pool", res.GetPayload().IsPool)
+	d.Set("mark_utilized", res.GetPayload().MarkUtilized)
 	if res.GetPayload().Status != nil {
 		d.Set("status", res.GetPayload().Status.Value)
 	}
@@ -166,12 +171,14 @@ func resourceNetboxPrefixUpdate(d *schema.ResourceData, m interface{}) error {
 	status := d.Get("status").(string)
 	description := d.Get("description").(string)
 	is_pool := d.Get("is_pool").(bool)
+	mark_utilized := d.Get("mark_utilized").(bool)
 
 	data.Prefix = &prefix
 	data.Status = status
 
 	data.Description = description
 	data.IsPool = is_pool
+	data.MarkUtilized = mark_utilized
 
 	if vrfID, ok := d.GetOk("vrf_id"); ok {
 		data.Vrf = int64ToPtr(int64(vrfID.(int)))

--- a/netbox/resource_netbox_prefix_test.go
+++ b/netbox/resource_netbox_prefix_test.go
@@ -64,6 +64,7 @@ resource "netbox_prefix" "test" {
   description = "%s"
   status = "active"
   tags = [netbox_tag.test.name]
+  mark_utilized = true
 }`, testPrefix, testDesc),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_prefix.test", "prefix", testPrefix),
@@ -71,6 +72,7 @@ resource "netbox_prefix" "test" {
 					resource.TestCheckResourceAttr("netbox_prefix.test", "description", testDesc),
 					resource.TestCheckResourceAttr("netbox_prefix.test", "tags.#", "1"),
 					resource.TestCheckResourceAttr("netbox_prefix.test", "tags.0", testName),
+					resource.TestCheckResourceAttr("netbox_prefix.test", "mark_utilized", "true"),
 				),
 			},
 			{
@@ -80,6 +82,7 @@ resource "netbox_prefix" "test" {
   description = "%s"
   status = "provoke_error"
   tags = [netbox_tag.test.name]
+  mark_utilized = true
 }`, testPrefix, testDesc),
 				ExpectError: regexp.MustCompile("expected status to be one of .*"),
 			},
@@ -88,8 +91,25 @@ resource "netbox_prefix" "test" {
 resource "netbox_prefix" "test" {
   prefix = "%s"
   description = "%s"
+  status = "active"
+  tags = [netbox_tag.test.name]
+  mark_utilized = false
+}`, testPrefix, testDesc),
+				Check: resource.TestCheckResourceAttr("netbox_prefix.test", "mark_utilized", "false"),
+				// This test will fail due to a incorrect behavior when changing parameters to "false" or "0".
+				// See https://github.com/e-breuninger/terraform-provider-netbox/issues/109
+				// We test the right behavior and we simply catch the error.
+				// Once the bug is fixed, we can simply remove the ExpectError line.
+				ExpectError: regexp.MustCompile("Attribute 'mark_utilized' expected \"false\", got \"true\""),
+			},
+			{
+				Config: testAccNetboxPrefixFullDependencies(testName, randomSlug, testVid) + fmt.Sprintf(`
+resource "netbox_prefix" "test" {
+  prefix = "%s"
+  description = "%s"
   status = "deprecated"
   tags = [netbox_tag.test.name]
+  mark_utilized = true
 }`, testPrefix, testDesc),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_prefix.test", "prefix", testPrefix),
@@ -103,6 +123,7 @@ resource "netbox_prefix" "test" {
   description = "%s"
   status = "container"
   tags = [netbox_tag.test.name]
+  mark_utilized = true
 }`, testPrefix, testDesc),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_prefix.test", "prefix", testPrefix),
@@ -116,6 +137,7 @@ resource "netbox_prefix" "test" {
   description = "%s 2"
   status = "active"
   tags = [netbox_tag.test.name]
+  mark_utilized = true
 }`, testPrefix, testDesc),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_prefix.test", "prefix", testPrefix),
@@ -126,6 +148,7 @@ resource "netbox_prefix" "test" {
 					resource.TestCheckResourceAttr("netbox_prefix.test", "site_id", "0"),
 					resource.TestCheckResourceAttr("netbox_prefix.test", "tags.#", "1"),
 					resource.TestCheckResourceAttr("netbox_prefix.test", "tags.0", testName),
+					resource.TestCheckResourceAttr("netbox_prefix.test", "mark_utilized", "true"),
 				),
 			},
 			{
@@ -137,6 +160,7 @@ resource "netbox_prefix" "test" {
   vrf_id = netbox_vrf.test.id
   tenant_id = netbox_tenant.test.id
   tags = [netbox_tag.test.name]
+  mark_utilized = true
 }`, testPrefix, testDesc),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_prefix.test", "prefix", testPrefix),
@@ -146,6 +170,7 @@ resource "netbox_prefix" "test" {
 					resource.TestCheckResourceAttrPair("netbox_prefix.test", "tenant_id", "netbox_tenant.test", "id"),
 					resource.TestCheckResourceAttr("netbox_prefix.test", "tags.#", "1"),
 					resource.TestCheckResourceAttr("netbox_prefix.test", "tags.0", testName),
+					resource.TestCheckResourceAttr("netbox_prefix.test", "mark_utilized", "true"),
 				),
 			},
 			{
@@ -160,6 +185,7 @@ resource "netbox_prefix" "test" {
   vlan_id = netbox_vlan.test.id
   role_id = netbox_ipam_role.test.id
   tags = [netbox_tag.test.name]
+  mark_utilized = true
 }`, testPrefix, testDesc),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_prefix.test", "prefix", testPrefix),
@@ -172,6 +198,7 @@ resource "netbox_prefix" "test" {
 					resource.TestCheckResourceAttrPair("netbox_prefix.test", "role_id", "netbox_ipam_role.test", "id"),
 					resource.TestCheckResourceAttr("netbox_prefix.test", "tags.#", "1"),
 					resource.TestCheckResourceAttr("netbox_prefix.test", "tags.0", testName),
+					resource.TestCheckResourceAttr("netbox_prefix.test", "mark_utilized", "true"),
 				),
 			},
 			{


### PR DESCRIPTION
This small patch simply add the mark_utilized parameter for available_prefix resource. Changes in data source are only to make my linter happy :)