### PR TITLE
Add slug generator

### DIFF
--- a/netbox/provider.go
+++ b/netbox/provider.go
@@ -41,6 +41,10 @@ func Provider() *schema.Provider {
 			"netbox_region":               resourceNetboxRegion(),
 			"netbox_aggregate":            resourceNetboxAggregate(),
 			"netbox_rir":                  resourceNetboxRir(),
+			"netbox_circuit":              resourceNetboxCircuit(),
+			"netbox_circuit_type":         resourceNetboxCircuitType(),
+			"netbox_circuit_provider":     resourceNetboxCircuitProvider(),
+			"netbox_circuit_termination":  resourceNetboxCircuitTermination(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"netbox_cluster":          dataSourceNetboxCluster(),

--- a/netbox/resource_netbox_circuit.go
+++ b/netbox/resource_netbox_circuit.go
@@ -1,0 +1,176 @@
+package netbox
+
+import (
+	"strconv"
+
+	"github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/circuits"
+	"github.com/fbreckle/go-netbox/netbox/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceNetboxCircuit() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetboxCircuitCreate,
+		Read:   resourceNetboxCircuitRead,
+		Update: resourceNetboxCircuitUpdate,
+		Delete: resourceNetboxCircuitDelete,
+
+		Schema: map[string]*schema.Schema{
+			"provider_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"cid": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"tenant_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"status": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"planned", "provisioning", "active", "offline", "deprovisioning", "decommissioning"}, false),
+			},
+		},
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+	}
+}
+
+func resourceNetboxCircuitCreate(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	data := models.WritableCircuit{}
+
+	cid := d.Get("cid").(string)
+	data.Cid = &cid
+
+	data.Status = d.Get("status").(string)
+
+	providerIDValue, ok := d.GetOk("provider_id")
+	if ok {
+		data.Provider = int64ToPtr(int64(providerIDValue.(int)))
+	}
+
+	typeIDValue, ok := d.GetOk("type_id")
+	if ok {
+		data.Type = int64ToPtr(int64(typeIDValue.(int)))
+	}
+
+	tenantIDValue, ok := d.GetOk("tenant_id")
+	if ok {
+		data.Tenant = int64ToPtr(int64(tenantIDValue.(int)))
+	}
+
+	data.Tags = []*models.NestedTag{}
+
+	params := circuits.NewCircuitsCircuitsCreateParams().WithData(&data)
+
+	res, err := api.Circuits.CircuitsCircuitsCreate(params, nil)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.FormatInt(res.GetPayload().ID, 10))
+
+	return resourceNetboxCircuitRead(d, m)
+}
+
+func resourceNetboxCircuitRead(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	params := circuits.NewCircuitsCircuitsReadParams().WithID(id)
+
+	res, err := api.Circuits.CircuitsCircuitsRead(params, nil)
+
+	if err != nil {
+		errorcode := err.(*circuits.CircuitsCircuitsReadDefault).Code()
+		if errorcode == 404 {
+			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-.html
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("cid", res.GetPayload().Cid)
+	d.Set("status", res.GetPayload().Status.Value)
+
+	if res.GetPayload().Provider != nil {
+		d.Set("provider_id", res.GetPayload().Provider.ID)
+	} else {
+		d.Set("provider_id", nil)
+	}
+
+	if res.GetPayload().Type != nil {
+		d.Set("type_id", res.GetPayload().Type.ID)
+	} else {
+		d.Set("type_id", nil)
+	}
+
+	if res.GetPayload().Tenant != nil {
+		d.Set("tenant_id", res.GetPayload().Tenant.ID)
+	} else {
+		d.Set("tenant_id", nil)
+	}
+
+	return nil
+}
+
+func resourceNetboxCircuitUpdate(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	data := models.WritableCircuit{}
+
+	cid := d.Get("cid").(string)
+	data.Cid = &cid
+
+	data.Status = d.Get("status").(string)
+
+	providerIDValue, ok := d.GetOk("provider_id")
+	if ok {
+		data.Provider = int64ToPtr(int64(providerIDValue.(int)))
+	}
+
+	typeIDValue, ok := d.GetOk("type_id")
+	if ok {
+		data.Type = int64ToPtr(int64(typeIDValue.(int)))
+	}
+
+	tenantIDValue, ok := d.GetOk("tenant_id")
+	if ok {
+		data.Tenant = int64ToPtr(int64(tenantIDValue.(int)))
+	}
+
+	params := circuits.NewCircuitsCircuitsPartialUpdateParams().WithID(id).WithData(&data)
+
+	_, err := api.Circuits.CircuitsCircuitsPartialUpdate(params, nil)
+	if err != nil {
+		return err
+	}
+
+	return resourceNetboxCircuitRead(d, m)
+}
+
+func resourceNetboxCircuitDelete(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	params := circuits.NewCircuitsCircuitsDeleteParams().WithID(id)
+
+	_, err := api.Circuits.CircuitsCircuitsDelete(params, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/netbox/resource_netbox_circuit_provider.go
+++ b/netbox/resource_netbox_circuit_provider.go
@@ -46,7 +46,7 @@ func resourceNetboxCircuitProviderCreate(d *schema.ResourceData, m interface{}) 
 	slugValue, slugOk := d.GetOk("slug")
 	// Default slug to model if not given
 	if !slugOk {
-		data.Slug = strToPtr(name)
+		data.Slug = strToPtr(getSlugFromName(name))
 	} else {
 		data.Slug = strToPtr(slugValue.(string))
 	}
@@ -100,7 +100,7 @@ func resourceNetboxCircuitProviderUpdate(d *schema.ResourceData, m interface{}) 
 	slugValue, slugOk := d.GetOk("slug")
 	// Default slug to model if not given
 	if !slugOk {
-		data.Slug = strToPtr(name)
+		data.Slug = strToPtr(getSlugFromName(name))
 	} else {
 		data.Slug = strToPtr(slugValue.(string))
 	}

--- a/netbox/resource_netbox_circuit_provider.go
+++ b/netbox/resource_netbox_circuit_provider.go
@@ -1,0 +1,129 @@
+package netbox
+
+import (
+	"strconv"
+
+	"github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/circuits"
+	"github.com/fbreckle/go-netbox/netbox/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceNetboxCircuitProvider() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetboxCircuitProviderCreate,
+		Read:   resourceNetboxCircuitProviderRead,
+		Update: resourceNetboxCircuitProviderUpdate,
+		Delete: resourceNetboxCircuitProviderDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"slug": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringLenBetween(0, 30),
+			},
+		},
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+	}
+}
+
+func resourceNetboxCircuitProviderCreate(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	data := models.Provider{}
+
+	name := d.Get("name").(string)
+	data.Name = &name
+
+	slugValue, slugOk := d.GetOk("slug")
+	// Default slug to model if not given
+	if !slugOk {
+		data.Slug = strToPtr(name)
+	} else {
+		data.Slug = strToPtr(slugValue.(string))
+	}
+
+	data.Tags = []*models.NestedTag{}
+
+	params := circuits.NewCircuitsProvidersCreateParams().WithData(&data)
+
+	res, err := api.Circuits.CircuitsProvidersCreate(params, nil)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.FormatInt(res.GetPayload().ID, 10))
+
+	return resourceNetboxCircuitProviderRead(d, m)
+}
+
+func resourceNetboxCircuitProviderRead(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	params := circuits.NewCircuitsProvidersReadParams().WithID(id)
+
+	res, err := api.Circuits.CircuitsProvidersRead(params, nil)
+
+	if err != nil {
+		errorcode := err.(*circuits.CircuitsProvidersReadDefault).Code()
+		if errorcode == 404 {
+			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("name", res.GetPayload().Name)
+	d.Set("slug", res.GetPayload().Slug)
+
+	return nil
+}
+
+func resourceNetboxCircuitProviderUpdate(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	data := models.Provider{}
+
+	name := d.Get("name").(string)
+	data.Name = &name
+
+	slugValue, slugOk := d.GetOk("slug")
+	// Default slug to model if not given
+	if !slugOk {
+		data.Slug = strToPtr(name)
+	} else {
+		data.Slug = strToPtr(slugValue.(string))
+	}
+
+	params := circuits.NewCircuitsProvidersPartialUpdateParams().WithID(id).WithData(&data)
+
+	_, err := api.Circuits.CircuitsProvidersPartialUpdate(params, nil)
+	if err != nil {
+		return err
+	}
+
+	return resourceNetboxCircuitProviderRead(d, m)
+}
+
+func resourceNetboxCircuitProviderDelete(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	params := circuits.NewCircuitsProvidersDeleteParams().WithID(id)
+
+	_, err := api.Circuits.CircuitsProvidersDelete(params, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/netbox/resource_netbox_circuit_provider_test.go
+++ b/netbox/resource_netbox_circuit_provider_test.go
@@ -1,0 +1,71 @@
+package netbox
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/circuits"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccNetboxCircuitProvider_basic(t *testing.T) {
+
+	testSlug := "circuit_prov"
+	testName := testAccGetTestName(testSlug)
+	randomSlug := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`	  
+resource "netbox_circuit_provider" "test" {
+  name = "%[1]s"
+  slug = "%[2]s"
+}`, testName, randomSlug),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_circuit_provider.test", "name", testName),
+					resource.TestCheckResourceAttr("netbox_circuit_provider.test", "slug", randomSlug),
+				),
+			},
+			{
+				ResourceName:      "netbox_circuit_provider.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func init() {
+	resource.AddTestSweepers("netbox_circuit_provider", &resource.Sweeper{
+		Name:         "netbox_circuit_provider",
+		Dependencies: []string{},
+		F: func(region string) error {
+			m, err := sharedClientForRegion(region)
+			if err != nil {
+				return fmt.Errorf("Error getting client: %s", err)
+			}
+			api := m.(*client.NetBoxAPI)
+			params := circuits.NewCircuitsProvidersListParams()
+			res, err := api.Circuits.CircuitsProvidersList(params, nil)
+			if err != nil {
+				return err
+			}
+			for _, CircuitProvider := range res.GetPayload().Results {
+				if strings.HasPrefix(*CircuitProvider.Name, testPrefix) {
+					deleteParams := circuits.NewCircuitsProvidersDeleteParams().WithID(CircuitProvider.ID)
+					_, err := api.Circuits.CircuitsProvidersDelete(deleteParams, nil)
+					if err != nil {
+						return err
+					}
+					log.Print("[DEBUG] Deleted a circuit provider")
+				}
+			}
+			return nil
+		},
+	})
+}

--- a/netbox/resource_netbox_circuit_termination.go
+++ b/netbox/resource_netbox_circuit_termination.go
@@ -1,0 +1,184 @@
+package netbox
+
+import (
+	"strconv"
+
+	"github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/circuits"
+	"github.com/fbreckle/go-netbox/netbox/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceNetboxCircuitTermination() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetboxCircuitTerminationCreate,
+		Read:   resourceNetboxCircuitTerminationRead,
+		Update: resourceNetboxCircuitTerminationUpdate,
+		Delete: resourceNetboxCircuitTerminationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"circuit_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"site_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"port_speed": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"upstream_speed": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"term_side": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"A", "Z"}, false),
+			},
+		},
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+	}
+}
+
+func resourceNetboxCircuitTerminationCreate(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	data := models.WritableCircuitTermination{}
+
+	termside := d.Get("term_side").(string)
+	data.TermSide = &termside
+
+	circuitIDValue, ok := d.GetOk("circuit_id")
+	if ok {
+		data.Circuit = int64ToPtr(int64(circuitIDValue.(int)))
+	}
+
+	siteIDValue, ok := d.GetOk("site_id")
+	if ok {
+		data.Site = int64ToPtr(int64(siteIDValue.(int)))
+	}
+
+	portspeedValue, ok := d.GetOk("port_speed")
+	if ok {
+		data.PortSpeed = int64ToPtr(int64(portspeedValue.(int)))
+	}
+
+	upstreamspeedValue, ok := d.GetOk("upstream_speed")
+	if ok {
+		data.UpstreamSpeed = int64ToPtr(int64(upstreamspeedValue.(int)))
+	}
+
+	params := circuits.NewCircuitsCircuitTerminationsCreateParams().WithData(&data)
+
+	res, err := api.Circuits.CircuitsCircuitTerminationsCreate(params, nil)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.FormatInt(res.GetPayload().ID, 10))
+
+	return resourceNetboxCircuitTerminationRead(d, m)
+}
+
+func resourceNetboxCircuitTerminationRead(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	params := circuits.NewCircuitsCircuitTerminationsReadParams().WithID(id)
+
+	res, err := api.Circuits.CircuitsCircuitTerminationsRead(params, nil)
+
+	if err != nil {
+		errorcode := err.(*circuits.CircuitsCircuitTerminationsReadDefault).Code()
+		if errorcode == 404 {
+			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-.html
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("term_side", res.GetPayload().TermSide)
+
+	if res.GetPayload().Circuit != nil {
+		d.Set("circuit_id", res.GetPayload().Circuit.ID)
+	} else {
+		d.Set("circuit_id", nil)
+	}
+
+	if res.GetPayload().Site != nil {
+		d.Set("site_id", res.GetPayload().Site.ID)
+	} else {
+		d.Set("site_id", nil)
+	}
+
+	if res.GetPayload().PortSpeed != nil {
+		d.Set("port_speed", res.GetPayload().PortSpeed)
+	} else {
+		d.Set("port_speed", nil)
+	}
+
+	if res.GetPayload().UpstreamSpeed != nil {
+		d.Set("upstream_speed", res.GetPayload().UpstreamSpeed)
+	} else {
+		d.Set("upstream_speed", nil)
+	}
+
+	return nil
+}
+
+func resourceNetboxCircuitTerminationUpdate(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	data := models.WritableCircuitTermination{}
+
+	termside := d.Get("term_side").(string)
+	data.TermSide = &termside
+
+	circuitIDValue, ok := d.GetOk("circuit_id")
+	if ok {
+		data.Circuit = int64ToPtr(int64(circuitIDValue.(int)))
+	}
+
+	siteIDValue, ok := d.GetOk("site_id")
+	if ok {
+		data.Site = int64ToPtr(int64(siteIDValue.(int)))
+	}
+
+	portspeedValue, ok := d.GetOk("port_speed")
+	if ok {
+		data.PortSpeed = int64ToPtr(int64(portspeedValue.(int)))
+	}
+
+	upstreamspeedValue, ok := d.GetOk("upstream_speed")
+	if ok {
+		data.UpstreamSpeed = int64ToPtr(int64(upstreamspeedValue.(int)))
+	}
+	params := circuits.NewCircuitsCircuitTerminationsPartialUpdateParams().WithID(id).WithData(&data)
+
+	_, err := api.Circuits.CircuitsCircuitTerminationsPartialUpdate(params, nil)
+	if err != nil {
+		return err
+	}
+
+	return resourceNetboxCircuitTerminationRead(d, m)
+}
+
+func resourceNetboxCircuitTerminationDelete(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	params := circuits.NewCircuitsCircuitTerminationsDeleteParams().WithID(id)
+
+	_, err := api.Circuits.CircuitsCircuitTerminationsDelete(params, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/netbox/resource_netbox_circuit_termination_test.go
+++ b/netbox/resource_netbox_circuit_termination_test.go
@@ -1,0 +1,94 @@
+package netbox
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/circuits"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccNetboxCircuitTermination_basic(t *testing.T) {
+	testSlug := "circuit_term"
+	testName := testAccGetTestName(testSlug)
+	randomSlug := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_site" "test" {
+	name = "%[1]s"
+	slug = "%[2]s"
+	status = "active"
+}	
+resource "netbox_circuit_provider" "test" {
+	name = "%[1]s"
+	slug = "%[2]s"
+}
+resource "netbox_circuit_type" "test" {
+	name = "%[1]s"
+	slug = "%[2]s"
+}									  
+resource "netbox_circuit" "test" {
+  cid = "%[1]s"
+  status = "active"
+  provider_id = netbox_circuit_provider.test.id
+  type_id = netbox_circuit_type.test.id
+}
+resource "netbox_circuit_termination" "test" {
+	circuit_id = netbox_circuit.test.id
+	term_side = "A"
+	site_id = netbox_site.test.id
+	port_speed = 100000
+	upstream_speed = 50000
+  }`, testName, randomSlug),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_circuit_termination.test", "circuit_id", "netbox_circuit.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_circuit_termination.test", "site_id", "netbox_site.test", "id"),
+					resource.TestCheckResourceAttr("netbox_circuit_termination.test", "port_speed", "100000"),
+					resource.TestCheckResourceAttr("netbox_circuit_termination.test", "upstream_speed", "50000"),
+				),
+			},
+			{
+				ResourceName:      "netbox_circuit_termination.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func init() {
+	resource.AddTestSweepers("netbox_circuit_termination", &resource.Sweeper{
+		Name:         "netbox_circuit_termination",
+		Dependencies: []string{},
+		F: func(region string) error {
+			m, err := sharedClientForRegion(region)
+			if err != nil {
+				return fmt.Errorf("Error getting client: %s", err)
+			}
+			api := m.(*client.NetBoxAPI)
+			params := circuits.NewCircuitsCircuitsListParams()
+			res, err := api.Circuits.CircuitsCircuitsList(params, nil)
+			if err != nil {
+				return err
+			}
+			for _, Circuit := range res.GetPayload().Results {
+				if strings.HasPrefix(*Circuit.Cid, testPrefix) {
+					deleteParams := circuits.NewCircuitsCircuitsDeleteParams().WithID(Circuit.ID)
+					_, err := api.Circuits.CircuitsCircuitsDelete(deleteParams, nil)
+					if err != nil {
+						return err
+					}
+					log.Print("[DEBUG] Deleted a circuit termination")
+				}
+			}
+			return nil
+		},
+	})
+}

--- a/netbox/resource_netbox_circuit_test.go
+++ b/netbox/resource_netbox_circuit_test.go
@@ -1,0 +1,87 @@
+package netbox
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/circuits"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccNetboxCircuit_basic(t *testing.T) {
+	testSlug := "circuit_prov"
+	testName := testAccGetTestName(testSlug)
+	randomSlug := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_tenant" "test" {
+	name = "%[1]s"
+	slug = "%[2]s"
+}
+resource "netbox_circuit_provider" "test" {
+	name = "%[1]s"
+	slug = "%[2]s"
+}
+resource "netbox_circuit_type" "test" {
+	name = "%[1]s"
+	slug = "%[2]s"
+}									  
+resource "netbox_circuit" "test" {
+  cid = "%[1]s"
+  status = "active"
+  provider_id = netbox_circuit_provider.test.id
+  type_id = netbox_circuit_type.test.id
+  tenant_id = netbox_tenant.test.id
+}`, testName, randomSlug),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_circuit.test", "cid", testName),
+					resource.TestCheckResourceAttrPair("netbox_circuit.test", "provider_id", "netbox_circuit_provider.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_circuit.test", "type_id", "netbox_circuit_type.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_circuit.test", "tenant_id", "netbox_tenant.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "netbox_circuit.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func init() {
+	resource.AddTestSweepers("netbox_circuit", &resource.Sweeper{
+		Name:         "netbox_circuit",
+		Dependencies: []string{},
+		F: func(region string) error {
+			m, err := sharedClientForRegion(region)
+			if err != nil {
+				return fmt.Errorf("Error getting client: %s", err)
+			}
+			api := m.(*client.NetBoxAPI)
+			params := circuits.NewCircuitsCircuitsListParams()
+			res, err := api.Circuits.CircuitsCircuitsList(params, nil)
+			if err != nil {
+				return err
+			}
+			for _, Circuit := range res.GetPayload().Results {
+				if strings.HasPrefix(*Circuit.Cid, testPrefix) {
+					deleteParams := circuits.NewCircuitsCircuitsDeleteParams().WithID(Circuit.ID)
+					_, err := api.Circuits.CircuitsCircuitsDelete(deleteParams, nil)
+					if err != nil {
+						return err
+					}
+					log.Print("[DEBUG] Deleted a circuit")
+				}
+			}
+			return nil
+		},
+	})
+}

--- a/netbox/resource_netbox_circuit_type.go
+++ b/netbox/resource_netbox_circuit_type.go
@@ -1,0 +1,127 @@
+package netbox
+
+import (
+	"strconv"
+
+	"github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/circuits"
+	"github.com/fbreckle/go-netbox/netbox/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceNetboxCircuitType() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetboxCircuitTypeCreate,
+		Read:   resourceNetboxCircuitTypeRead,
+		Update: resourceNetboxCircuitTypeUpdate,
+		Delete: resourceNetboxCircuitTypeDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"slug": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringLenBetween(0, 30),
+			},
+		},
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+	}
+}
+
+func resourceNetboxCircuitTypeCreate(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	data := models.CircuitType{}
+
+	name := d.Get("name").(string)
+	data.Name = &name
+
+	slugValue, slugOk := d.GetOk("slug")
+	// Default slug to model if not given
+	if !slugOk {
+		data.Slug = strToPtr(name)
+	} else {
+		data.Slug = strToPtr(slugValue.(string))
+	}
+
+	params := circuits.NewCircuitsCircuitTypesCreateParams().WithData(&data)
+
+	res, err := api.Circuits.CircuitsCircuitTypesCreate(params, nil)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.FormatInt(res.GetPayload().ID, 10))
+
+	return resourceNetboxCircuitTypeRead(d, m)
+}
+
+func resourceNetboxCircuitTypeRead(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	params := circuits.NewCircuitsCircuitTypesReadParams().WithID(id)
+
+	res, err := api.Circuits.CircuitsCircuitTypesRead(params, nil)
+
+	if err != nil {
+		errorcode := err.(*circuits.CircuitsCircuitTypesReadDefault).Code()
+		if errorcode == 404 {
+			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("name", res.GetPayload().Name)
+	d.Set("slug", res.GetPayload().Slug)
+
+	return nil
+}
+
+func resourceNetboxCircuitTypeUpdate(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	data := models.CircuitType{}
+
+	name := d.Get("name").(string)
+	data.Name = &name
+
+	slugValue, slugOk := d.GetOk("slug")
+	// Default slug to model if not given
+	if !slugOk {
+		data.Slug = strToPtr(name)
+	} else {
+		data.Slug = strToPtr(slugValue.(string))
+	}
+
+	params := circuits.NewCircuitsCircuitTypesPartialUpdateParams().WithID(id).WithData(&data)
+
+	_, err := api.Circuits.CircuitsCircuitTypesPartialUpdate(params, nil)
+	if err != nil {
+		return err
+	}
+
+	return resourceNetboxCircuitTypeRead(d, m)
+}
+
+func resourceNetboxCircuitTypeDelete(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	params := circuits.NewCircuitsCircuitTypesDeleteParams().WithID(id)
+
+	_, err := api.Circuits.CircuitsCircuitTypesDelete(params, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/netbox/resource_netbox_circuit_type.go
+++ b/netbox/resource_netbox_circuit_type.go
@@ -46,7 +46,7 @@ func resourceNetboxCircuitTypeCreate(d *schema.ResourceData, m interface{}) erro
 	slugValue, slugOk := d.GetOk("slug")
 	// Default slug to model if not given
 	if !slugOk {
-		data.Slug = strToPtr(name)
+		data.Slug = strToPtr(getSlugFromName(name))
 	} else {
 		data.Slug = strToPtr(slugValue.(string))
 	}
@@ -98,7 +98,7 @@ func resourceNetboxCircuitTypeUpdate(d *schema.ResourceData, m interface{}) erro
 	slugValue, slugOk := d.GetOk("slug")
 	// Default slug to model if not given
 	if !slugOk {
-		data.Slug = strToPtr(name)
+		data.Slug = strToPtr(getSlugFromName(name))
 	} else {
 		data.Slug = strToPtr(slugValue.(string))
 	}

--- a/netbox/resource_netbox_circuit_type_test.go
+++ b/netbox/resource_netbox_circuit_type_test.go
@@ -1,0 +1,71 @@
+package netbox
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/circuits"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccNetboxCircuitType_basic(t *testing.T) {
+
+	testSlug := "circuit_type"
+	testName := testAccGetTestName(testSlug)
+	randomSlug := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`	  
+resource "netbox_circuit_type" "test" {
+  name = "%[1]s"
+  slug = "%[2]s"
+}`, testName, randomSlug),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_circuit_type.test", "name", testName),
+					resource.TestCheckResourceAttr("netbox_circuit_type.test", "slug", randomSlug),
+				),
+			},
+			{
+				ResourceName:      "netbox_circuit_type.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func init() {
+	resource.AddTestSweepers("netbox_circuit_type", &resource.Sweeper{
+		Name:         "netbox_circuit_type",
+		Dependencies: []string{},
+		F: func(region string) error {
+			m, err := sharedClientForRegion(region)
+			if err != nil {
+				return fmt.Errorf("Error getting client: %s", err)
+			}
+			api := m.(*client.NetBoxAPI)
+			params := circuits.NewCircuitsCircuitTypesListParams()
+			res, err := api.Circuits.CircuitsCircuitTypesList(params, nil)
+			if err != nil {
+				return err
+			}
+			for _, CircuitType := range res.GetPayload().Results {
+				if strings.HasPrefix(*CircuitType.Name, testPrefix) {
+					deleteParams := circuits.NewCircuitsCircuitTypesDeleteParams().WithID(CircuitType.ID)
+					_, err := api.Circuits.CircuitsCircuitTypesDelete(deleteParams, nil)
+					if err != nil {
+						return err
+					}
+					log.Print("[DEBUG] Deleted a circuit type")
+				}
+			}
+			return nil
+		},
+	})
+}

--- a/netbox/resource_netbox_manufacturer.go
+++ b/netbox/resource_netbox_manufacturer.go
@@ -46,7 +46,7 @@ func resourceNetboxManufacturerCreate(d *schema.ResourceData, m interface{}) err
 	slugValue, slugOk := d.GetOk("slug")
 	// Default slug to name if not given
 	if !slugOk {
-		data.Slug = strToPtr(name)
+		data.Slug = strToPtr(getSlugFromName(name))
 	} else {
 		data.Slug = strToPtr(slugValue.(string))
 	}
@@ -98,7 +98,7 @@ func resourceNetboxManufacturerUpdate(d *schema.ResourceData, m interface{}) err
 	slugValue, slugOk := d.GetOk("slug")
 	// Default slug to name if not given
 	if !slugOk {
-		data.Slug = strToPtr(name)
+		data.Slug = strToPtr(getSlugFromName(name))
 	} else {
 		data.Slug = strToPtr(slugValue.(string))
 	}

--- a/netbox/resource_netbox_region.go
+++ b/netbox/resource_netbox_region.go
@@ -59,7 +59,7 @@ func resourceNetboxRegionCreate(d *schema.ResourceData, m interface{}) error {
 	slugValue, slugOk := d.GetOk("slug")
 	// Default slug to name if not given
 	if !slugOk {
-		data.Slug = strToPtr(name)
+		data.Slug = strToPtr(getSlugFromName(name))
 	} else {
 		data.Slug = strToPtr(slugValue.(string))
 	}
@@ -124,7 +124,7 @@ func resourceNetboxRegionUpdate(d *schema.ResourceData, m interface{}) error {
 	slugValue, slugOk := d.GetOk("slug")
 	// Default slug to name if not given
 	if !slugOk {
-		data.Slug = strToPtr(name)
+		data.Slug = strToPtr(getSlugFromName(name))
 	} else {
 		data.Slug = strToPtr(slugValue.(string))
 	}

--- a/netbox/resource_netbox_site.go
+++ b/netbox/resource_netbox_site.go
@@ -81,7 +81,7 @@ func resourceNetboxSiteCreate(d *schema.ResourceData, m interface{}) error {
 	slugValue, slugOk := d.GetOk("slug")
 	// Default slug to name if not given
 	if !slugOk {
-		data.Slug = strToPtr(name)
+		data.Slug = strToPtr(getSlugFromName(name))
 	} else {
 		data.Slug = strToPtr(slugValue.(string))
 	}
@@ -175,7 +175,7 @@ func resourceNetboxSiteUpdate(d *schema.ResourceData, m interface{}) error {
 	slugValue, slugOk := d.GetOk("slug")
 	// Default slug to name if not given
 	if !slugOk {
-		data.Slug = strToPtr(name)
+		data.Slug = strToPtr(getSlugFromName(name))
 	} else {
 		data.Slug = strToPtr(slugValue.(string))
 	}

--- a/netbox/util.go
+++ b/netbox/util.go
@@ -1,7 +1,9 @@
 package netbox
 
 import (
+	"regexp"
 	"strconv"
+	"strings"
 
 	sp "github.com/davecgh/go-spew/spew"
 )
@@ -25,4 +27,10 @@ func intToPtr(i int) *int {
 
 func int64ToPtr(i int64) *int64 {
 	return &i
+}
+
+func getSlugFromName(s string) string {
+	reg, _ := regexp.Compile("[^a-z0-9-_ ]+")
+	res := strings.Replace(strings.ToLower(s), " ", "-", -1)
+	return reg.ReplaceAllString(res, "")
 }


### PR DESCRIPTION
Slugs must contain only letters, numbers, underscores or hyphens.
This PR adds basic support for generating slugs.

It follows similar pattern as netbox by replacing spaces with hypens,
casting to lowercase and removing unsupported characters.
```
Enter a valid "slug" consisting of letters, numbers, underscores or hyphens.
```