### PR TITLE
Add matrix build

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -22,6 +22,10 @@ jobs:
 
   testacc:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        netbox-version:
+          - "v3.1.9"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
@@ -37,6 +41,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: testacc
-        run: make testacc
+        run: make -e testacc
         env:
-          NETBOX_VERSION: "v3.1.9"
+          NETBOX_VERSION: ${{ matrix.netbox-version }}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,16 +1,17 @@
 TEST?=netbox/*.go
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 
-export NETBOX_VERSION?=v3.1.9
+export NETBOX_VERSION=v3.1.9
 export NETBOX_SERVER_URL=http://localhost:8001
 export NETBOX_API_TOKEN=0123456789abcdef0123456789abcdef01234567
-export NETBOX_TOKEN=${NETBOX_API_TOKEN}
+export NETBOX_TOKEN=$(NETBOX_API_TOKEN)
 
 default: testacc
 
 # Run acceptance tests
 .PHONY: testacc
 testacc: docker-up
+	@echo "⌛ Startup acceptance tests on $(NETBOX_SERVER_URL)"
 	TF_ACC=1 go test -v -cover $(TEST)
 
 .PHONY: test
@@ -20,13 +21,13 @@ test:
 # Run dockerized Netbox for acceptance testing
 .PHONY: docker-up
 docker-up: 
-	echo "Startup and wait for Netbox to become ready"
+	@echo "⌛ Startup Netbox $(NETBOX_VERSION) and wait for service to become ready"	
 	docker-compose -f docker/docker-compose.yml up --build wait
 	docker-compose -f docker/docker-compose.yml logs
-	echo "🚀 Netbox is up and running!"
+	@echo "🚀 Netbox is up and running!"
 
 .PHONY: docker-logs
-docker-logs: 
+docker-logs:
 	docker-compose -f docker/docker-compose.yml logs
 	
 .PHONY: docker-down

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   redis:
     image: redis:6-alpine
   netbox:
-    image: netboxcommunity/netbox:${NETBOX_VERSION-latest}
+    image: netboxcommunity/netbox:${NETBOX_VERSION}
     depends_on:
       - postgres
       - redis


### PR DESCRIPTION
Successor of #88 

For now only one version. I tried to test with a v3.0 but this is not compatible because of the missing `available_prefix` feature.
Maybe we should implement some kind of feature flag to detect which tests can run from which Netbox version. 

Simple approach for now to get started. 