### PR TITLE
fix: Add tests for platform on devices, and fix one failing test

### DIFF
--- a/netbox/data_source_netbox_devices_test.go
+++ b/netbox/data_source_netbox_devices_test.go
@@ -31,6 +31,7 @@ func TestAccNetboxDevicesDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair("data.netbox_devices.test", "devices.0.role_id", "netbox_device_role.test", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_devices.test", "devices.0.device_type_id", "netbox_device_type.test", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_devices.test", "devices.0.site_id", "netbox_site.test", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_devices.test", "devices.0.platform_id", "netbox_platform.test", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_devices.test", "devices.0.location_id", "netbox_location.test", "id"),
 					resource.TestCheckResourceAttr("data.netbox_devices.test", "devices.0.serial", "ABCDEF0"),
 				),
@@ -85,6 +86,7 @@ resource "netbox_device" "test0" {
   role_id = netbox_device_role.test.id
   device_type_id = netbox_device_type.test.id
   site_id = netbox_site.test.id
+  platform_id = netbox_platform.test.id
   location_id = netbox_location.test.id
   serial = "ABCDEF0"
 }
@@ -96,6 +98,7 @@ resource "netbox_device" "test1" {
   role_id = netbox_device_role.test.id
   device_type_id = netbox_device_type.test.id
   site_id = netbox_site.test.id
+  platform_id = netbox_platform.test.id
   location_id = netbox_location.test.id
   serial = "ABCDEF1"
 }
@@ -107,6 +110,7 @@ resource "netbox_device" "test2" {
   role_id = netbox_device_role.test.id
   device_type_id = netbox_device_type.test.id
   site_id = netbox_site.test.id
+  platform_id = netbox_platform.test.id
   location_id = netbox_location.test.id
   serial = "ABCDEF2"
 }
@@ -118,6 +122,7 @@ resource "netbox_device" "test3" {
   role_id = netbox_device_role.test.id
   device_type_id = netbox_device_type.test.id
   site_id = netbox_site.test.id
+  platform_id = netbox_platform.test.id
   location_id = netbox_location.test.id
   serial = "ABCDEF3"
 }

--- a/netbox/provider_test.go
+++ b/netbox/provider_test.go
@@ -83,7 +83,7 @@ func TestAccNetboxProviderConfigure_failure(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testProviderConfig(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
-				ExpectError: regexp.MustCompile("Post \"https://fake.netbox.server/api/dcim/platforms/\": dial tcp: lookup fake.netbox.server: no such host"),
+				ExpectError: regexp.MustCompile("Post \"https://fake.netbox.server/api/dcim/platforms/\": dial tcp: lookup fake.netbox.server.*: no such host"),
 			},
 		},
 	})


### PR DESCRIPTION
TestAccNetboxProviderConfigure_failure was itself failing as the output can return 
```
tcp: lookup fake.netbox.server on X.X.X.X: no such host
```
in some setups, where X.X.X.X is your DNS server