### PR TITLE
Add local_context_data to virtual machines

### DIFF
--- a/docs/resources/virtual_machine.md
+++ b/docs/resources/virtual_machine.md
@@ -80,6 +80,7 @@ resource "netbox_virtual_machine" "full_vm" {
 - `tags` (Set of String)
 - `tenant_id` (Number)
 - `vcpus` (Number)
+- `local_context_data` (String) This is best managed through the use of `jsonencode` and a map of settings.
 
 ### Read-Only
 

--- a/examples/resources/netbox_virtual_machine/resource.tf
+++ b/examples/resources/netbox_virtual_machine/resource.tf
@@ -37,4 +37,8 @@ resource "netbox_virtual_machine" "full_vm" {
   vcpus        = "2"
   role_id      = 31 // This corresponds to the Netbox ID for a given role
   tenant_id    = data.netbox_tenant.customer_a.id
+  local_context_data = jsonencode({
+    "setting_a" = "Some Setting"
+    "setting_b" = 42
+  })
 }

--- a/netbox/resource_netbox_virtual_machine.go
+++ b/netbox/resource_netbox_virtual_machine.go
@@ -3,7 +3,6 @@ package netbox
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strconv"
 
 	"github.com/fbreckle/go-netbox/netbox/client"
@@ -285,7 +284,6 @@ func resourceNetboxVirtualMachineRead(ctx context.Context, d *schema.ResourceDat
 	}
 
 	if vm.LocalContextData != nil {
-		fmt.Printf("%+v\n", vm.LocalContextData)
 		if jsonArr, err := json.Marshal(vm.LocalContextData); err == nil {
 			d.Set("local_context_data", string(jsonArr))
 		}

--- a/netbox/resource_netbox_virtual_machine_test.go
+++ b/netbox/resource_netbox_virtual_machine_test.go
@@ -95,7 +95,6 @@ resource "netbox_cluster" "test" {
 }
 
 func TestAccNetboxVirtualMachine_SiteOnly(t *testing.T) {
-
 	testSlug := "vm_site"
 	testName := testAccGetTestName(testSlug)
 	resource.ParallelTest(t, resource.TestCase{
@@ -125,7 +124,6 @@ resource "netbox_virtual_machine" "only_site" {
 }
 
 func TestAccNetboxVirtualMachine_ClusterWithoutSite(t *testing.T) {
-
 	testSlug := "vm_clstrnosite"
 	testName := testAccGetTestName(testSlug)
 	resource.ParallelTest(t, resource.TestCase{
@@ -164,7 +162,6 @@ resource "netbox_virtual_machine" "cluster_without_site" {
 }
 
 func TestAccNetboxVirtualMachine_basic(t *testing.T) {
-
 	testSlug := "vm_basic"
 	testName := testAccGetTestName(testSlug)
 	resource.ParallelTest(t, resource.TestCase{
@@ -275,7 +272,6 @@ resource "netbox_virtual_machine" "test" {
 }
 
 func TestAccNetboxVirtualMachine_fractionalVcpu(t *testing.T) {
-
 	testSlug := "vm_fracVcpu"
 	testName := testAccGetTestName(testSlug)
 	resource.ParallelTest(t, resource.TestCase{
@@ -354,7 +350,6 @@ func testAccCheckVirtualMachineDestroy(s *terraform.State) error {
 }
 
 func TestAccNetboxVirtualMachine_tags(t *testing.T) {
-
 	testSlug := "vm_tags"
 	testName := testAccGetTestName(testSlug)
 	resource.ParallelTest(t, resource.TestCase{
@@ -424,6 +419,29 @@ resource "netbox_virtual_machine" "test" {
 }`, testName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "custom_fields.custom_field", "76"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetboxVirtualMachine_localContext(t *testing.T) {
+	testSlug := "vm_lc"
+	testName := testAccGetTestName(testSlug)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxVirtualMachineFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_virtual_machine" "test" {
+  name               = "%[1]s"
+  cluster_id         = netbox_cluster.test.id
+  site_id            = netbox_site.test.id
+  local_context_data = jsonencode({"context_string"="context_value"})
+  }`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "local_context_data", "{\"context_string\":\"context_value\"}"),
 				),
 			},
 		},


### PR DESCRIPTION
Originally checked in under another pull request, this is the newly entered change complete with documentation and testing. The tests have passed and the documentation follows current standards. There is no "DataSource" update because the data source already has "local_context_data".

Modifications elsewhere in the file are from a "make fmt" run that was done before check-in.