### PR TITLE
Add VLAN tagging support to interfaces

### DIFF
--- a/docs/resources/interface.md
+++ b/docs/resources/interface.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-// Assumes Netbox already has a VM whos name matches 'dc-west-myvm-20'
+// Assume Netbox already has a VM whos name matches 'dc-west-myvm-20'
 data "netbox_virtual_machine" "myvm" {
   name_regex = "dc-west-myvm-20"
 }
@@ -21,6 +21,18 @@ data "netbox_virtual_machine" "myvm" {
 resource "netbox_interface" "myvm_eth0" {
   name               = "eth0"
   virtual_machine_id = data.netbox_virtual_machine.myvm.id
+}
+
+// Assume existing VLAN resources 'test1' and 'test2'
+resource "netbox_interface" "myvm_eth1" {
+  name = "eth1"
+  enabled = true
+  mac_address = "00:16:3E:A8:B5:D7"
+  mode = "tagged"
+  mtu = 1440
+  tagged_vlans = [netbox_vlan.test1.id]
+  untagged_vlan = netbox_vlan.test2.id
+  virtual_machine_id = netbox_virtual_machine.test.id
 }
 ```
 
@@ -35,9 +47,14 @@ resource "netbox_interface" "myvm_eth0" {
 ### Optional
 
 - `description` (String)
+- `enabled` (Boolean)
 - `mac_address` (String)
+- `mode` (String)
+- `mtu` (Number)
+- `tagged_vlans` (Set of Number)
 - `tags` (Set of String)
 - `type` (String, Deprecated)
+- `untagged_vlan` (Number)
 
 ### Read-Only
 

--- a/examples/resources/netbox_interface/resource.tf
+++ b/examples/resources/netbox_interface/resource.tf
@@ -1,4 +1,4 @@
-// Assumes Netbox already has a VM whos name matches 'dc-west-myvm-20'
+// Assume Netbox already has a VM whos name matches 'dc-west-myvm-20'
 data "netbox_virtual_machine" "myvm" {
   name_regex = "dc-west-myvm-20"
 }
@@ -6,4 +6,16 @@ data "netbox_virtual_machine" "myvm" {
 resource "netbox_interface" "myvm_eth0" {
   name               = "eth0"
   virtual_machine_id = data.netbox_virtual_machine.myvm.id
+}
+
+// Assume existing VLAN resources 'test1' and 'test2'
+resource "netbox_interface" "myvm_eth1" {
+  name = "eth1"
+  enabled = true
+  mac_address = "00:16:3E:A8:B5:D7"
+  mode = "tagged"
+  mtu = 1440
+  tagged_vlans = [netbox_vlan.test1.id]
+  untagged_vlan = netbox_vlan.test2.id
+  virtual_machine_id = netbox_virtual_machine.test.id
 }

--- a/netbox/resource_netbox_interface_test.go
+++ b/netbox/resource_netbox_interface_test.go
@@ -29,24 +29,75 @@ resource "netbox_virtual_machine" "test" {
   cluster_id = netbox_cluster.test.id
 }
 
-`, testName)
+resource "netbox_vlan" "test1" {
+  name = "%[1]s_vlan1"
+  vid = 1001
+  tags = []
+}
+
+resource "netbox_vlan" "test2" {
+  name = "%[1]s_vlan2"
+  vid = 1002
+  tags = []
+}`, testName)
+}
+
+func testAccNetboxInterface_basic(testName string) string {
+	return fmt.Sprintf(`
+resource "netbox_interface" "test" {
+  name = "%s"
+  virtual_machine_id = netbox_virtual_machine.test.id
+}`, testName)
+}
+
+func testAccNetboxInterface_opts(testName string, testMac string) string {
+	return fmt.Sprintf(`
+resource "netbox_interface" "test" {
+  name = "%[1]s"
+  description = "%[1]s"
+  enabled = true
+  mac_address = "%[2]s"
+  mtu = 1440
+  virtual_machine_id = netbox_virtual_machine.test.id
+}`, testName, testMac)
+}
+
+func testAccNetboxInterface_vlans(testName string) string {
+	return fmt.Sprintf(`
+resource "netbox_interface" "test1" {
+  name = "%[1]s_1"
+  mode = "access"
+  untagged_vlan = netbox_vlan.test1.id
+  virtual_machine_id = netbox_virtual_machine.test.id
+}
+
+resource "netbox_interface" "test2" {
+  name = "%[1]s_2"
+  mode = "tagged"
+  tagged_vlans = [netbox_vlan.test2.id]
+  untagged_vlan = netbox_vlan.test1.id
+  virtual_machine_id = netbox_virtual_machine.test.id
+}
+
+resource "netbox_interface" "test3" {
+  name = "%[1]s_3"
+  mode = "tagged-all"
+  tagged_vlans = [netbox_vlan.test1.id, netbox_vlan.test2.id]
+  virtual_machine_id = netbox_virtual_machine.test.id
+}`, testName)
 }
 
 func TestAccNetboxInterface_basic(t *testing.T) {
-
 	testSlug := "iface_basic"
 	testName := testAccGetTestName(testSlug)
+	setUp := testAccNetboxInterfaceFullDependencies(testName)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetboxInterfaceFullDependencies(testName) + fmt.Sprintf(`
-resource "netbox_interface" "test" {
-  name = "%s"
-  virtual_machine_id = netbox_virtual_machine.test.id
-}`, testName),
+				Config: setUp + testAccNetboxInterface_basic(testName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_interface.test", "name", testName),
 					resource.TestCheckResourceAttrPair("netbox_interface.test", "virtual_machine_id", "netbox_virtual_machine.test", "id"),
@@ -61,31 +112,69 @@ resource "netbox_interface" "test" {
 	})
 }
 
-func TestAccNetboxInterface_mac(t *testing.T) {
-
+func TestAccNetboxInterface_opts(t *testing.T) {
 	testSlug := "iface_mac"
 	testMac := "00:01:02:03:04:05"
 	testName := testAccGetTestName(testSlug)
+	setUp := testAccNetboxInterfaceFullDependencies(testName)
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccNetboxInterfaceFullDependencies(testName) + fmt.Sprintf(`
-resource "netbox_interface" "test" {
-  name = "%[1]s"
-  virtual_machine_id = netbox_virtual_machine.test.id
-  mac_address = "%[2]s"
-}`, testName, testMac),
+				Config: setUp + testAccNetboxInterface_opts(testName, testMac),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_interface.test", "name", testName),
-					resource.TestCheckResourceAttrPair("netbox_interface.test", "virtual_machine_id", "netbox_virtual_machine.test", "id"),
+					resource.TestCheckResourceAttr("netbox_interface.test", "description", testName),
+					resource.TestCheckResourceAttr("netbox_interface.test", "enabled", "true"),
 					resource.TestCheckResourceAttr("netbox_interface.test", "mac_address", "00:01:02:03:04:05"),
+					resource.TestCheckResourceAttr("netbox_interface.test", "mtu", "1440"),
+					resource.TestCheckResourceAttrPair("netbox_interface.test", "virtual_machine_id", "netbox_virtual_machine.test", "id"),
 				),
 			},
 			{
 				ResourceName:      "netbox_interface.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccNetboxInterface_vlans(t *testing.T) {
+	testSlug := "iface_vlan"
+	testName := testAccGetTestName(testSlug)
+	setUp := testAccNetboxInterfaceFullDependencies(testName)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: setUp + testAccNetboxInterface_vlans(testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_interface.test1", "mode", "access"),
+					resource.TestCheckResourceAttr("netbox_interface.test2", "mode", "tagged"),
+					resource.TestCheckResourceAttr("netbox_interface.test3", "mode", "tagged-all"),
+					resource.TestCheckResourceAttrPair("netbox_interface.test1", "untagged_vlan", "netbox_vlan.test1", "id"),
+					resource.TestCheckResourceAttrPair("netbox_interface.test2", "untagged_vlan", "netbox_vlan.test1", "id"),
+					resource.TestCheckResourceAttrPair("netbox_interface.test2", "tagged_vlans.0", "netbox_vlan.test2", "id"),
+					resource.TestCheckResourceAttr("netbox_interface.test3", "tagged_vlans.#", "2"),
+				),
+			},
+			{
+				ResourceName:      "netbox_interface.test1",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "netbox_interface.test2",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "netbox_interface.test3",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/netbox/util.go
+++ b/netbox/util.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	sp "github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func spew(obj interface{}) string {
@@ -29,4 +30,16 @@ func int64ToPtr(i int64) *int64 {
 
 func float64ToPtr(i float64) *float64 {
 	return &i
+}
+
+func toInt64List(a interface{}) []int64 {
+	intList := []int64{}
+	for _, number := range a.(*schema.Set).List() {
+		if n, ok := number.(int); ok {
+			intList = append(intList, int64(n))
+		} else if n, ok := number.(int64); ok {
+			intList = append(intList, n)
+		}
+	}
+	return intList
 }


### PR DESCRIPTION
To be more precise `netbox_interface` resource now knows how to handle following attributes:

- enabled
- mtu
- mode, tagged_vlans, untagged_vlan

**Note for reviewer**: This includes changes from https://github.com/e-breuninger/terraform-provider-netbox/pull/184 , please see that first.