### PR TITLE
Add description field to VMs, Devices, Clusters Resource/Data

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -32,6 +32,7 @@ data "netbox_cluster" "vmw_cluster_01" {
 - `cluster_id` (Number)
 - `cluster_type_id` (Number)
 - `comments` (String)
+- `description` (String)
 - `id` (String) The ID of this resource.
 - `tags` (Set of String)
 

--- a/docs/data-sources/devices.md
+++ b/docs/data-sources/devices.md
@@ -44,6 +44,7 @@ Read-Only:
 - `cluster_id` (Number)
 - `comments` (String)
 - `custom_fields` (Map of String)
+- `description` (String)
 - `device_id` (Number)
 - `device_type_id` (Number)
 - `location_id` (Number)

--- a/docs/data-sources/virtual_machines.md
+++ b/docs/data-sources/virtual_machines.md
@@ -59,6 +59,7 @@ Read-Only:
 - `comments` (String)
 - `config_context` (String)
 - `custom_fields` (Map of String)
+- `description` (String)
 - `disk_size_gb` (Number)
 - `local_context_data` (String)
 - `memory_mb` (Number)

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -47,6 +47,7 @@ resource "netbox_cluster" "vmw_cluster_01" {
 
 - `cluster_group_id` (Number)
 - `comments` (String)
+- `description` (String)
 - `site_id` (Number)
 - `tags` (Set of String)
 - `tenant_id` (Number)

--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -57,6 +57,7 @@ resource "netbox_device" "test" {
 - `cluster_id` (Number)
 - `comments` (String)
 - `custom_fields` (Map of String)
+- `description` (String)
 - `location_id` (Number)
 - `platform_id` (Number)
 - `rack_face` (String) Valid values are `front` and `rear`. Required when `rack_position` is set.

--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -74,6 +74,7 @@ resource "netbox_virtual_machine" "full_vm" {
 - `cluster_id` (Number) At least one of `site_id` or `cluster_id` must be given.
 - `comments` (String)
 - `custom_fields` (Map of String)
+- `description` (String)
 - `device_id` (Number)
 - `disk_size_gb` (Number)
 - `local_context_data` (String) This is best managed through the use of `jsonencode` and a map of settings.

--- a/netbox/data_source_netbox_cluster.go
+++ b/netbox/data_source_netbox_cluster.go
@@ -22,6 +22,10 @@ func dataSourceNetboxCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"site_id": {
 				Type:         schema.TypeInt,
 				Computed:     true,
@@ -85,6 +89,7 @@ func dataSourceNetboxClusterRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("cluster_group_id", nil)
 	}
 	d.Set("comments", result.Comments)
+	d.Set("description", result.Description)
 	if result.Site != nil {
 		d.Set("site_id", result.Site.ID)
 	} else {

--- a/netbox/data_source_netbox_cluster_test.go
+++ b/netbox/data_source_netbox_cluster_test.go
@@ -38,6 +38,7 @@ resource "netbox_cluster" "test" {
   cluster_group_id = netbox_cluster_group.test.id
   site_id = netbox_site.test.id
   comments = "%[1]scomments"
+  description = "%[1]sdescription"
   tags = [netbox_tag.test.name]
 }
 
@@ -56,6 +57,7 @@ data "netbox_cluster" "by_site_id" {
 					resource.TestCheckResourceAttrPair("data.netbox_cluster.by_name", "cluster_type_id", "netbox_cluster_type.test", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_cluster.by_name", "cluster_group_id", "netbox_cluster_group.test", "id"),
 					resource.TestCheckResourceAttr("data.netbox_cluster.by_name", "comments", testName+"comments"),
+					resource.TestCheckResourceAttr("data.netbox_cluster.by_name", "description", testName+"description"),
 					resource.TestCheckResourceAttrPair("data.netbox_cluster.by_name", "site_id", "netbox_site.test", "id"),
 					resource.TestCheckResourceAttr("data.netbox_cluster.by_name", "tags.#", "1"),
 					resource.TestCheckResourceAttr("data.netbox_cluster.by_name", "tags.0", testName),

--- a/netbox/data_source_netbox_devices.go
+++ b/netbox/data_source_netbox_devices.go
@@ -66,6 +66,10 @@ func dataSourceNetboxDevices() *schema.Resource {
 							Type:     schema.TypeMap,
 							Computed: true,
 						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"device_id": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -204,6 +208,9 @@ func dataSourceNetboxDevicesRead(d *schema.ResourceData, m interface{}) error {
 		}
 		if device.Comments != "" {
 			mapping["comments"] = device.Comments
+		}
+		if device.Description != "" {
+			mapping["description"] = device.Description
 		}
 		mapping["device_id"] = device.ID
 		if device.DeviceType != nil {

--- a/netbox/data_source_netbox_devices_test.go
+++ b/netbox/data_source_netbox_devices_test.go
@@ -27,6 +27,7 @@ func TestAccNetboxDevicesDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.netbox_devices.test", "devices.#", "1"),
 					resource.TestCheckResourceAttr("data.netbox_devices.test", "devices.0.name", testName+"_0"),
 					resource.TestCheckResourceAttr("data.netbox_devices.test", "devices.0.comments", "this is also a comment"),
+					resource.TestCheckResourceAttr("data.netbox_devices.test", "devices.0.description", "this is also a description"),
 					resource.TestCheckResourceAttrPair("data.netbox_devices.test", "devices.0.tenant_id", "netbox_tenant.test", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_devices.test", "devices.0.role_id", "netbox_device_role.test", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_devices.test", "devices.0.device_type_id", "netbox_device_type.test", "id"),
@@ -83,6 +84,7 @@ func testAccNetboxDeviceDataSourceDependencies(testName string) string {
 resource "netbox_device" "test0" {
   name = "%[1]s_0"
   comments = "this is also a comment"
+  description = "this is also a description"
   tenant_id = netbox_tenant.test.id
   role_id = netbox_device_role.test.id
   device_type_id = netbox_device_type.test.id
@@ -204,6 +206,7 @@ resource "netbox_custom_field" "test" {
 resource "netbox_device" "test" {
   name = "%[2]s"
   comments = "thisisacomment"
+  description = "thisisadescription"
   tenant_id = netbox_tenant.test.id
   platform_id = netbox_platform.test.id
   role_id = netbox_device_role.test.id
@@ -214,13 +217,14 @@ resource "netbox_device" "test" {
   location_id = netbox_location.test.id
   status = "staged"
   serial = "ABCDEF"
-	custom_fields = {"${netbox_custom_field.test.name}" = "81"}
+  custom_fields = {"${netbox_custom_field.test.name}" = "81"}
 }
 `, testField, testName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_devices.test", "devices.#", "1"),
 					resource.TestCheckResourceAttr("data.netbox_devices.test", "devices.0.name", testName),
 					resource.TestCheckResourceAttr("data.netbox_devices.test", "devices.0.comments", "thisisacomment"),
+					resource.TestCheckResourceAttr("data.netbox_devices.test", "devices.0.description", "thisisadescription"),
 					resource.TestCheckResourceAttrPair("data.netbox_devices.test", "devices.0.tenant_id", "netbox_tenant.test", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_devices.test", "devices.0.role_id", "netbox_device_role.test", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_devices.test", "devices.0.device_type_id", "netbox_device_type.test", "id"),

--- a/netbox/data_source_netbox_virtual_machines.go
+++ b/netbox/data_source_netbox_virtual_machines.go
@@ -65,6 +65,10 @@ func dataSourceNetboxVirtualMachine() *schema.Resource {
 							Type:     schema.TypeMap,
 							Computed: true,
 						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"disk_size_gb": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -204,6 +208,9 @@ func dataSourceNetboxVirtualMachineRead(d *schema.ResourceData, m interface{}) e
 		}
 		if v.Comments != "" {
 			mapping["comments"] = v.Comments
+		}
+		if v.Description != "" {
+			mapping["description"] = v.Description
 		}
 		if v.ConfigContext != nil {
 			if configContext, err := json.Marshal(v.ConfigContext); err == nil {

--- a/netbox/resource_netbox_cluster.go
+++ b/netbox/resource_netbox_cluster.go
@@ -39,6 +39,10 @@ func resourceNetboxCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"site_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -72,6 +76,7 @@ func resourceNetboxClusterCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	data.Comments = getOptionalStr(d, "comments", false)
+	data.Description = getOptionalStr(d, "description", false)
 
 	if siteIDValue, ok := d.GetOk("site_id"); ok {
 		siteID := int64(siteIDValue.(int))
@@ -127,6 +132,7 @@ func resourceNetboxClusterRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	d.Set("comments", res.GetPayload().Comments)
+	d.Set("description", res.GetPayload().Description)
 
 	if res.GetPayload().Site != nil {
 		d.Set("site_id", res.GetPayload().Site.ID)
@@ -162,6 +168,7 @@ func resourceNetboxClusterUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	data.Comments = getOptionalStr(d, "comments", true)
+	data.Description = getOptionalStr(d, "description", true)
 
 	if siteIDValue, ok := d.GetOk("site_id"); ok {
 		siteID := int64(siteIDValue.(int))

--- a/netbox/resource_netbox_cluster_test.go
+++ b/netbox/resource_netbox_cluster_test.go
@@ -42,6 +42,7 @@ resource "netbox_cluster" "test" {
   cluster_type_id = netbox_cluster_type.test.id
   cluster_group_id = netbox_cluster_group.test.id
   comments = "%[1]scomments"
+  description = "%[1]sdescription"
   site_id = netbox_site.test.id
   tags = [netbox_tag.test.name]
 }`, testName),
@@ -50,6 +51,7 @@ resource "netbox_cluster" "test" {
 					resource.TestCheckResourceAttrPair("netbox_cluster.test", "cluster_type_id", "netbox_cluster_type.test", "id"),
 					resource.TestCheckResourceAttrPair("netbox_cluster.test", "cluster_group_id", "netbox_cluster_group.test", "id"),
 					resource.TestCheckResourceAttr("netbox_cluster.test", "comments", testName+"comments"),
+					resource.TestCheckResourceAttr("netbox_cluster.test", "description", testName+"description"),
 					resource.TestCheckResourceAttrPair("netbox_cluster.test", "site_id", "netbox_site.test", "id"),
 					resource.TestCheckResourceAttr("netbox_cluster.test", "tags.#", "1"),
 					resource.TestCheckResourceAttr("netbox_cluster.test", "tags.0", testName),

--- a/netbox/resource_netbox_device.go
+++ b/netbox/resource_netbox_device.go
@@ -67,6 +67,10 @@ func resourceNetboxDevice() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			tagsKey: tagsSchema,
 			"primary_ipv4": {
 				Type:     schema.TypeInt,
@@ -121,14 +125,13 @@ func resourceNetboxDeviceCreate(ctx context.Context, d *schema.ResourceData, m i
 		data.DeviceType = &typeID
 	}
 
-	comments := d.Get("comments").(string)
-	data.Comments = comments
+	data.Comments = d.Get("comments").(string)
 
-	serial := d.Get("serial").(string)
-	data.Serial = serial
+	data.Description = d.Get("description").(string)
 
-	status := d.Get("status").(string)
-	data.Status = status
+	data.Serial = d.Get("serial").(string)
+
+	data.Status = d.Get("status").(string)
 
 	tenantIDValue, ok := d.GetOk("tenant_id")
 	if ok {
@@ -280,6 +283,8 @@ func resourceNetboxDeviceRead(ctx context.Context, d *schema.ResourceData, m int
 
 	d.Set("comments", device.Comments)
 
+	d.Set("description", device.Description)
+
 	d.Set("serial", device.Serial)
 
 	d.Set("status", device.Status.Value)
@@ -356,15 +361,6 @@ func resourceNetboxDeviceUpdate(ctx context.Context, d *schema.ResourceData, m i
 		data.Site = &siteID
 	}
 
-	commentsValue, ok := d.GetOk("comments")
-	if ok {
-		comments := commentsValue.(string)
-		data.Comments = comments
-	} else {
-		comments := " "
-		data.Comments = comments
-	}
-
 	primaryIP4Value, ok := d.GetOk("primary_ipv4")
 	if ok {
 		primaryIP4 := int64(primaryIP4Value.(int))
@@ -390,15 +386,19 @@ func resourceNetboxDeviceUpdate(ctx context.Context, d *schema.ResourceData, m i
 
 	if d.HasChanges("comments") {
 		// check if comment is set
-		commentsValue, ok := d.GetOk("comments")
-		comments := ""
-		if !ok {
-			// Setting an space string deletes the comment
-			comments = " "
+		if commentsValue, ok := d.GetOk("comments"); ok {
+			data.Comments = commentsValue.(string)
 		} else {
-			comments = commentsValue.(string)
+			data.Comments = " "
 		}
-		data.Comments = comments
+	}
+	if d.HasChanges("description") {
+		// check if description is set
+		if descriptionValue, ok := d.GetOk("description"); ok {
+			data.Description = descriptionValue.(string)
+		} else {
+			data.Description = " "
+		}
 	}
 
 	if d.HasChanges("serial") {

--- a/netbox/resource_netbox_device_test.go
+++ b/netbox/resource_netbox_device_test.go
@@ -94,6 +94,7 @@ func TestAccNetboxDevice_basic(t *testing.T) {
 resource "netbox_device" "test" {
   name = "%[1]s"
   comments = "thisisacomment"
+  description = "thisisadescription"
   tenant_id = netbox_tenant.test.id
   platform_id = netbox_platform.test.id
   role_id = netbox_device_role.test.id
@@ -118,6 +119,7 @@ resource "netbox_device" "test" {
 					resource.TestCheckResourceAttrPair("netbox_device.test", "cluster_id", "netbox_cluster.test", "id"),
 					resource.TestCheckResourceAttrPair("netbox_device.test", "rack_id", "netbox_rack.test", "id"),
 					resource.TestCheckResourceAttr("netbox_device.test", "comments", "thisisacomment"),
+					resource.TestCheckResourceAttr("netbox_device.test", "description", "thisisadescription"),
 					resource.TestCheckResourceAttr("netbox_device.test", "status", "staged"),
 					resource.TestCheckResourceAttr("netbox_device.test", "serial", "ABCDEF"),
 					resource.TestCheckResourceAttr("netbox_device.test", "tags.#", "1"),
@@ -131,6 +133,7 @@ resource "netbox_device" "test" {
 resource "netbox_device" "test" {
   name = "%[1]s"
   comments = "thisisacomment"
+  description = "thisisadescription"
   tenant_id = netbox_tenant.test.id
   platform_id = netbox_platform.test.id
   role_id = netbox_device_role.test.id
@@ -153,6 +156,7 @@ resource "netbox_device" "test" {
 					resource.TestCheckResourceAttrPair("netbox_device.test", "cluster_id", "netbox_cluster.test", "id"),
 					resource.TestCheckResourceAttrPair("netbox_device.test", "rack_id", "netbox_rack.test", "id"),
 					resource.TestCheckResourceAttr("netbox_device.test", "comments", "thisisacomment"),
+					resource.TestCheckResourceAttr("netbox_device.test", "description", "thisisadescription"),
 					resource.TestCheckResourceAttr("netbox_device.test", "status", "staged"),
 					resource.TestCheckResourceAttr("netbox_device.test", "serial", "ABCDEF"),
 					resource.TestCheckResourceAttr("netbox_device.test", "tags.#", "1"),
@@ -166,6 +170,7 @@ resource "netbox_device" "test" {
 resource "netbox_device" "test" {
   name = "%[1]s"
   comments = "thisisacomment"
+  description = "thisisadescription"
   tenant_id = netbox_tenant.test.id
   platform_id = netbox_platform.test.id
   role_id = netbox_device_role.test.id
@@ -186,6 +191,7 @@ resource "netbox_device" "test" {
 					resource.TestCheckResourceAttrPair("netbox_device.test", "site_id", "netbox_site.test", "id"),
 					resource.TestCheckResourceAttrPair("netbox_device.test", "cluster_id", "netbox_cluster.test", "id"),
 					resource.TestCheckResourceAttr("netbox_device.test", "comments", "thisisacomment"),
+					resource.TestCheckResourceAttr("netbox_device.test", "description", "thisisadescription"),
 					resource.TestCheckResourceAttr("netbox_device.test", "status", "staged"),
 					resource.TestCheckResourceAttr("netbox_device.test", "serial", "ABCDEF"),
 					resource.TestCheckResourceAttr("netbox_device.test", "tags.#", "1"),

--- a/netbox/resource_netbox_primary_ip.go
+++ b/netbox/resource_netbox_primary_ip.go
@@ -111,6 +111,7 @@ func resourceNetboxPrimaryIPUpdate(d *schema.ResourceData, m interface{}) error 
 		tag.Display = ""
 	}
 	data.Comments = vm.Comments
+	data.Description = vm.Description
 	data.Memory = vm.Memory
 	data.Vcpus = vm.Vcpus
 	data.Disk = vm.Disk

--- a/netbox/resource_netbox_virtual_machine.go
+++ b/netbox/resource_netbox_virtual_machine.go
@@ -61,6 +61,10 @@ func resourceNetboxVirtualMachine() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"memory_mb": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -131,8 +135,8 @@ func resourceNetboxVirtualMachineCreate(ctx context.Context, d *schema.ResourceD
 		data.Site = &siteID
 	}
 
-	comments := d.Get("comments").(string)
-	data.Comments = comments
+	data.Comments = d.Get("comments").(string)
+	data.Description = d.Get("description").(string)
 
 	vcpusValue, ok := d.GetOk("vcpus")
 	if ok {
@@ -295,6 +299,7 @@ func resourceNetboxVirtualMachineRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	d.Set("comments", vm.Comments)
+	d.Set("description", vm.Description)
 	vcpus := vm.Vcpus
 	if vcpus != nil {
 		d.Set("vcpus", vm.Vcpus)
@@ -381,15 +386,6 @@ func resourceNetboxVirtualMachineUpdate(ctx context.Context, d *schema.ResourceD
 		data.Disk = &diskSize
 	}
 
-	commentsValue, ok := d.GetOk("comments")
-	if ok {
-		comments := commentsValue.(string)
-		data.Comments = comments
-	} else {
-		comments := " "
-		data.Comments = comments
-	}
-
 	primaryIP4Value, ok := d.GetOk("primary_ipv4")
 	if ok {
 		primaryIP4 := int64(primaryIP4Value.(int))
@@ -420,15 +416,19 @@ func resourceNetboxVirtualMachineUpdate(ctx context.Context, d *schema.ResourceD
 
 	if d.HasChanges("comments") {
 		// check if comment is set
-		commentsValue, ok := d.GetOk("comments")
-		comments := ""
-		if !ok {
-			// Setting an space string deletes the comment
-			comments = " "
+		if commentsValue, ok := d.GetOk("comments"); ok {
+			data.Comments = commentsValue.(string)
 		} else {
-			comments = commentsValue.(string)
+			data.Comments = " "
 		}
-		data.Comments = comments
+	}
+	if d.HasChanges("description") {
+		// check if description is set
+		if descriptionValue, ok := d.GetOk("description"); ok {
+			data.Description = descriptionValue.(string)
+		} else {
+			data.Description = " "
+		}
 	}
 
 	// if d.HasChanges("status") {

--- a/netbox/resource_netbox_virtual_machine_test.go
+++ b/netbox/resource_netbox_virtual_machine_test.go
@@ -188,6 +188,7 @@ resource "netbox_virtual_machine" "test" {
   cluster_id = netbox_cluster.test.id
   site_id = netbox_site.test.id
   comments = "thisisacomment"
+  description = "thisisadescription"
   memory_mb = 1024
   disk_size_gb = 256
   tenant_id = netbox_tenant.test.id
@@ -206,6 +207,7 @@ resource "netbox_virtual_machine" "test" {
 					resource.TestCheckResourceAttrPair("netbox_virtual_machine.test", "role_id", "netbox_device_role.test", "id"),
 					resource.TestCheckResourceAttrPair("netbox_virtual_machine.test", "device_id", "netbox_device.test", "id"),
 					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "comments", "thisisacomment"),
+					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "description", "thisisadescription"),
 					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "memory_mb", "1024"),
 					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "vcpus", "4"),
 					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "disk_size_gb", "256"),
@@ -220,6 +222,7 @@ resource "netbox_virtual_machine" "test" {
   name = "%[1]s"
   site_id = netbox_site.test.id
   comments = "thisisacomment"
+  description = "thisisadescription"
   memory_mb = 1024
   disk_size_gb = 256
   tenant_id = netbox_tenant.test.id
@@ -236,6 +239,7 @@ resource "netbox_virtual_machine" "test" {
 					resource.TestCheckResourceAttrPair("netbox_virtual_machine.test", "platform_id", "netbox_platform.test", "id"),
 					resource.TestCheckResourceAttrPair("netbox_virtual_machine.test", "role_id", "netbox_device_role.test", "id"),
 					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "comments", "thisisacomment"),
+					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "description", "thisisadescription"),
 					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "memory_mb", "1024"),
 					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "vcpus", "4"),
 					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "disk_size_gb", "256"),
@@ -260,6 +264,7 @@ resource "netbox_virtual_machine" "test" {
 					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "memory_mb", "0"),
 					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "disk_size_gb", "0"),
 					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "comments", ""),
+					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "description", ""),
 				),
 			},
 			{


### PR DESCRIPTION
We were missing the ability to add a descriptions to devices, VMs, and
clusters. There are also corresponding data sources that do not have the
description field.

These fields were not available prior to netbox 3.4.3.

This adds the description field, following the example of the comment
field. The code was also slightly modified to be simpler to understand.