### PR TITLE
Fix unchecked type assertion in resources

### DIFF
--- a/netbox/resource_netbox_aggregate.go
+++ b/netbox/resource_netbox_aggregate.go
@@ -83,11 +83,13 @@ func resourceNetboxAggregateRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Ipam.IpamAggregatesRead(params, nil)
 	if err != nil {
-		errorcode := err.(*ipam.IpamAggregatesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*ipam.IpamAggregatesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_asn.go
+++ b/netbox/resource_netbox_asn.go
@@ -71,11 +71,13 @@ func resourceNetboxAsnRead(d *schema.ResourceData, m interface{}) error {
 	res, err := api.Ipam.IpamAsnsRead(params, nil)
 
 	if err != nil {
-		errorcode := err.(*ipam.IpamAsnsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*ipam.IpamAsnsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_available_ip_address.go
+++ b/netbox/resource_netbox_available_ip_address.go
@@ -120,11 +120,13 @@ func resourceNetboxAvailableIPAddressRead(d *schema.ResourceData, m interface{})
 
 	res, err := api.Ipam.IpamIPAddressesRead(params, nil)
 	if err != nil {
-		errorcode := err.(*ipam.IpamIPAddressesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*ipam.IpamIPAddressesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_circuit.go
+++ b/netbox/resource_netbox_circuit.go
@@ -99,11 +99,13 @@ func resourceNetboxCircuitRead(d *schema.ResourceData, m interface{}) error {
 	res, err := api.Circuits.CircuitsCircuitsRead(params, nil)
 
 	if err != nil {
-		errorcode := err.(*circuits.CircuitsCircuitsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*circuits.CircuitsCircuitsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_circuit_provider.go
+++ b/netbox/resource_netbox_circuit_provider.go
@@ -80,11 +80,13 @@ func resourceNetboxCircuitProviderRead(d *schema.ResourceData, m interface{}) er
 	res, err := api.Circuits.CircuitsProvidersRead(params, nil)
 
 	if err != nil {
-		errorcode := err.(*circuits.CircuitsProvidersReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*circuits.CircuitsProvidersReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_circuit_termination.go
+++ b/netbox/resource_netbox_circuit_termination.go
@@ -109,11 +109,13 @@ func resourceNetboxCircuitTerminationRead(d *schema.ResourceData, m interface{})
 	res, err := api.Circuits.CircuitsCircuitTerminationsRead(params, nil)
 
 	if err != nil {
-		errorcode := err.(*circuits.CircuitsCircuitTerminationsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*circuits.CircuitsCircuitTerminationsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_circuit_type.go
+++ b/netbox/resource_netbox_circuit_type.go
@@ -77,11 +77,13 @@ func resourceNetboxCircuitTypeRead(d *schema.ResourceData, m interface{}) error 
 	res, err := api.Circuits.CircuitsCircuitTypesRead(params, nil)
 
 	if err != nil {
-		errorcode := err.(*circuits.CircuitsCircuitTypesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*circuits.CircuitsCircuitTypesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_cluster.go
+++ b/netbox/resource_netbox_cluster.go
@@ -100,11 +100,13 @@ func resourceNetboxClusterRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Virtualization.VirtualizationClustersRead(params, nil)
 	if err != nil {
-		errorcode := err.(*virtualization.VirtualizationClustersReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*virtualization.VirtualizationClustersReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_cluster_group.go
+++ b/netbox/resource_netbox_cluster_group.go
@@ -86,11 +86,13 @@ func resourceNetboxClusterGroupRead(d *schema.ResourceData, m interface{}) error
 
 	res, err := api.Virtualization.VirtualizationClusterGroupsRead(params, nil)
 	if err != nil {
-		errorcode := err.(*virtualization.VirtualizationClusterGroupsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*virtualization.VirtualizationClusterGroupsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_cluster_type.go
+++ b/netbox/resource_netbox_cluster_type.go
@@ -77,11 +77,13 @@ func resourceNetboxClusterTypeRead(d *schema.ResourceData, m interface{}) error 
 
 	res, err := api.Virtualization.VirtualizationClusterTypesRead(params, nil)
 	if err != nil {
-		errorcode := err.(*virtualization.VirtualizationClusterTypesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*virtualization.VirtualizationClusterTypesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_contact.go
+++ b/netbox/resource_netbox_contact.go
@@ -88,11 +88,13 @@ func resourceNetboxContactRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Tenancy.TenancyContactsRead(params, nil)
 	if err != nil {
-		errorcode := err.(*tenancy.TenancyContactsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*tenancy.TenancyContactsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_contact_assignment.go
+++ b/netbox/resource_netbox_contact_assignment.go
@@ -78,11 +78,13 @@ func resourceNetboxContactAssignmentRead(d *schema.ResourceData, m interface{}) 
 
 	res, err := api.Tenancy.TenancyContactAssignmentsRead(params, nil)
 	if err != nil {
-		errorcode := err.(*tenancy.TenancyContactAssignmentsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*tenancy.TenancyContactAssignmentsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_contact_role.go
+++ b/netbox/resource_netbox_contact_role.go
@@ -77,11 +77,13 @@ func resourceNetboxContactRoleRead(d *schema.ResourceData, m interface{}) error 
 	res, err := api.Tenancy.TenancyContactRolesRead(params, nil)
 
 	if err != nil {
-		errorcode := err.(*tenancy.TenancyContactRolesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*tenancy.TenancyContactRolesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_custom_field.go
+++ b/netbox/resource_netbox_custom_field.go
@@ -227,7 +227,6 @@ func resourceNetboxCustomFieldRead(d *schema.ResourceData, m interface{}) error 
 		}
 		return err
 	}
-
 	d.Set("name", res.GetPayload().Name)
 	d.Set("type", *res.GetPayload().Type.Value)
 
@@ -261,9 +260,11 @@ func resourceNetboxCustomFieldDelete(d *schema.ResourceData, m interface{}) erro
 	params := extras.NewExtrasCustomFieldsDeleteParams().WithID(id)
 	_, err := api.Extras.ExtrasCustomFieldsDelete(params, nil)
 	if err != nil {
-		errorcode := err.(*extras.ExtrasCustomFieldsDeleteDefault).Code()
-		if errorcode == 404 {
-			d.SetId("")
+		if errresp, ok := err.(*extras.ExtrasCustomFieldsDeleteDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				d.SetId("")
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_device.go
+++ b/netbox/resource_netbox_device.go
@@ -201,11 +201,13 @@ func resourceNetboxDeviceRead(ctx context.Context, d *schema.ResourceData, m int
 
 	res, err := api.Dcim.DcimDevicesRead(params, nil)
 	if err != nil {
-		errorcode := err.(*dcim.DcimDevicesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*dcim.DcimDevicesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return diag.FromErr(err)
 	}

--- a/netbox/resource_netbox_device_interface.go
+++ b/netbox/resource_netbox_device_interface.go
@@ -148,11 +148,13 @@ func resourceNetboxDeviceInterfaceRead(ctx context.Context, d *schema.ResourceDa
 
 	res, err := api.Dcim.DcimInterfacesRead(params, nil)
 	if err != nil {
-		errorcode := err.(*dcim.DcimInterfacesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*dcim.DcimInterfacesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return diag.FromErr(err)
 	}

--- a/netbox/resource_netbox_device_interface_test.go
+++ b/netbox/resource_netbox_device_interface_test.go
@@ -232,9 +232,11 @@ func testAccCheckDeviceInterfaceDestroy(s *terraform.State) error {
 		}
 
 		if err != nil {
-			errorcode := err.(*dcim.DcimInterfacesReadDefault).Code()
-			if errorcode == 404 {
-				return nil
+			if errresp, ok := err.(*dcim.DcimInterfacesReadDefault); ok {
+				errorcode := errresp.Code()
+				if errorcode == 404 {
+					return nil
+				}
 			}
 			return err
 		}

--- a/netbox/resource_netbox_device_role.go
+++ b/netbox/resource_netbox_device_role.go
@@ -94,11 +94,13 @@ func resourceNetboxDeviceRoleRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Dcim.DcimDeviceRolesRead(params, nil)
 	if err != nil {
-		errorcode := err.(*dcim.DcimDeviceRolesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*dcim.DcimDeviceRolesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_device_test.go
+++ b/netbox/resource_netbox_device_test.go
@@ -226,9 +226,11 @@ func testAccCheckDeviceDestroy(s *terraform.State) error {
 		}
 
 		if err != nil {
-			errorcode := err.(*dcim.DcimDevicesReadDefault).Code()
-			if errorcode == 404 {
-				return nil
+			if errresp, ok := err.(*dcim.DcimDevicesReadDefault); ok {
+				errorcode := errresp.Code()
+				if errorcode == 404 {
+					return nil
+				}
 			}
 			return err
 		}

--- a/netbox/resource_netbox_device_type.go
+++ b/netbox/resource_netbox_device_type.go
@@ -104,11 +104,13 @@ func resourceNetboxDeviceTypeRead(d *schema.ResourceData, m interface{}) error {
 	res, err := api.Dcim.DcimDeviceTypesRead(params, nil)
 
 	if err != nil {
-		errorcode := err.(*dcim.DcimDeviceTypesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*dcim.DcimDeviceTypesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_interface.go
+++ b/netbox/resource_netbox_interface.go
@@ -137,11 +137,13 @@ func resourceNetboxInterfaceRead(ctx context.Context, d *schema.ResourceData, m 
 
 	res, err := api.Virtualization.VirtualizationInterfacesRead(params, nil)
 	if err != nil {
-		errorcode := err.(*virtualization.VirtualizationInterfacesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*virtualization.VirtualizationInterfacesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return diag.FromErr(err)
 	}

--- a/netbox/resource_netbox_interface_test.go
+++ b/netbox/resource_netbox_interface_test.go
@@ -211,9 +211,11 @@ func testAccCheckInterfaceDestroy(s *terraform.State) error {
 		}
 
 		if err != nil {
-			errorcode := err.(*virtualization.VirtualizationInterfacesReadDefault).Code()
-			if errorcode == 404 {
-				return nil
+			if errresp, ok := err.(*virtualization.VirtualizationInterfacesReadDefault); ok {
+				errorcode := errresp.Code()
+				if errorcode == 404 {
+					return nil
+				}
 			}
 			return err
 		}

--- a/netbox/resource_netbox_ip_address.go
+++ b/netbox/resource_netbox_ip_address.go
@@ -109,11 +109,13 @@ func resourceNetboxIPAddressRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Ipam.IpamIPAddressesRead(params, nil)
 	if err != nil {
-		errorcode := err.(*ipam.IpamIPAddressesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*ipam.IpamIPAddressesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_ip_range.go
+++ b/netbox/resource_netbox_ip_range.go
@@ -93,11 +93,13 @@ func resourceNetboxIpRangeRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Ipam.IpamIPRangesRead(params, nil)
 	if err != nil {
-		errorcode := err.(*ipam.IpamIPRangesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*ipam.IpamIPRangesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_ipam_role.go
+++ b/netbox/resource_netbox_ipam_role.go
@@ -87,11 +87,13 @@ func resourceNetboxIpamRoleRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Ipam.IpamRolesRead(params, nil)
 	if err != nil {
-		errorcode := err.(*ipam.IpamRolesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*ipam.IpamRolesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_location.go
+++ b/netbox/resource_netbox_location.go
@@ -110,11 +110,13 @@ func resourceNetboxLocationRead(d *schema.ResourceData, m interface{}) error {
 	res, err := api.Dcim.DcimLocationsRead(params, nil)
 
 	if err != nil {
-		errorcode := err.(*dcim.DcimLocationsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*dcim.DcimLocationsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_manufacturer.go
+++ b/netbox/resource_netbox_manufacturer.go
@@ -77,11 +77,13 @@ func resourceNetboxManufacturerRead(d *schema.ResourceData, m interface{}) error
 	res, err := api.Dcim.DcimManufacturersRead(params, nil)
 
 	if err != nil {
-		errorcode := err.(*dcim.DcimManufacturersReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*dcim.DcimManufacturersReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_platform.go
+++ b/netbox/resource_netbox_platform.go
@@ -80,11 +80,13 @@ func resourceNetboxPlatformRead(d *schema.ResourceData, m interface{}) error {
 	res, err := api.Dcim.DcimPlatformsRead(params, nil)
 
 	if err != nil {
-		errorcode := err.(*dcim.DcimPlatformsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*dcim.DcimPlatformsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_prefix.go
+++ b/netbox/resource_netbox_prefix.go
@@ -130,11 +130,13 @@ func resourceNetboxPrefixRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Ipam.IpamPrefixesRead(params, nil)
 	if err != nil {
-		errorcode := err.(*ipam.IpamPrefixesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*ipam.IpamPrefixesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_primary_ip.go
+++ b/netbox/resource_netbox_primary_ip.go
@@ -54,11 +54,13 @@ func resourceNetboxPrimaryIPRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Virtualization.VirtualizationVirtualMachinesRead(params, nil)
 	if err != nil {
-		errorcode := err.(*virtualization.VirtualizationVirtualMachinesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*virtualization.VirtualizationVirtualMachinesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_rack.go
+++ b/netbox/resource_netbox_rack.go
@@ -215,11 +215,13 @@ func resourceNetboxRackRead(d *schema.ResourceData, m interface{}) error {
 	res, err := api.Dcim.DcimRacksRead(params, nil)
 
 	if err != nil {
-		errorcode := err.(*dcim.DcimRacksReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*dcim.DcimRacksReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_rack_reservation.go
+++ b/netbox/resource_netbox_rack_reservation.go
@@ -91,11 +91,13 @@ func resourceNetboxRackReservationRead(d *schema.ResourceData, m interface{}) er
 
 	res, err := api.Dcim.DcimRackReservationsRead(params, nil)
 	if err != nil {
-		errorcode := err.(*dcim.DcimRackReservationsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*dcim.DcimRackReservationsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_rack_role.go
+++ b/netbox/resource_netbox_rack_role.go
@@ -92,11 +92,13 @@ func resourceNetboxRackRoleRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Dcim.DcimRackRolesRead(params, nil)
 	if err != nil {
-		errorcode := err.(*dcim.DcimRackRolesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*dcim.DcimRackRolesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_rack_test.go
+++ b/netbox/resource_netbox_rack_test.go
@@ -173,9 +173,11 @@ func testAccCheckRackDestroy(s *terraform.State) error {
 		}
 
 		if err != nil {
-			errorcode := err.(*dcim.DcimRacksReadDefault).Code()
-			if errorcode == 404 {
-				return nil
+			if errresp, ok := err.(*dcim.DcimRacksReadDefault); ok {
+				errorcode := errresp.Code()
+				if errorcode == 404 {
+					return nil
+				}
 			}
 			return err
 		}

--- a/netbox/resource_netbox_region.go
+++ b/netbox/resource_netbox_region.go
@@ -100,11 +100,13 @@ func resourceNetboxRegionRead(d *schema.ResourceData, m interface{}) error {
 	res, err := api.Dcim.DcimRegionsRead(params, nil)
 
 	if err != nil {
-		errorcode := err.(*dcim.DcimRegionsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*dcim.DcimRegionsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_rir.go
+++ b/netbox/resource_netbox_rir.go
@@ -78,11 +78,13 @@ func resourceNetboxRirRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Ipam.IpamRirsRead(params, nil)
 	if err != nil {
-		errorcode := err.(*ipam.IpamRirsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*ipam.IpamRirsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_route_target.go
+++ b/netbox/resource_netbox_route_target.go
@@ -69,11 +69,13 @@ func resourceNetboxRouteTargetRead(d *schema.ResourceData, m interface{}) error 
 
 	res, err := api.Ipam.IpamRouteTargetsRead(params, nil)
 	if err != nil {
-		errorcode := err.(*ipam.IpamRouteTargetsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*ipam.IpamRouteTargetsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_service.go
+++ b/netbox/resource_netbox_service.go
@@ -108,11 +108,13 @@ func resourceNetboxServiceRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Ipam.IpamServicesRead(params, nil)
 	if err != nil {
-		errorcode := err.(*ipam.IpamServicesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*ipam.IpamServicesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_service_test.go
+++ b/netbox/resource_netbox_service_test.go
@@ -87,9 +87,11 @@ func testAccCheckServiceDestroy(s *terraform.State) error {
 		}
 
 		if err != nil {
-			errorcode := err.(*ipam.IpamServicesReadDefault).Code()
-			if errorcode == 404 {
-				return nil
+			if errresp, ok := err.(*ipam.IpamServicesReadDefault); ok {
+				errorcode := errresp.Code()
+				if errorcode == 404 {
+					return nil
+				}
 			}
 			return err
 		}

--- a/netbox/resource_netbox_site.go
+++ b/netbox/resource_netbox_site.go
@@ -197,11 +197,13 @@ func resourceNetboxSiteRead(d *schema.ResourceData, m interface{}) error {
 	res, err := api.Dcim.DcimSitesRead(params, nil)
 
 	if err != nil {
-		errorcode := err.(*dcim.DcimSitesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*dcim.DcimSitesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_site_group.go
+++ b/netbox/resource_netbox_site_group.go
@@ -95,11 +95,13 @@ func resourceNetboxSiteGroupRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Dcim.DcimSiteGroupsRead(params, nil)
 	if err != nil {
-		errorcode := err.(*dcim.DcimSiteGroupsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*dcim.DcimSiteGroupsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_tag.go
+++ b/netbox/resource_netbox_tag.go
@@ -94,11 +94,13 @@ func resourceNetboxTagRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Extras.ExtrasTagsRead(params, nil)
 	if err != nil {
-		errorcode := err.(*extras.ExtrasTagsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*extras.ExtrasTagsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_tenant.go
+++ b/netbox/resource_netbox_tenant.go
@@ -98,11 +98,13 @@ func resourceNetboxTenantRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Tenancy.TenancyTenantsRead(params, nil)
 	if err != nil {
-		errorcode := err.(*tenancy.TenancyTenantsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*tenancy.TenancyTenantsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_tenant_group.go
+++ b/netbox/resource_netbox_tenant_group.go
@@ -95,11 +95,13 @@ func resourceNetboxTenantGroupRead(d *schema.ResourceData, m interface{}) error 
 
 	res, err := api.Tenancy.TenancyTenantGroupsRead(params, nil)
 	if err != nil {
-		errorcode := err.(*tenancy.TenancyTenantGroupsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*tenancy.TenancyTenantGroupsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_token.go
+++ b/netbox/resource_netbox_token.go
@@ -95,11 +95,13 @@ func resourceNetboxTokenRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Users.UsersTokensRead(params, nil)
 	if err != nil {
-		errorcode := err.(*users.UsersTokensReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*users.UsersTokensReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_user.go
+++ b/netbox/resource_netbox_user.go
@@ -77,11 +77,13 @@ func resourceNetboxUserRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Users.UsersUsersRead(params, nil)
 	if err != nil {
-		errorcode := err.(*users.UsersUsersReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*users.UsersUsersReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_virtual_machine.go
+++ b/netbox/resource_netbox_virtual_machine.go
@@ -200,11 +200,13 @@ func resourceNetboxVirtualMachineRead(ctx context.Context, d *schema.ResourceDat
 
 	res, err := api.Virtualization.VirtualizationVirtualMachinesRead(params, nil)
 	if err != nil {
-		errorcode := err.(*virtualization.VirtualizationVirtualMachinesReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*virtualization.VirtualizationVirtualMachinesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return diag.FromErr(err)
 	}

--- a/netbox/resource_netbox_virtual_machine_test.go
+++ b/netbox/resource_netbox_virtual_machine_test.go
@@ -341,9 +341,11 @@ func testAccCheckVirtualMachineDestroy(s *terraform.State) error {
 		}
 
 		if err != nil {
-			errorcode := err.(*virtualization.VirtualizationVirtualMachinesReadDefault).Code()
-			if errorcode == 404 {
-				return nil
+			if errresp, ok := err.(*virtualization.VirtualizationVirtualMachinesReadDefault); ok {
+				errorcode := errresp.Code()
+				if errorcode == 404 {
+					return nil
+				}
 			}
 			return err
 		}

--- a/netbox/resource_netbox_vlan.go
+++ b/netbox/resource_netbox_vlan.go
@@ -116,11 +116,13 @@ func resourceNetboxVlanRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Ipam.IpamVlansRead(params, nil)
 	if err != nil {
-		errorcode := err.(*ipam.IpamVlansReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*ipam.IpamVlansReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_vlan_group.go
+++ b/netbox/resource_netbox_vlan_group.go
@@ -106,11 +106,13 @@ func resourceNetboxVlanGroupRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Ipam.IpamVlanGroupsRead(params, nil)
 	if err != nil {
-		errorcode := err.(*ipam.IpamVlanGroupsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*ipam.IpamVlanGroupsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}

--- a/netbox/resource_netbox_vrf.go
+++ b/netbox/resource_netbox_vrf.go
@@ -79,11 +79,13 @@ func resourceNetboxVrfRead(d *schema.ResourceData, m interface{}) error {
 
 	res, err := api.Ipam.IpamVrfsRead(params, nil)
 	if err != nil {
-		errorcode := err.(*ipam.IpamVrfsReadDefault).Code()
-		if errorcode == 404 {
-			// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
-			d.SetId("")
-			return nil
+		if errresp, ok := err.(*ipam.IpamVrfsReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
 		}
 		return err
 	}


### PR DESCRIPTION
The read function in each resource checks if the http status code is 404 to handle he case where the resource has disappeared.

To obtain the http status code, the following is done:

```go
errorcode := err.(*ipam.IpamObjectDefault).Code()
```

In the client, the error returned might be a different error that is asserted here (for example when `transport.Submit()` returns an error).

When that's the case, a panic occurs:

```
panic: interface conversion: error is *errors.errorString, not *dcim.DcimDevicesReadDefault
```

And the actual error is masked. This can be fixed by checking if the type assertion is actually valid:

```
if errorcode, ok := err.(*ipam.IpamObjectDefault).Code(); ok {
...
}
```

The following [gopatch]() is used to apply these changes to all resources:

```diff
@@
var x expression
@@
-errorcode := err.(x).Code()
-if errorcode == 404 {
+if errresp, ok := err.(x); ok {
+       errorcode := errresp.Code()
+       if errorcode == 404 {
 ...
+       }
}
```

Only if the error is of the expected type, and the error code is 404, it returns nil, otherwise it returns the original error.

[gopatch]: https://github.com/uber-go/gopatch/