### PR TITLE
🐛 Fix provider crash when netbox connection is unavailable

### DIFF
--- a/netbox/provider.go
+++ b/netbox/provider.go
@@ -103,7 +103,12 @@ func providerConfigure(ctx context.Context, data *schema.ResourceData) (interfac
 	}
 
 	req := status.NewStatusListParams()
-	res, _ := netboxClient.(*client.NetBoxAPI).Status.StatusList(req, nil)
+	res, err := netboxClient.(*client.NetBoxAPI).Status.StatusList(req, nil)
+
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+
 	netboxVersion := res.GetPayload().(map[string]interface{})["netbox-version"]
 
 	supportedVersion := "3.1.3"

--- a/netbox/provider_test.go
+++ b/netbox/provider_test.go
@@ -1,11 +1,16 @@
 package netbox
 
 import (
+	"context"
+	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -32,4 +37,49 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("NETBOX_API_TOKEN"); v == "" {
 		t.Fatal("NETBOX_API_TOKEN must be set for acceptance tests.")
 	}
+}
+
+func testProviderConfig(plattform string) string {
+	return fmt.Sprintf(`
+	resource "netbox_platform" "testplatform" {
+    name = "%s"
+	}`, plattform)
+}
+
+func providerInvalidConfigure() schema.ConfigureContextFunc {
+	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+		var diags diag.Diagnostics
+
+		config := &Config{}
+		config.ServerURL = "https://fake.netbox.server"
+		config.APIToken = "1234567890"
+
+		netboxClient, clientError := config.Client()
+		if clientError != nil {
+			return nil, diag.FromErr(clientError)
+		}
+
+		return netboxClient, diags
+	}
+}
+
+func TestAccNetboxProviderConfigure_failure(t *testing.T) {
+
+	var testAccInvalidProviders map[string]*schema.Provider
+
+	testAccInvalidProvider := Provider()
+	testAccInvalidProvider.ConfigureContextFunc = providerInvalidConfigure()
+	testAccInvalidProviders = map[string]*schema.Provider{
+		"netbox": testAccInvalidProvider,
+	}
+
+	resource.Test(t, resource.TestCase{
+		Providers: testAccInvalidProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testProviderConfig(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+				ExpectError: regexp.MustCompile("Post \"https://fake.netbox.server/api/dcim/platforms/\": dial tcp: lookup fake.netbox.server: no such host"),
+			},
+		},
+	})
 }


### PR DESCRIPTION
Hi folks!

While writing tests and run `make testacc` I forgot to change the URL in my local provider configuration and the provider crashes with a SIGSEGV. Some other users already reported this issue (https://github.com/e-breuninger/terraform-provider-netbox/issues/110). 

Cheers