### PR TITLE
fix: Region data-source fix slug field reference

### DIFF
--- a/netbox/data_source_netbox_region.go
+++ b/netbox/data_source_netbox_region.go
@@ -103,7 +103,7 @@ func dataSourceNetboxRegionRead(d *schema.ResourceData, m interface{}) error {
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))
 	d.Set("name", result.Name)
-	d.Set("slug", result.Name)
+	d.Set("slug", result.Slug)
 	d.Set("description", result.Description)
 	if result.Parent != nil {
 		d.Set("parent_region_id", result.Parent.ID)


### PR DESCRIPTION
Fixes #301 
I think the slug should also reference the slug instead of the name.
I checked the region model in the source [go module](https://github.com/fbreckle/go-netbox/blob/master/netbox/models/region.go#L85) the field should be called `Slug`