### PR TITLE
🐛 netbox_ip_addresses: Fix usage of wrong attribute

### DIFF
--- a/netbox/data_source_netbox_ip_addresses.go
+++ b/netbox/data_source_netbox_ip_addresses.go
@@ -158,7 +158,7 @@ func dataSourceNetboxIpAddressesRead(d *schema.ResourceData, m interface{}) erro
 		mapping["address_family"] = v.Family.Label
 		mapping["status"] = v.Status.Value
 		mapping["dns_name"] = v.DNSName
-		mapping["role"] = v.Role
+		mapping["role"] = v.Role.Label
 		mapping["tenant"] = flattenTenant(v.Tenant)
 
 		s = append(s, mapping)


### PR DESCRIPTION
This change fixes the issue while using the `netbox_ip_addresses`.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1e6d0b5]

goroutine 431 [running]:
command-line-arguments.dataSourceNetboxIpAddressesRead(0xadc3290?, {0x2020500?, 0xc00038acf0})
        /Users/XX/Projects/XXXX/terraform-provider-netbox/netbox/data_source_netbox_ip_addresses.go:161 +0x655
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0x24acc90?, {0x24acc90?, 0xc0000d9890?}, 0xd?, {0x2020500?, 0xc00038acf0?})
        /Users/XX/Projects/XXXX/Go-Workspace/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.16.0/helper/schema/resource.go:712 +0x178
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0xc00020db20, {0x24acc90, 0xc0000d9890}, 0xc0003b3e80, {0x2020500, 0xc00038acf0})
        /Users/XX/Projects/XXXX/Go-Workspace/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.16.0/helper/schema/resource.go:943 +0x145
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0xc0006db470, {0x24acbe8?, 0xc000352200?}, 0xc0006edb60)
        /Users/XX/Projects/XXXX/Go-Workspace/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.16.0/helper/schema/grpc_provider.go:1179 +0x38f
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadDataSource(0xc00033a640, {0x24acc90?, 0xc0000d9170?}, 0xc00062f7c0)
        /Users/XX/Projects/XXXX/Go-Workspace/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.9.0/tfprotov5/tf5server/server.go:657 +0x409
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadDataSource_Handler({0x220d5e0?, 0xc00033a640}, {0x24acc90, 0xc0000d9170}, 0xc00062aa80, 0x0)
        /Users/XX/Projects/XXXX/Go-Workspace/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.9.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:421 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000610700, {0x24afcb8, 0xc00037a680}, 0xc0007fa7e0, 0xc000438f30, 0x30430d0, 0x0)
        /Users/XX/Projects/XXXX/Go-Workspace/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:1282 +0xccf
google.golang.org/grpc.(*Server).handleStream(0xc000610700, {0x24afcb8, 0xc00037a680}, 0xc0007fa7e0, 0x0)
        /Users/XX/Projects/XXXX/Go-Workspace/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:1619 +0xa1b
google.golang.org/grpc.(*Server).serveStreams.func1.2()
        /Users/XX/Projects/XXXX/Go-Workspace/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:921 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /Users/XX/Projects/XXXX/Go-Workspace/pkg/mod/google.golang.org/grpc@v1.45.0/server.go:919 +0x28a
```