### PR TITLE
Go staticcheck fixes

### DIFF
--- a/netbox/client.go
+++ b/netbox/client.go
@@ -29,7 +29,7 @@ type customHeaderTransport struct {
 }
 
 // Client does the heavy lifting of establishing a base Open API client to Netbox.
-func (cfg *Config) Client() (interface{}, error) {
+func (cfg *Config) Client() (*netboxclient.NetBoxAPI, error) {
 
 	log.WithFields(log.Fields{
 		"server_url": cfg.ServerURL,

--- a/netbox/client_test.go
+++ b/netbox/client_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	netboxClient "github.com/fbreckle/go-netbox/netbox/client"
 	"github.com/fbreckle/go-netbox/netbox/client/status"
 	"github.com/stretchr/testify/assert"
 )
@@ -91,7 +90,7 @@ func TestAdditionalHeadersSet(t *testing.T) {
 	assert.NoError(t, err)
 
 	req := status.NewStatusListParams()
-	client.(*netboxClient.NetBoxAPI).Status.StatusList(req, nil)
+	client.Status.StatusList(req, nil)
 }
 
 /* TODO

--- a/netbox/data_source_netbox_asns.go
+++ b/netbox/data_source_netbox_asns.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fbreckle/go-netbox/netbox/client"
 	"github.com/fbreckle/go-netbox/netbox/client/ipam"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -116,6 +116,6 @@ func dataSourceNetboxAsnsRead(d *schema.ResourceData, m interface{}) error {
 		s = append(s, mapping)
 	}
 
-	d.SetId(resource.UniqueId())
+	d.SetId(id.UniqueId())
 	return d.Set("asns", s)
 }

--- a/netbox/data_source_netbox_devices.go
+++ b/netbox/data_source_netbox_devices.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fbreckle/go-netbox/netbox/client"
 	"github.com/fbreckle/go-netbox/netbox/client/dcim"
 	"github.com/fbreckle/go-netbox/netbox/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -254,6 +254,6 @@ func dataSourceNetboxDevicesRead(d *schema.ResourceData, m interface{}) error {
 		s = append(s, mapping)
 	}
 
-	d.SetId(resource.UniqueId())
+	d.SetId(id.UniqueId())
 	return d.Set("devices", s)
 }

--- a/netbox/data_source_netbox_interfaces.go
+++ b/netbox/data_source_netbox_interfaces.go
@@ -8,7 +8,7 @@ import (
 	"github.com/fbreckle/go-netbox/netbox/client"
 	"github.com/fbreckle/go-netbox/netbox/client/virtualization"
 	"github.com/fbreckle/go-netbox/netbox/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -227,7 +227,7 @@ func dataSourceNetboxInterfaceRead(d *schema.ResourceData, m interface{}) error 
 		s = append(s, mapping)
 	}
 
-	d.SetId(resource.UniqueId())
+	d.SetId(id.UniqueId())
 	return d.Set("interfaces", s)
 
 }

--- a/netbox/data_source_netbox_ip_addresses.go
+++ b/netbox/data_source_netbox_ip_addresses.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fbreckle/go-netbox/netbox/client"
 	"github.com/fbreckle/go-netbox/netbox/client/ipam"
 	"github.com/fbreckle/go-netbox/netbox/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -178,7 +178,7 @@ func dataSourceNetboxIpAddressesRead(d *schema.ResourceData, m interface{}) erro
 		s = append(s, mapping)
 	}
 
-	d.SetId(resource.UniqueId())
+	d.SetId(id.UniqueId())
 	return d.Set("ip_addresses", s)
 
 }

--- a/netbox/data_source_netbox_prefix_test.go
+++ b/netbox/data_source_netbox_prefix_test.go
@@ -7,11 +7,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func resources() string {
-	return `
-`
-}
-
 func TestAccNetboxPrefixDataSource_basic(t *testing.T) {
 
 	testPrefix := "10.0.0.0/24"

--- a/netbox/data_source_netbox_prefixes.go
+++ b/netbox/data_source_netbox_prefixes.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fbreckle/go-netbox/netbox/client"
 	"github.com/fbreckle/go-netbox/netbox/client/ipam"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -144,6 +144,6 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 		s = append(s, mapping)
 	}
 
-	d.SetId(resource.UniqueId())
+	d.SetId(id.UniqueId())
 	return d.Set("prefixes", s)
 }

--- a/netbox/data_source_netbox_racks.go
+++ b/netbox/data_source_netbox_racks.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fbreckle/go-netbox/netbox/client"
 	"github.com/fbreckle/go-netbox/netbox/client/dcim"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -278,6 +278,6 @@ func dataSourceNetboxRacksRead(d *schema.ResourceData, m interface{}) error {
 		s = append(s, mapping)
 	}
 
-	d.SetId(resource.UniqueId())
+	d.SetId(id.UniqueId())
 	return d.Set("racks", s)
 }

--- a/netbox/data_source_netbox_tenants.go
+++ b/netbox/data_source_netbox_tenants.go
@@ -7,7 +7,7 @@ import (
 	"github.com/fbreckle/go-netbox/netbox/client"
 	"github.com/fbreckle/go-netbox/netbox/client/tenancy"
 	"github.com/fbreckle/go-netbox/netbox/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -213,7 +213,7 @@ func dataSourceNetboxTenantsRead(d *schema.ResourceData, m interface{}) error {
 		s = append(s, mapping)
 	}
 
-	d.SetId(resource.UniqueId())
+	d.SetId(id.UniqueId())
 	return d.Set("tenants", s)
 
 }

--- a/netbox/data_source_netbox_virtual_machines.go
+++ b/netbox/data_source_netbox_virtual_machines.go
@@ -9,7 +9,7 @@ import (
 	"github.com/fbreckle/go-netbox/netbox/client"
 	"github.com/fbreckle/go-netbox/netbox/client/virtualization"
 	"github.com/fbreckle/go-netbox/netbox/models"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -267,6 +267,6 @@ func dataSourceNetboxVirtualMachineRead(d *schema.ResourceData, m interface{}) e
 		s = append(s, mapping)
 	}
 
-	d.SetId(resource.UniqueId())
+	d.SetId(id.UniqueId())
 	return d.Set("vms", s)
 }

--- a/netbox/provider.go
+++ b/netbox/provider.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/fbreckle/go-netbox/netbox/client"
 	"github.com/fbreckle/go-netbox/netbox/client/status"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -238,7 +237,7 @@ func providerConfigure(ctx context.Context, data *schema.ResourceData) (interfac
 
 	if !skipVersionCheck {
 		req := status.NewStatusListParams()
-		res, err := netboxClient.(*client.NetBoxAPI).Status.StatusList(req, nil)
+		res, err := netboxClient.Status.StatusList(req, nil)
 
 		if err != nil {
 			return nil, diag.FromErr(err)

--- a/netbox/resource_netbox_route_target_test.go
+++ b/netbox/resource_netbox_route_target_test.go
@@ -15,16 +15,16 @@ import (
 func getNetboxRouteTargetResource(rtName, tenantName string) string {
 	return fmt.Sprintf(`
 resource "netbox_tenant" "rt_acctest_basic" {
-	name = %[2]s
+	name = "%[2]s"
 }
-resource "netbox_ipam_route_target" "rt_acctest_basic" {
-	name = "%[1]s",
-	description = "rt for acctest",
-	tenant_id = netbox_tenant.test.id
+resource "netbox_route_target" "rt_acctest_basic" {
+	name = "%[1]s"
+	description = "rt for acctest"
+	tenant_id = netbox_tenant.rt_acctest_basic.id
 }`, rtName, tenantName)
 }
 
-func resourceNetboxRouteTarget_test(t *testing.T) {
+func Test_resourceNetboxRouteTarget(t *testing.T) {
 	testSlug := "rt"
 	testName := testAccGetTestName(testSlug)
 	resource.ParallelTest(t, resource.TestCase{
@@ -37,42 +37,44 @@ func resourceNetboxRouteTarget_test(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_route_target.rt_acctest_basic", "name", testName),
 					resource.TestCheckResourceAttr("netbox_route_target.rt_acctest_basic", "description", "rt for acctest"),
-					resource.TestCheckResourceAttrPair("netbox_route_target.rt_acc_test_basic", "tenant_id", "netbox_tenant.rt_acc_test_basic", "id"),
+					resource.TestCheckResourceAttrPair("netbox_route_target.rt_acctest_basic", "tenant_id", "netbox_tenant.rt_acctest_basic", "id"),
 				),
+			},
+			{
 				ResourceName:      "netbox_route_target.rt_acctest_basic",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
 				Config: fmt.Sprintf(`
-resource "netbox_tenant" "rt_acctest_basic" {
-	name = %[2]s
-}
-resource "netbox_ipam_route_target" "rt_acctest_basic" {
-	name = "%[1]s",
-	description = "change description",
-	tenant_id = netbox_tenant.test.id
-}`, testName, fmt.Sprintf("new%s", testName)),
+			resource "netbox_tenant" "rt_acctest_basic" {
+				name = "%[2]s"
+			}
+			resource "netbox_route_target" "rt_acctest_basic" {
+				name = "%[1]s"
+				description = "change description"
+				tenant_id = netbox_tenant.rt_acctest_basic.id
+			}`, testName, fmt.Sprintf("new%s", testName)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_route_target.rt_acctest_basic", "name", testName),
 					resource.TestCheckResourceAttr("netbox_route_target.rt_acctest_basic", "description", "change description"),
-					resource.TestCheckResourceAttrPair("netbox_route_target.rt_acc_test_basic", "tenant_id", "netbox_tenant.rt_acc_test_basic", "id"),
+					resource.TestCheckResourceAttrPair("netbox_route_target.rt_acctest_basic", "tenant_id", "netbox_tenant.rt_acctest_basic", "id"),
 				),
+			},
+			{
 				ResourceName:      "netbox_route_target.rt_acctest_basic",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
 				Config: fmt.Sprintf(`
-resource "netbox_ipam_route_target" "rt_acctest_basic" {
-	name = "%[1]s",
-	description = "change description",
-	tenant_id = "10001"
-}`, testName, fmt.Sprintf(testName)),
-				ExpectError:       regexp.MustCompile("tenant_id does not exist.*"),
-				ResourceName:      "netbox_route_target.rt_acctest_basic",
-				ImportState:       true,
-				ImportStateVerify: true,
+			resource "netbox_route_target" "rt_acctest_basic2" {
+				name = "%[1]s"
+				description = "change description"
+				tenant_id = "10001"
+			}`, fmt.Sprintf("2%s", testName)),
+
+				ExpectError: regexp.MustCompile(`.*Related object not found using the provided numeric ID.*`),
 			},
 		},
 	})


### PR DESCRIPTION
Found several issues that the [go-staticcheck](https://staticcheck.io/) linter is complaining about.

---
## fix: Replace deprecated resource.UniqueId() function
Getting the following error from `go-staticcheck` linter:

```
resource.UniqueId is deprecated: Use helper/id package instead.
This is required for migrating acceptance testing to
terraform-plugin-testing.  (SA1019)
```

This changes all instances of resource.UniqueId() with the suggested
`id.UniqueId()` function with the same functionality.

All acceptance tests are still passing.

---
## style: Make Client() return *netboxclient.NetBoxAPI

The `Client()` function was returning an `interface{}` which
required casting to `*netboxclient.NetBoxAPI` in the `providerConfigure`
function, which is not necessary. `providerConfigure()` can take the
`*netboxclient.NetBoxAPI` type as it's return, since it takes an
`interface{}`.

---
## fix: Other go-staticcheck fixes

Removed unused function: `func resources is unused (U1000)`

Removed unused printf call:
```
printf-style function with dynamic format string and no further
arguments should use print-style function instead (SA1006)
```

Updated `resourceNetboxRouteTarget_test` to
`Test_resourceNetboxRouteTarget` to make test able to run.
```
func resourceNetboxRouteTarget_test is unused (U1000)
func getNetboxRouteTargetResource is unused (U1000)
```