### PR TITLE
fix: Add error to tags lookup if tag does not exist

### DIFF
--- a/netbox/resource_netbox_virtual_machine.go
+++ b/netbox/resource_netbox_virtual_machine.go
@@ -170,8 +170,8 @@ func resourceNetboxVirtualMachineCreate(ctx context.Context, d *schema.ResourceD
 
 	data.Status = d.Get("status").(string)
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
-
+	tags, diags := getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.Tags = tags
 	ct, ok := d.GetOk(customFieldsKey)
 	if ok {
 		data.CustomFields = ct
@@ -186,7 +186,7 @@ func resourceNetboxVirtualMachineCreate(ctx context.Context, d *schema.ResourceD
 
 	d.SetId(strconv.FormatInt(res.GetPayload().ID, 10))
 
-	return resourceNetboxVirtualMachineRead(ctx, d, m)
+	return append(resourceNetboxVirtualMachineRead(ctx, d, m), diags...)
 }
 
 func resourceNetboxVirtualMachineRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -377,8 +377,8 @@ func resourceNetboxVirtualMachineUpdate(ctx context.Context, d *schema.ResourceD
 		data.PrimaryIp6 = &primaryIP6
 	}
 
-	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
-
+	tags, diags := getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+	data.Tags = tags
 	cf, ok := d.GetOk(customFieldsKey)
 	if ok {
 		data.CustomFields = cf
@@ -410,7 +410,7 @@ func resourceNetboxVirtualMachineUpdate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	return resourceNetboxVirtualMachineRead(ctx, d, m)
+	return append(resourceNetboxVirtualMachineRead(ctx, d, m), diags...)
 }
 
 func resourceNetboxVirtualMachineDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/netbox/tags.go
+++ b/netbox/tags.go
@@ -45,26 +45,35 @@ func getNestedTagListFromResourceDataSet(client *client.NetBoxAPI, d interface{}
 		res, err := client.Extras.ExtrasTagsList(params, nil)
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
-				Severity: diag.Warning,
+				Severity: diag.Error,
 				Summary:  fmt.Sprintf("Error retrieving tag %s from netbox", tag.(string)),
 				Detail:   fmt.Sprintf("API Error trying to retrieve tag %s from netbox", tag.(string)),
 			})
-		} else {
-			payload := res.GetPayload()
-			if *payload.Count == int64(1) {
-				tags = append(tags, &models.NestedTag{
-					Name: payload.Results[0].Name,
-					Slug: payload.Results[0].Slug,
-				})
-			} else {
-				diags = append(diags, diag.Diagnostic{
-					Severity: diag.Warning,
-					Summary:  fmt.Sprintf("Error retrieving tag %s from netbox", tag.(string)),
-					Detail:   fmt.Sprintf("Could not map tag %s to unique tag in netbox", tag.(string)),
-				})
-			}
+			return tags, diags
+		}
+		payload := res.GetPayload()
+		switch *payload.Count {
+		case int64(0):
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("Error retrieving tag %s from netbox", tag.(string)),
+				Detail:   fmt.Sprintf("Could not locate referenced tag %s in netbox", tag.(string)),
+			})
+			return tags, diags
+		case int64(1):
+			tags = append(tags, &models.NestedTag{
+				Name: payload.Results[0].Name,
+				Slug: payload.Results[0].Slug,
+			})
+		default:
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Warning,
+				Summary:  fmt.Sprintf("Error retrieving tag %s from netbox", tag.(string)),
+				Detail:   fmt.Sprintf("Could not map tag %s to unique tag in netbox", tag.(string)),
+			})
 		}
 	}
+
 	return tags, diags
 }
 


### PR DESCRIPTION
There has been no error or check to determine if a tag exists already or not. This causes the terraform to always try to make a change if the tag does not exist, since there's no indication that the lookup didn't find anything.

This is helpful, since it provides feedback to the user that the associated tag does not exist, and needs to be added with the `netbox_tag` resource.

Since there are a lot of resources that use tags, we are only activating this feature on the netbox_virtual_machine resource to start. It can be added to other resources by returning the diag and appending it to the return of the function.