### PR TITLE
Adding vrf_id to interface

### DIFF
--- a/netbox/resource_netbox_interface.go
+++ b/netbox/resource_netbox_interface.go
@@ -58,6 +58,10 @@ func resourceNetboxInterface() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.IntBetween(1, 65536),
 			},
+			"vrf_id": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+			},
 			"type": {
 				Type:       schema.TypeString,
 				Optional:   true,
@@ -164,6 +168,11 @@ func resourceNetboxInterfaceRead(ctx context.Context, d *schema.ResourceData, m 
 	if iface.UntaggedVlan != nil {
 		d.Set("untagged_vlan", iface.UntaggedVlan.ID)
 	}
+	if res.GetPayload().Vrf != nil {
+		d.Set("vrf_id", res.GetPayload().Vrf.ID)
+	} else {
+		d.Set("vrf_id", nil)
+	}
 
 	return diags
 }
@@ -207,6 +216,9 @@ func resourceNetboxInterfaceUpdate(ctx context.Context, d *schema.ResourceData, 
 	if d.HasChange("untagged_vlan") {
 		untaggedvlan := int64(d.Get("untagged_vlan").(int))
 		data.UntaggedVlan = &untaggedvlan
+	}
+	if vrfID, ok := d.GetOk("vrf_id"); ok {
+		data.Vrf = int64ToPtr(int64(vrfID.(int)))
 	}
 
 	params := virtualization.NewVirtualizationInterfacesPartialUpdateParams().WithID(id).WithData(&data)

--- a/netbox/resource_netbox_interface_test.go
+++ b/netbox/resource_netbox_interface_test.go
@@ -53,6 +53,10 @@ resource "netbox_interface" "test" {
   name = "%s"
   virtual_machine_id = netbox_virtual_machine.test.id
   tags = ["%[1]s"]
+}
+
+resource "netbox_vrf" "test" {
+  name = "%[1]s"
 }`, testName)
 }
 
@@ -109,6 +113,7 @@ func TestAccNetboxInterface_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair("netbox_interface.test", "virtual_machine_id", "netbox_virtual_machine.test", "id"),
 					resource.TestCheckResourceAttr("netbox_interface.test", "tags.#", "1"),
 					resource.TestCheckResourceAttr("netbox_interface.test", "tags.0", testName),
+					resource.TestCheckResourceAttr("netbox_interface.test", "vrf_id", "0"),
 				),
 			},
 			{


### PR DESCRIPTION
We are running v3.3.10 and I noticed that I cannot set the VRF_ID on the virtualization/interface endpoint via the Terraform provider.