### PR TITLE
netbox_ip_addresses: Remove role attribute

### DIFF
--- a/netbox/data_source_netbox_ip_addresses.go
+++ b/netbox/data_source_netbox_ip_addresses.go
@@ -73,10 +73,6 @@ func dataSourceNetboxIpAddresses() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"role": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
 
 						"tenant": {
 							Type:     schema.TypeList,
@@ -158,7 +154,6 @@ func dataSourceNetboxIpAddressesRead(d *schema.ResourceData, m interface{}) erro
 		mapping["address_family"] = v.Family.Label
 		mapping["status"] = v.Status.Value
 		mapping["dns_name"] = v.DNSName
-		mapping["role"] = v.Role
 		mapping["tenant"] = flattenTenant(v.Tenant)
 
 		s = append(s, mapping)


### PR DESCRIPTION
Remove this attribute because it isn't supported by `netbox_ip_address`.
This is needed to get this tested with `make acctest`.
I want to implement this and created a issue in the upstream [go library](https://github.com/fbreckle/go-netbox/issues/15). Until then, this attribute is removed.
