### PR TITLE
:sparkles: Add support for device ip addresses

### DIFF
--- a/docs/data-sources/devices.md
+++ b/docs/data-sources/devices.md
@@ -43,6 +43,7 @@ Read-Only:
 - `asset_tag` (String)
 - `cluster_id` (Number)
 - `comments` (String)
+- `custom_fields` (Map of String)
 - `device_id` (Number)
 - `device_type_id` (Number)
 - `location_id` (Number)

--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -56,6 +56,7 @@ resource "netbox_device" "test" {
 
 - `cluster_id` (Number)
 - `comments` (String)
+- `custom_fields` (Map of String)
 - `location_id` (Number)
 - `platform_id` (Number)
 - `serial` (String)

--- a/docs/resources/ip_address.md
+++ b/docs/resources/ip_address.md
@@ -54,6 +54,7 @@ resource "netbox_ip_address" "myvm_ip" {
 - `description` (String)
 - `dns_name` (String)
 - `interface_id` (Number)
+- `object_type` (String) Defaults to `virtualization.vminterface`.
 - `role` (String)
 - `tags` (Set of String)
 - `tenant_id` (Number)

--- a/docs/resources/site.md
+++ b/docs/resources/site.md
@@ -46,7 +46,9 @@ resource "netbox_site" "example1" {
 - `group_id` (Number)
 - `latitude` (Number)
 - `longitude` (Number)
+- `physical_address` (String)
 - `region_id` (Number)
+- `shipping_address` (String)
 - `slug` (String)
 - `status` (String) Defaults to `active`.
 - `tags` (Set of String)

--- a/netbox/resource_netbox_ip_address.go
+++ b/netbox/resource_netbox_ip_address.go
@@ -50,6 +50,12 @@ func resourceNetboxIPAddress() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"object_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "virtualization.vminterface",
+				ValidateFunc: validation.StringInSlice([]string{"virtualization.vminterface", "dcim.interface"}, false),
+			},
 			tagsKey: tagsSchema,
 			"description": {
 				Type:     schema.TypeString,
@@ -114,8 +120,10 @@ func resourceNetboxIPAddressRead(d *schema.ResourceData, m interface{}) error {
 
 	if res.GetPayload().AssignedObjectID != nil {
 		d.Set("interface_id", res.GetPayload().AssignedObjectID)
+		d.Set("object_type", res.GetPayload().AssignedObjectType)
 	} else {
 		d.Set("interface_id", nil)
+		d.Set("object_type", nil)
 	}
 
 	if res.GetPayload().Vrf != nil {
@@ -156,6 +164,7 @@ func resourceNetboxIPAddressUpdate(d *schema.ResourceData, m interface{}) error 
 
 	ipAddress := d.Get("ip_address").(string)
 	status := d.Get("status").(string)
+	objectType := d.Get("object_type").(string)
 
 	descriptionValue, ok := d.GetOk("description")
 	if ok {
@@ -179,8 +188,7 @@ func resourceNetboxIPAddressUpdate(d *schema.ResourceData, m interface{}) error 
 	}
 
 	if interfaceID, ok := d.GetOk("interface_id"); ok {
-		// The other possible type is dcim.interface for devices
-		data.AssignedObjectType = strToPtr("virtualization.vminterface")
+		data.AssignedObjectType = strToPtr(objectType)
 		data.AssignedObjectID = int64ToPtr(int64(interfaceID.(int)))
 	}
 


### PR DESCRIPTION
Adds a new field object_type to the device ip address resource that allows to select device or virtualmachine as device type to support ip address configuration for devices.