### PR TITLE
:sparkles: Allow empty site description

### DIFF
--- a/netbox/resource_netbox_site.go
+++ b/netbox/resource_netbox_site.go
@@ -246,6 +246,9 @@ func resourceNetboxSiteUpdate(d *schema.ResourceData, m interface{}) error {
 
 	if description, ok := d.GetOk("description"); ok {
 		data.Description = description.(string)
+	} else if d.HasChange("description") {
+		// If GetOK returned unset description and its value changed, set it as a space string to delete it ...
+		data.Description = " "
 	}
 
 	if facility, ok := d.GetOk("facility"); ok {

--- a/netbox/resource_netbox_site_test.go
+++ b/netbox/resource_netbox_site_test.go
@@ -132,6 +132,36 @@ resource "netbox_site" "test" {
 	})
 }
 
+func TestAccNetboxSite_fieldUpdate(t *testing.T) {
+	testSlug := "site_field_update"
+	testName := testAccGetTestName(testSlug)
+	testField := strings.ReplaceAll(testAccGetTestName(testSlug), "-", "_")
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_site" "test" {
+	name        = "%[2]s"
+	description = "Test site description"
+}`, testField, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_site.test", "description", "Test site description"),
+				)},
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_site" "test" {
+	name = "%[2]s"
+}`, testField, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_site.test", "description", ""),
+				),
+			},
+		},
+	})
+}
+
 func init() {
 	resource.AddTestSweepers("netbox_site", &resource.Sweeper{
 		Name:         "netbox_site",


### PR DESCRIPTION
Currently, site that has been previously configured with a description can no longer be cleared out. Even if the terraform configuration indicates empty or nil description, the change will not be persisted to NSOT. Additionally, every time a terraform plan is run, it will always detect an update-in-place for this field.

This change fixes this behavior by setting site description's to space character. This is based on the pattern on other existing resource such as network device.

References:
- https://github.com/fbreckle/go-netbox/pull/25
- https://github.com/e-breuninger/terraform-provider-netbox/blob/master/netbox/resource_netbox_device.go#L331