### PR TITLE
Remove IP Prefix description if it is null

### DIFF
--- a/netbox/resource_netbox_prefix.go
+++ b/netbox/resource_netbox_prefix.go
@@ -191,16 +191,20 @@ func resourceNetboxPrefixUpdate(d *schema.ResourceData, m interface{}) error {
 	data := models.WritablePrefix{}
 	prefix := d.Get("prefix").(string)
 	status := d.Get("status").(string)
-	description := d.Get("description").(string)
 	is_pool := d.Get("is_pool").(bool)
 	mark_utilized := d.Get("mark_utilized").(bool)
 
 	data.Prefix = &prefix
 	data.Status = status
 
-	data.Description = description
 	data.IsPool = is_pool
 	data.MarkUtilized = mark_utilized
+
+	if description, ok := d.GetOk("description"); ok {
+		data.Description = description.(string)
+	} else {
+		data.Description = " "
+	}
 
 	if vrfID, ok := d.GetOk("vrf_id"); ok {
 		data.Vrf = int64ToPtr(int64(vrfID.(int)))

--- a/netbox/resource_netbox_prefix_test.go
+++ b/netbox/resource_netbox_prefix_test.go
@@ -216,6 +216,17 @@ resource "netbox_prefix" "test" {
 				),
 			},
 			{
+				Config: testAccNetboxPrefixFullDependencies(testName, randomSlug, testVid) + fmt.Sprintf(`
+resource "netbox_prefix" "test" {
+  prefix = "%s"
+  status = "active"
+}`, testPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_prefix.test", "prefix", testPrefix),
+					resource.TestCheckResourceAttr("netbox_prefix.test", "status", "active"),
+				),
+			},
+			{
 				ResourceName:      "netbox_prefix.test",
 				ImportState:       true,
 				ImportStateVerify: true,


### PR DESCRIPTION
This PR fixes an issue whereby removing the description of an IP Prefix had no effect when applied. 

This will set the description to a single space (`" "`) if the description is passed in as `null`. Setting the description to an empty string also does not appear to clear the description, so this uses the same pattern as in the IP Address resource type.