### PR TITLE
Add ability to attach custom headers to every request

### DIFF
--- a/netbox/client_test.go
+++ b/netbox/client_test.go
@@ -1,8 +1,12 @@
 package netbox
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	netboxClient "github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/status"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -62,6 +66,32 @@ func TestURLMissingAccessKey(t *testing.T) {
 
 	_, err := config.Client()
 	assert.Error(t, err)
+}
+
+func TestAdditionalHeadersSet(t *testing.T) {
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vals, ok := r.Header["Hello"]
+
+		assert.True(t, ok)
+		assert.Len(t, vals, 1)
+		assert.Equal(t, vals[0], "World!")
+	}))
+	defer ts.Close()
+
+	config := Config{
+		APIToken:  "07b12b765127747e4afd56cb531b7bf9c61f3c30",
+		ServerURL: ts.URL,
+		Headers: map[string]interface{}{
+			"Hello": "World!",
+		},
+	}
+
+	client, err := config.Client()
+	assert.NoError(t, err)
+
+	req := status.NewStatusListParams()
+	client.(*netboxClient.NetBoxAPI).Status.StatusList(req, nil)
 }
 
 /* TODO

--- a/netbox/provider.go
+++ b/netbox/provider.go
@@ -69,6 +69,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("NETBOX_ALLOW_INSECURE_HTTPS", false),
 				Description: "Flag to set whether to allow https with invalid certificates",
 			},
+			"headers": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("NETBOX_HEADERS", map[string]interface{}{}),
+				Description: "Set these header on all requests to Netbox",
+			},
 		},
 		ConfigureContextFunc: providerConfigure,
 	}
@@ -83,6 +89,7 @@ func providerConfigure(ctx context.Context, data *schema.ResourceData) (interfac
 		ServerURL:          data.Get("server_url").(string),
 		APIToken:           data.Get("api_token").(string),
 		AllowInsecureHttps: data.Get("allow_insecure_https").(bool),
+		Headers:            data.Get("headers").(map[string]interface{}),
 	}
 
 	netboxClient, clientError := config.Client()


### PR DESCRIPTION
# Context
We expose our Netbox instances through a [Google Cloud IAP](https://cloud.google.com/iap) which allows us to publish them to the internet while having strict control over which identity may connect to the service. To make this work nicely with Netbox, we have a custom remote auth middleware that validates the ID tokens issued by the IAP and binds them to Netbox users.

For this to work in a headless process, an additional header has to be attached to every request sent to Netbox. The `Proxy-Authorization` header contains the ID token of the principle that should be able to pass the IAP. The IAP then generates a new ID token for that principle that is handed to Netbox.

# Problem
This Terraform provider currently does not support the definition of additional headers that should be attached to every request. Thus, requests are not able to pass the IAP and are rejected.

# Solution
Users are able to define an additional variable for the provider's schema called `headers`. It is a map which maps a header's key to its respective value. Values are transformed to strings. Multiple headers with the same name are not supported.

## Example
This example retrieves an ID token and sets it as an additional header to be sent with every request.

```
data "google_service_account_id_token" "sa" {
  target_service_account = local.service_account_email
  include_email          = true
  target_audience        = "${local.oauth2_app_id}.apps.googleusercontent.com"
}

provider "netbox" {
  server_url = local.netbox_url
  api_token  = local_netbox_api_token
  headers = {
    "Proxy-Authorization" : "Bearer ${data.google_service_account_id_token.sa.id_token}"
  }
}
```