### PR TITLE
Fix crash with netbox_prefixs filtered by VLAN VID

### DIFF
--- a/netbox/data_source_netbox_prefixes.go
+++ b/netbox/data_source_netbox_prefixes.go
@@ -2,6 +2,7 @@ package netbox
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/fbreckle/go-netbox/netbox/client"
 	"github.com/fbreckle/go-netbox/netbox/client/ipam"
@@ -97,7 +98,11 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 			case "prefix":
 				params.Prefix = &vString
 			case "vlan_vid":
-				params.VlanVid = v.(*float64)
+				float, err := strconv.ParseFloat(vString, 64)
+				if err != nil {
+					return err
+				}
+				params.VlanVid = &float
 			case "vrf_id":
 				params.VrfID = &vString
 			case "vlan_id":

--- a/netbox/data_source_netbox_prefixes_test.go
+++ b/netbox/data_source_netbox_prefixes_test.go
@@ -69,6 +69,14 @@ data "netbox_prefixes" "by_vrf" {
   }
 }
 
+data "netbox_prefixes" "by_vid" {
+  depends_on = [netbox_prefix.test_prefix1, netbox_prefix.test_prefix2]
+  filter {
+    name  = "vlan_vid"
+    value = "%[5]d"
+  }
+}
+
 data "netbox_prefixes" "by_tag" {
   depends_on = [netbox_prefix.test_prefix1]
   filter {
@@ -96,6 +104,7 @@ data "netbox_prefixes" "find_prefix_without_vrf_and_vlan" {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_prefixes.by_vrf", "prefixes.#", "2"),
 					resource.TestCheckResourceAttrPair("data.netbox_prefixes.by_vrf", "prefixes.1.vlan_vid", "netbox_vlan.test_vlan2", "vid"),
+					resource.TestCheckResourceAttrPair("data.netbox_prefixes.by_vid", "prefixes.0.vlan_vid", "netbox_vlan.test_vlan1", "vid"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.by_tag", "prefixes.#", "1"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.by_tag", "prefixes.0.description", "my-description"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.no_results", "prefixes.#", "0"),


### PR DESCRIPTION
This fixes the issue documented in #365 

The problem was an incorrect attempt to get a float from a string. The fix was to add a string conversion to float.