### PR TITLE
Catch 404 out-of-band removal destroy

### DIFF
--- a/netbox/resource_netbox_aggregate.go
+++ b/netbox/resource_netbox_aggregate.go
@@ -148,6 +148,11 @@ func resourceNetboxAggregateDelete(d *schema.ResourceData, m interface{}) error 
 	params := ipam.NewIpamAggregatesDeleteParams().WithID(id)
 	_, err := api.Ipam.IpamAggregatesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*ipam.IpamAggregatesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	d.SetId("")

--- a/netbox/resource_netbox_asn.go
+++ b/netbox/resource_netbox_asn.go
@@ -120,6 +120,11 @@ func resourceNetboxAsnDelete(d *schema.ResourceData, m interface{}) error {
 
 	_, err := api.Ipam.IpamAsnsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*ipam.IpamAsnsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_available_ip_address.go
+++ b/netbox/resource_netbox_available_ip_address.go
@@ -217,6 +217,11 @@ func resourceNetboxAvailableIPAddressDelete(d *schema.ResourceData, m interface{
 
 	_, err := api.Ipam.IpamIPAddressesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*ipam.IpamIPAddressesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_circuit.go
+++ b/netbox/resource_netbox_circuit.go
@@ -178,6 +178,11 @@ func resourceNetboxCircuitDelete(d *schema.ResourceData, m interface{}) error {
 
 	_, err := api.Circuits.CircuitsCircuitsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*circuits.CircuitsCircuitsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_circuit_termination.go
+++ b/netbox/resource_netbox_circuit_termination.go
@@ -210,6 +210,11 @@ func resourceNetboxCircuitTerminationDelete(d *schema.ResourceData, m interface{
 
 	_, err := api.Circuits.CircuitsCircuitTerminationsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*circuits.CircuitsCircuitTerminationsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_circuit_type.go
+++ b/netbox/resource_netbox_circuit_type.go
@@ -129,6 +129,11 @@ func resourceNetboxCircuitTypeDelete(d *schema.ResourceData, m interface{}) erro
 
 	_, err := api.Circuits.CircuitsCircuitTypesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*circuits.CircuitsCircuitTypesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_cluster.go
+++ b/netbox/resource_netbox_cluster.go
@@ -182,6 +182,11 @@ func resourceNetboxClusterDelete(d *schema.ResourceData, m interface{}) error {
 
 	_, err := api.Virtualization.VirtualizationClustersDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*virtualization.VirtualizationClustersDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_cluster_group.go
+++ b/netbox/resource_netbox_cluster_group.go
@@ -149,6 +149,11 @@ func resourceNetboxClusterGroupDelete(d *schema.ResourceData, m interface{}) err
 
 	_, err := api.Virtualization.VirtualizationClusterGroupsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*virtualization.VirtualizationClusterGroupsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_cluster_type.go
+++ b/netbox/resource_netbox_cluster_type.go
@@ -130,6 +130,11 @@ func resourceNetboxClusterTypeDelete(d *schema.ResourceData, m interface{}) erro
 
 	_, err := api.Virtualization.VirtualizationClusterTypesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*virtualization.VirtualizationClusterTypesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_contact.go
+++ b/netbox/resource_netbox_contact.go
@@ -146,6 +146,11 @@ func resourceNetboxContactDelete(d *schema.ResourceData, m interface{}) error {
 
 	_, err := api.Tenancy.TenancyContactsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*tenancy.TenancyContactsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_contact_assignment.go
+++ b/netbox/resource_netbox_contact_assignment.go
@@ -142,6 +142,11 @@ func resourceNetboxContactAssignmentDelete(d *schema.ResourceData, m interface{}
 
 	_, err := api.Tenancy.TenancyContactAssignmentsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*tenancy.TenancyContactAssignmentsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_contact_role.go
+++ b/netbox/resource_netbox_contact_role.go
@@ -129,6 +129,11 @@ func resourceNetboxContactRoleDelete(d *schema.ResourceData, m interface{}) erro
 
 	_, err := api.Tenancy.TenancyContactRolesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*tenancy.TenancyContactRolesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_custom_field.go
+++ b/netbox/resource_netbox_custom_field.go
@@ -260,5 +260,10 @@ func resourceNetboxCustomFieldDelete(d *schema.ResourceData, m interface{}) erro
 	id, _ := strconv.ParseInt(d.Id(), 10, 64)
 	params := extras.NewExtrasCustomFieldsDeleteParams().WithID(id)
 	_, err := api.Extras.ExtrasCustomFieldsDelete(params, nil)
-	return err
+if err != nil {
+errorcode := err.(*extras.ExtrasCustomFieldsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")		
+return nil
+		}
 }

--- a/netbox/resource_netbox_device.go
+++ b/netbox/resource_netbox_device.go
@@ -427,6 +427,11 @@ func resourceNetboxDeviceDelete(ctx context.Context, d *schema.ResourceData, m i
 
 	_, err := api.Dcim.DcimDevicesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*dcim.DcimDevicesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 	return diags

--- a/netbox/resource_netbox_device_interface.go
+++ b/netbox/resource_netbox_device_interface.go
@@ -244,6 +244,11 @@ func resourceNetboxDeviceInterfaceDelete(ctx context.Context, d *schema.Resource
 
 	_, err := api.Dcim.DcimInterfacesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*dcim.DcimInterfacesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 	return nil

--- a/netbox/resource_netbox_device_role.go
+++ b/netbox/resource_netbox_device_role.go
@@ -157,6 +157,11 @@ func resourceNetboxDeviceRoleDelete(d *schema.ResourceData, m interface{}) error
 
 	_, err := api.Dcim.DcimDeviceRolesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*dcim.DcimDeviceRolesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_device_type.go
+++ b/netbox/resource_netbox_device_type.go
@@ -174,6 +174,11 @@ func resourceNetboxDeviceTypeDelete(d *schema.ResourceData, m interface{}) error
 
 	_, err := api.Dcim.DcimDeviceTypesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*dcim.DcimDeviceTypesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_interface.go
+++ b/netbox/resource_netbox_interface.go
@@ -225,6 +225,11 @@ func resourceNetboxInterfaceDelete(ctx context.Context, d *schema.ResourceData, 
 
 	_, err := api.Virtualization.VirtualizationInterfacesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*virtualization.VirtualizationInterfacesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 	return nil

--- a/netbox/resource_netbox_ip_address.go
+++ b/netbox/resource_netbox_ip_address.go
@@ -224,6 +224,11 @@ func resourceNetboxIPAddressDelete(d *schema.ResourceData, m interface{}) error 
 
 	_, err := api.Ipam.IpamIPAddressesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*ipam.IpamIPAddressesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_ip_range.go
+++ b/netbox/resource_netbox_ip_range.go
@@ -178,6 +178,11 @@ func resourceNetboxIpRangeDelete(d *schema.ResourceData, m interface{}) error {
 	params := ipam.NewIpamIPRangesDeleteParams().WithID(id)
 	_, err := api.Ipam.IpamIPRangesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*ipam.IpamIPRangesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/netbox/resource_netbox_ipam_role.go
+++ b/netbox/resource_netbox_ipam_role.go
@@ -153,6 +153,11 @@ func resourceNetboxIpamRoleDelete(d *schema.ResourceData, m interface{}) error {
 	params := ipam.NewIpamRolesDeleteParams().WithID(id)
 	_, err := api.Ipam.IpamRolesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*ipam.IpamRolesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	d.SetId("")

--- a/netbox/resource_netbox_location.go
+++ b/netbox/resource_netbox_location.go
@@ -200,6 +200,11 @@ func resourceNetboxLocationDelete(d *schema.ResourceData, m interface{}) error {
 
 	_, err := api.Dcim.DcimLocationsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*dcim.DcimLocationsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_manufacturer.go
+++ b/netbox/resource_netbox_manufacturer.go
@@ -129,6 +129,11 @@ func resourceNetboxManufacturerDelete(d *schema.ResourceData, m interface{}) err
 
 	_, err := api.Dcim.DcimManufacturersDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*dcim.DcimManufacturersDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_platform.go
+++ b/netbox/resource_netbox_platform.go
@@ -133,6 +133,11 @@ func resourceNetboxPlatformDelete(d *schema.ResourceData, m interface{}) error {
 
 	_, err := api.Dcim.DcimPlatformsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*dcim.DcimPlatformsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_prefix.go
+++ b/netbox/resource_netbox_prefix.go
@@ -238,6 +238,11 @@ func resourceNetboxPrefixDelete(d *schema.ResourceData, m interface{}) error {
 	params := ipam.NewIpamPrefixesDeleteParams().WithID(id)
 	_, err := api.Ipam.IpamPrefixesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*ipam.IpamPrefixesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	d.SetId("")

--- a/netbox/resource_netbox_rack.go
+++ b/netbox/resource_netbox_rack.go
@@ -381,6 +381,11 @@ func resourceNetboxRackDelete(d *schema.ResourceData, m interface{}) error {
 
 	_, err := api.Dcim.DcimRacksDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*dcim.DcimRacksDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_rack_reservation.go
+++ b/netbox/resource_netbox_rack_reservation.go
@@ -163,6 +163,11 @@ func resourceNetboxRackReservationDelete(d *schema.ResourceData, m interface{}) 
 
 	_, err := api.Dcim.DcimRackReservationsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*dcim.DcimRackReservationsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_rack_role.go
+++ b/netbox/resource_netbox_rack_role.go
@@ -156,6 +156,11 @@ func resourceNetboxRackRoleDelete(d *schema.ResourceData, m interface{}) error {
 
 	_, err := api.Dcim.DcimRackRolesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*dcim.DcimRackRolesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_region.go
+++ b/netbox/resource_netbox_region.go
@@ -166,6 +166,11 @@ func resourceNetboxRegionDelete(d *schema.ResourceData, m interface{}) error {
 
 	_, err := api.Dcim.DcimRegionsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*dcim.DcimRegionsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_rir.go
+++ b/netbox/resource_netbox_rir.go
@@ -130,6 +130,11 @@ func resourceNetboxRirDelete(d *schema.ResourceData, m interface{}) error {
 	params := ipam.NewIpamRirsDeleteParams().WithID(id)
 	_, err := api.Ipam.IpamRirsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*ipam.IpamRirsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	d.SetId("")

--- a/netbox/resource_netbox_route_target.go
+++ b/netbox/resource_netbox_route_target.go
@@ -125,6 +125,11 @@ func resourceNetboxRouteTargetDelete(d *schema.ResourceData, m interface{}) erro
 	params := ipam.NewIpamRouteTargetsDeleteParams().WithID(id)
 	_, err := api.Ipam.IpamRouteTargetsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*ipam.IpamRouteTargetsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	d.SetId("")

--- a/netbox/resource_netbox_service.go
+++ b/netbox/resource_netbox_service.go
@@ -170,6 +170,11 @@ func resourceNetboxServiceDelete(d *schema.ResourceData, m interface{}) error {
 	params := ipam.NewIpamServicesDeleteParams().WithID(id)
 	_, err := api.Ipam.IpamServicesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*ipam.IpamServicesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_site.go
+++ b/netbox/resource_netbox_site.go
@@ -352,6 +352,11 @@ func resourceNetboxSiteDelete(d *schema.ResourceData, m interface{}) error {
 
 	_, err := api.Dcim.DcimSitesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*dcim.DcimSitesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_site_group.go
+++ b/netbox/resource_netbox_site_group.go
@@ -159,6 +159,11 @@ func resourceNetboxSiteGroupDelete(d *schema.ResourceData, m interface{}) error 
 
 	_, err := api.Dcim.DcimSiteGroupsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*dcim.DcimSiteGroupsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_tag.go
+++ b/netbox/resource_netbox_tag.go
@@ -152,6 +152,11 @@ func resourceNetboxTagDelete(d *schema.ResourceData, m interface{}) error {
 
 	_, err := api.Extras.ExtrasTagsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*extras.ExtrasTagsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_tenant.go
+++ b/netbox/resource_netbox_tenant.go
@@ -163,6 +163,11 @@ func resourceNetboxTenantDelete(d *schema.ResourceData, m interface{}) error {
 
 	_, err := api.Tenancy.TenancyTenantsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*tenancy.TenancyTenantsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_tenant_group.go
+++ b/netbox/resource_netbox_tenant_group.go
@@ -158,6 +158,11 @@ func resourceNetboxTenantGroupDelete(d *schema.ResourceData, m interface{}) erro
 
 	_, err := api.Tenancy.TenancyTenantGroupsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*tenancy.TenancyTenantGroupsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil

--- a/netbox/resource_netbox_token.go
+++ b/netbox/resource_netbox_token.go
@@ -151,6 +151,11 @@ func resourceNetboxTokenDelete(d *schema.ResourceData, m interface{}) error {
 	params := users.NewUsersTokensDeleteParams().WithID(id)
 	_, err := api.Users.UsersTokensDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*users.UsersTokensDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	d.SetId("")

--- a/netbox/resource_netbox_user.go
+++ b/netbox/resource_netbox_user.go
@@ -129,6 +129,11 @@ func resourceNetboxUserDelete(d *schema.ResourceData, m interface{}) error {
 	params := users.NewUsersUsersDeleteParams().WithID(id)
 	_, err := api.Users.UsersUsersDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*users.UsersUsersDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	d.SetId("")

--- a/netbox/resource_netbox_virtual_machine.go
+++ b/netbox/resource_netbox_virtual_machine.go
@@ -421,6 +421,11 @@ func resourceNetboxVirtualMachineDelete(ctx context.Context, d *schema.ResourceD
 
 	_, err := api.Virtualization.VirtualizationVirtualMachinesDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*virtualization.VirtualizationVirtualMachinesDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 	return diags

--- a/netbox/resource_netbox_vlan.go
+++ b/netbox/resource_netbox_vlan.go
@@ -182,6 +182,11 @@ func resourceNetboxVlanDelete(d *schema.ResourceData, m interface{}) error {
 	params := ipam.NewIpamVlansDeleteParams().WithID(id)
 	_, err := api.Ipam.IpamVlansDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*ipam.IpamVlansDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/netbox/resource_netbox_vrf.go
+++ b/netbox/resource_netbox_vrf.go
@@ -136,6 +136,11 @@ func resourceNetboxVrfDelete(d *schema.ResourceData, m interface{}) error {
 
 	_, err := api.Ipam.IpamVrfsDelete(params, nil)
 	if err != nil {
+		errorcode := err.(*ipam.IpamVrfsDeleteDefault).Code()
+		if errorcode == 404 {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 	return nil


### PR DESCRIPTION
Catches 404 not found when trying to destroy objects that were removed out of band.
This is recommended by terraform https://developer.hashicorp.com/terraform/tutorials/providers/provider-delete

```
In addition, the destroy callback should always handle the case where the resource might already be destroyed. If the resource is already destroyed, the destroy function should not return an error.
```