### PR TITLE
Add state migration for vm.vcpus

### DIFF
--- a/netbox/resource_netbox_virtual_machine.go
+++ b/netbox/resource_netbox_virtual_machine.go
@@ -75,6 +75,14 @@ func resourceNetboxVirtualMachine() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceNetboxVirtualMachineResourceV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceNetboxVirtualMachineStateUpgradeV0,
+				Version: 0,
+			},
+		},
 	}
 }
 

--- a/netbox/resource_netbox_virtual_machine_migrate_v0.go
+++ b/netbox/resource_netbox_virtual_machine_migrate_v0.go
@@ -1,0 +1,93 @@
+package netbox
+
+import (
+	"context"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceNetboxVirtualMachineResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cluster_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"tenant_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"platform_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"role_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"site_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"comments": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"memory_mb": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"vcpus": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"disk_size_gb": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"tags": &schema.Schema{
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional: true,
+				Set:      schema.HashString,
+			},
+			"primary_ipv4": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+func resourceNetboxVirtualMachineStateUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+
+	v, ok := rawState["vcpus"]
+	if !ok {
+		return rawState, nil
+	}
+
+	s, ok := v.(string)
+	if !ok {
+		return rawState, nil
+	}
+
+	log.Printf("[DEBUG] vcpus before migration: %#v", rawState["vcpus"])
+
+	f, err := strconv.ParseFloat(s, 64)
+	if err == nil {
+		rawState["vcpus"] = f
+	} else {
+		rawState["vcpus"] = float64(0)
+		log.Printf("[DEBUG] Schema upgrade: vcpus has been migrated to %g", f)
+	}
+
+	log.Printf("[DEBUG] vcpus after migration: %#v", rawState["vcpus"])
+	return rawState, nil
+}

--- a/netbox/resource_netbox_virtual_machine_migrate_v0_test.go
+++ b/netbox/resource_netbox_virtual_machine_migrate_v0_test.go
@@ -1,0 +1,57 @@
+package netbox
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestResourceNetboxVirtualMachineStateUpgradeV0(t *testing.T) {
+
+	for _, tt := range []struct {
+		name     string
+		state    map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name:     "Empty",
+			state:    map[string]interface{}{"vcpus": ""},
+			expected: map[string]interface{}{"vcpus": float64(0)},
+		},
+		{
+			name:     "Zero",
+			state:    map[string]interface{}{"vcpus": "0"},
+			expected: map[string]interface{}{"vcpus": float64(0)},
+		},
+		{
+			name:     "NonZero",
+			state:    map[string]interface{}{"vcpus": "123"},
+			expected: map[string]interface{}{"vcpus": float64(123)},
+		},
+		{
+			name:     "Float",
+			state:    map[string]interface{}{"vcpus": "4.5"},
+			expected: map[string]interface{}{"vcpus": 4.5},
+		},
+		{
+			name:     "Invalid",
+			state:    map[string]interface{}{"vcpus": "foo"},
+			expected: map[string]interface{}{"vcpus": float64(0)},
+		},
+		{
+			name:     "FloatAsFloat",
+			state:    map[string]interface{}{"vcpus": 4.5},
+			expected: map[string]interface{}{"vcpus": 4.5},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := resourceNetboxVirtualMachineStateUpgradeV0(context.Background(), tt.state, nil)
+			if err != nil {
+				t.Fatalf("error migrating state: %s", err)
+			}
+			if !reflect.DeepEqual(tt.expected, actual) {
+				t.Fatalf("\n\nexpected:\n\n%#v\n\ngot:\n\n%#v\n\n", tt.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The type change from `string` to `float` for `vm.vcpus` introduced with https://github.com/e-breuninger/terraform-provider-netbox/pull/92 breaks existing state if `vcpus` in the existing state is `""`:

> │ Error: Failed to decode resource from state
> │
> │ Error decoding "netbox_virtual_machine.this" from previous state: a number is required

This PR bumps the schema version for `resourceNetboxVirtualMachine` to `1` and introduces a `StateUpgrader` that will gracefully upgrade the state, even if the value already is a float.

Further reading:
- https://www.terraform.io/plugin/sdkv2/resources/state-migration#resources-state-migration
