### PR TITLE
MAC Addresses are not always a fixed entity

### DIFF
--- a/netbox/resource_netbox_interface.go
+++ b/netbox/resource_netbox_interface.go
@@ -46,7 +46,6 @@ func resourceNetboxInterface() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.IsMACAddress,
-				ForceNew:     true,
 			},
 			"mode": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
Forcing the replacement of the entire interface if the mac address changes causes weird issues with AWS. Sometimes the underlying mac address will change. When we force the replacement of this interface everything that uses this interface is getting replaced and it's causing data inconsistency.