### PR TITLE
Support tag and status filters for netbox_prefixes data source

### DIFF
--- a/docs/data-sources/prefixes.md
+++ b/docs/data-sources/prefixes.md
@@ -42,6 +42,7 @@ Read-Only:
 - `id` (Number)
 - `prefix` (String)
 - `status` (String)
+- `tags` (Set of String)
 - `vlan_id` (Number)
 - `vlan_vid` (Number)
 - `vrf_id` (Number)

--- a/netbox/data_source_netbox_prefixes.go
+++ b/netbox/data_source_netbox_prefixes.go
@@ -1,7 +1,6 @@
 package netbox
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/fbreckle/go-netbox/netbox/client"
@@ -67,6 +66,7 @@ func dataSourceNetboxPrefixes() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"tags": tagsSchemaRead,
 					},
 				},
 			},
@@ -98,6 +98,10 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 				params.VrfID = &vString
 			case "vlan_id":
 				params.VlanID = &vString
+			case "status":
+				params.Status = &vString
+			case "tag":
+				params.Tag = &vString
 			default:
 				return fmt.Errorf("'%s' is not a supported filter parameter", k)
 			}
@@ -109,9 +113,9 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
-	}
+	// if *res.GetPayload().Count == int64(0) {
+	// 	return errors.New("no result")
+	// }
 
 	filteredPrefixes := res.GetPayload().Results
 
@@ -129,6 +133,7 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 			mapping["vrf_id"] = v.Vrf.ID
 		}
 		mapping["status"] = v.Status.Value
+		mapping["tags"] = getTagListFromNestedTagList(v.Tags)
 
 		s = append(s, mapping)
 	}

--- a/netbox/data_source_netbox_prefixes.go
+++ b/netbox/data_source_netbox_prefixes.go
@@ -113,10 +113,6 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	// if *res.GetPayload().Count == int64(0) {
-	// 	return errors.New("no result")
-	// }
-
 	filteredPrefixes := res.GetPayload().Results
 
 	var s []map[string]interface{}


### PR DESCRIPTION
This PR adds support for using `tag` and `status` values as filters for the existing `netbox_prefixes` data source.

This PR also suggests removing the requirement that the data source must return at least 1 prefix as a result, and instead allows it to support returning 0 results:
```go
	if *res.GetPayload().Count == int64(0) {
		return errors.New("no result")
	}
```

There seems to be some inconsistency across the data sources in regards to this behavior - some data sources support returning 0 results, and others don't.

I'll defer to the maintainers on whether or not we can remove the above check, but IMO, the provider should not error out of a plan just because a particular data source might return 0 results (especially since the Netbox API itself support this).

If a user has a requirement that a data source must return results, then IMO they should implement logic locally to account for that rather than having the provider force the behavior.