### PR TITLE
Support site_id as filter type for data_source_netbox_prefixes

### DIFF
--- a/docs/data-sources/prefixes.md
+++ b/docs/data-sources/prefixes.md
@@ -17,8 +17,8 @@ description: |-
 
 ### Optional
 
-- `filter` (Block Set) (see [below for nested schema](#nestedblock--filter))
-- `limit` (Number) Defaults to `0`.
+- `filter` (Block Set) A list of filters to apply to the API query when requesting prefixes. (see [below for nested schema](#nestedblock--filter))
+- `limit` (Number) The limit of objects to return from the API lookup. Defaults to `0`.
 
 ### Read-Only
 
@@ -30,8 +30,8 @@ description: |-
 
 Required:
 
-- `name` (String)
-- `value` (String)
+- `name` (String) The name of the field to filter on. Supported fields are: `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `site_id`, & `tag`.
+- `value` (String) The value to pass to the specified filter.
 
 
 <a id="nestedatt--prefixes"></a>

--- a/netbox/data_source_netbox_prefixes.go
+++ b/netbox/data_source_netbox_prefixes.go
@@ -109,6 +109,8 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 				params.VlanID = &vString
 			case "status":
 				params.Status = &vString
+			case "site_id":
+				params.SiteID = &vString
 			case "tag":
 				params.Tag = []string{vString}
 			default:

--- a/netbox/data_source_netbox_prefixes.go
+++ b/netbox/data_source_netbox_prefixes.go
@@ -17,17 +17,20 @@ func dataSourceNetboxPrefixes() *schema.Resource {
 		Description: `:meta:subcategory:IP Address Management (IPAM):`,
 		Schema: map[string]*schema.Schema{
 			"filter": {
-				Type:     schema.TypeSet,
-				Optional: true,
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "A list of filters to apply to the API query when requesting prefixes.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The name of the field to filter on. Supported fields are: `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `site_id`, & `tag`.",
 						},
 						"value": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The value to pass to the specified filter.",
 						},
 					},
 				},
@@ -37,6 +40,7 @@ func dataSourceNetboxPrefixes() *schema.Resource {
 				Optional:         true,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
 				Default:          0,
+				Description:      "The limit of objects to return from the API lookup.",
 			},
 			"prefixes": {
 				Type:     schema.TypeList,

--- a/netbox/data_source_netbox_prefixes_test.go
+++ b/netbox/data_source_netbox_prefixes_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAccNetboxPrefixesDataSource_basic(t *testing.T) {
 
-	testPrefixes := []string{"10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"}
+	testPrefixes := []string{"10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24", "10.0.7.0/24"}
 	testSlug := "prefixes_ds_basic"
 	testVlanVids := []int{4093, 4094}
 	testName := testAccGetTestName(testSlug)
@@ -39,18 +39,29 @@ resource "netbox_prefix" "without_vrf_and_vlan" {
   status = "active"
 }
 
+resource "netbox_site" "test" {
+  name = "site-%[1]s"
+  timezone = "Europe/Berlin"
+}
+
+resource "netbox_prefix" "with_site_id" {
+  prefix  = "%[5]s"
+  status  = "active"
+  site_id = netbox_site.test.id
+}
+
 resource "netbox_vrf" "test_vrf" {
   name = "%[1]s_test_vrf"
 }
 
 resource "netbox_vlan" "test_vlan1" {
   name = "%[1]s_vlan1"
-  vid  = %[5]d
+  vid  = %[6]d
 }
 
 resource "netbox_vlan" "test_vlan2" {
   name = "%[1]s_vlan2"
-  vid  = %[6]d
+  vid  = %[7]d
 }
 
 resource "netbox_tag" "test_tag1" {
@@ -73,7 +84,7 @@ data "netbox_prefixes" "by_vid" {
   depends_on = [netbox_prefix.test_prefix1, netbox_prefix.test_prefix2]
   filter {
     name  = "vlan_vid"
-    value = "%[5]d"
+    value = "%[6]d"
   }
 }
 
@@ -100,7 +111,14 @@ data "netbox_prefixes" "find_prefix_without_vrf_and_vlan" {
     value = netbox_prefix.without_vrf_and_vlan.prefix
   }
 }
-`, testName, testPrefixes[0], testPrefixes[1], testPrefixes[2], testVlanVids[0], testVlanVids[1]),
+data "netbox_prefixes" "find_prefix_with_site_id" {
+  depends_on = [netbox_prefix.with_site_id]
+  filter {
+    name  = "site_id"
+    value = netbox_site.test.id
+  }
+}
+`, testName, testPrefixes[0], testPrefixes[1], testPrefixes[2], testPrefixes[3], testVlanVids[0], testVlanVids[1]),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_prefixes.by_vrf", "prefixes.#", "2"),
 					resource.TestCheckResourceAttrPair("data.netbox_prefixes.by_vrf", "prefixes.1.vlan_vid", "netbox_vlan.test_vlan2", "vid"),
@@ -108,6 +126,8 @@ data "netbox_prefixes" "find_prefix_without_vrf_and_vlan" {
 					resource.TestCheckResourceAttr("data.netbox_prefixes.by_tag", "prefixes.#", "1"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.by_tag", "prefixes.0.description", "my-description"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.no_results", "prefixes.#", "0"),
+					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_site_id", "prefixes.#", "1"),
+					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_site_id", "prefixes.0.prefix", "10.0.7.0/24"),
 				),
 			},
 		},


### PR DESCRIPTION
We need the ability to filter prefixes on their site_id. This adds the functionality that is documented in netbox here: http://localhost:8001/api/schema/swagger-ui/#/ipam/ipam_prefixes_list