### PR TITLE
:wrench: Adjust site slug max length

### DIFF
--- a/netbox/resource_netbox_site.go
+++ b/netbox/resource_netbox_site.go
@@ -32,7 +32,7 @@ func resourceNetboxSite() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validation.StringLenBetween(0, 30),
+				ValidateFunc: validation.StringLenBetween(0, 100),
 			},
 			"status": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
In line with Netbox's site slug max limit of 100, adjust the site resource slug max limit from 30 to 100.

Reference:
- https://github.com/netbox-community/netbox/blob/develop/netbox/dcim/models/sites.py#L149