### PR TITLE
Add description field to tenant resource and data source.

### DIFF
--- a/docs/data-sources/tenant.md
+++ b/docs/data-sources/tenant.md
@@ -23,6 +23,7 @@ data "netbox_tenant" "customer_a" {
 
 ### Optional
 
+- `description` (String)
 - `name` (String) At least one of `name` or `slug` must be given.
 - `slug` (String) At least one of `name` or `slug` must be given.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,12 +55,12 @@ provider "netbox" {
 
 ### Required
 
+- `api_token` (String) Netbox API authentication token. Can be set via the `NETBOX_API_TOKEN` environment variable.
 - `server_url` (String) Location of Netbox server including scheme (http or https) and optional port, but without trailing slash. Can be set via the `NETBOX_SERVER_URL` environment variable.
 
 ### Optional
 
 - `allow_insecure_https` (Boolean) Flag to set whether to allow https with invalid certificates. Can be set via the `NETBOX_ALLOW_INSECURE_HTTPS` environment variable.
-- `api_token` (String) Netbox API authentication token. Can be set via the `NETBOX_API_TOKEN` environment variable.
 - `headers` (Map of String) Set these header on all requests to Netbox. Can be set via the `NETBOX_HEADERS` environment variable.
 - `request_timeout` (Number) Netbox API HTTP request timeout in seconds. Can be set via the `NETBOX_REQUEST_TIMEOUT` environment variable.
 - `skip_version_check` (Boolean) If true, do not try to determine the running Netbox version at provider startup. Disables warnings about possibly unsupported Netbox version. Also useful for local testing on terraform plans. Can be set via the `NETBOX_SKIP_VERSION_CHECK` environment variable.

--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -33,6 +33,7 @@ resource "netbox_tenant" "customer_a" {
 
 ### Optional
 
+- `description` (String)
 - `group_id` (Number)
 - `slug` (String)
 - `tags` (Set of String)

--- a/netbox/data_source_netbox_tenant.go
+++ b/netbox/data_source_netbox_tenant.go
@@ -30,6 +30,10 @@ func dataSourceNetboxTenant() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"description": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+			},
 		},
 	}
 }
@@ -64,6 +68,7 @@ func dataSourceNetboxTenantRead(d *schema.ResourceData, m interface{}) error {
 	d.SetId(strconv.FormatInt(result.ID, 10))
 	d.Set("name", result.Name)
 	d.Set("slug", result.Slug)
+	d.Set("description", result.Description)
 	if result.Group != nil {
 		d.Set("group_id", result.Group.ID)
 	}

--- a/netbox/data_source_netbox_tenant_test.go
+++ b/netbox/data_source_netbox_tenant_test.go
@@ -30,15 +30,23 @@ data "netbox_tenant" "by_slug" {
   slug = "%[1]s"
 }
 
+data "netbox_tenant" "by_description" {
+  depends_on = [netbox_tenant.test]
+  name = "%[1]s"
+  description = "%[1]s"
+}
+
 data "netbox_tenant" "by_both" {
   depends_on = [netbox_tenant.test]
   name = "%[1]s"
   slug = "%[1]s"
+  description = "%[1]s"
 }
 `, testName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("data.netbox_tenant.by_name", "id", "netbox_tenant.test", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_tenant.by_slug", "id", "netbox_tenant.test", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_tenant.by_description", "id", "netbox_tenant.test", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_tenant.by_both", "id", "netbox_tenant.test", "id"),
 				),
 			},

--- a/netbox/resource_netbox_tenant.go
+++ b/netbox/resource_netbox_tenant.go
@@ -39,6 +39,10 @@ func resourceNetboxTenant() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -51,6 +55,8 @@ func resourceNetboxTenantCreate(d *schema.ResourceData, m interface{}) error {
 
 	name := d.Get("name").(string)
 	group_id := int64(d.Get("group_id").(int))
+	description := d.Get("description").(string)
+
 	slugValue, slugOk := d.GetOk("slug")
 	var slug string
 	// Default slug to name attribute if not given
@@ -66,6 +72,7 @@ func resourceNetboxTenantCreate(d *schema.ResourceData, m interface{}) error {
 
 	data.Name = &name
 	data.Slug = &slug
+	data.Description = description
 	data.Tags = tags
 
 	if group_id != 0 {
@@ -102,6 +109,7 @@ func resourceNetboxTenantRead(d *schema.ResourceData, m interface{}) error {
 
 	d.Set("name", res.GetPayload().Name)
 	d.Set("slug", res.GetPayload().Slug)
+	d.Set("description", res.GetPayload().Description)
 	if res.GetPayload().Group != nil {
 		d.Set("group_id", res.GetPayload().Group.ID)
 	}
@@ -116,6 +124,7 @@ func resourceNetboxTenantUpdate(d *schema.ResourceData, m interface{}) error {
 	data := models.WritableTenant{}
 
 	name := d.Get("name").(string)
+	description := d.Get("description").(string)
 	group_id := int64(d.Get("group_id").(int))
 	slugValue, slugOk := d.GetOk("slug")
 	var slug string
@@ -130,6 +139,7 @@ func resourceNetboxTenantUpdate(d *schema.ResourceData, m interface{}) error {
 
 	data.Slug = &slug
 	data.Name = &name
+	data.Description = description
 	data.Tags = tags
 	if group_id != 0 {
 		data.Group = &group_id

--- a/netbox/resource_netbox_tenant_test.go
+++ b/netbox/resource_netbox_tenant_test.go
@@ -27,6 +27,7 @@ func TestAccNetboxTenant_basic(t *testing.T) {
 
 	testSlug := "tenant_basic"
 	testName := testAccGetTestName(testSlug)
+	testDescription := testAccGetTestName(testSlug)
 	randomSlug := testAccGetTestName(testSlug)
 	resource.ParallelTest(t, resource.TestCase{
 		Providers: testAccProviders,
@@ -37,10 +38,12 @@ func TestAccNetboxTenant_basic(t *testing.T) {
 resource "netbox_tenant" "test" {
   name = "%s"
   slug = "%s"
-}`, testName, randomSlug),
+  description = "%s"
+}`, testName, randomSlug, testDescription),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_tenant.test", "name", testName),
 					resource.TestCheckResourceAttr("netbox_tenant.test", "slug", randomSlug),
+					resource.TestCheckResourceAttr("netbox_tenant.test", "description", testDescription),
 				),
 			},
 			{


### PR DESCRIPTION
Adds a new description field (optional) to resource "netbox_tenant".

Follows similar logic to the existing "netbox_tenant_group" resource.