### PR TITLE
feat: support primary ips for devices

### DIFF
--- a/netbox/provider.go
+++ b/netbox/provider.go
@@ -79,6 +79,7 @@ func Provider() *schema.Provider {
 			"netbox_prefix":               resourceNetboxPrefix(),
 			"netbox_available_prefix":     resourceNetboxAvailablePrefix(),
 			"netbox_primary_ip":           resourceNetboxPrimaryIP(),
+			"netbox_device_primary_ip":    resourceNetboxDevicePrimaryIP(),
 			"netbox_device_role":          resourceNetboxDeviceRole(),
 			"netbox_tag":                  resourceNetboxTag(),
 			"netbox_cluster_group":        resourceNetboxClusterGroup(),

--- a/netbox/resource_netbox_device_primary_ip.go
+++ b/netbox/resource_netbox_device_primary_ip.go
@@ -1,0 +1,197 @@
+package netbox
+
+import (
+	"strconv"
+
+	"github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/dcim"
+	"github.com/fbreckle/go-netbox/netbox/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceNetboxDevicePrimaryIP() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetboxDevicePrimaryIPCreate,
+		Read:   resourceNetboxDevicePrimaryIPRead,
+		Update: resourceNetboxDevicePrimaryIPUpdate,
+		Delete: resourceNetboxDevicePrimaryIPDelete,
+
+		Description: `:meta:subcategory:Data Center Inventory Management (DCIM):This resource is used to define the primary IP for a given device. The primary IP is reflected in the device Netbox UI, which identifies the Primary IPv4 and IPv6 addresses.`,
+
+		Schema: map[string]*schema.Schema{
+			"device_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"ip_address_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"ip_address_version": {
+				Type:         schema.TypeInt,
+				ValidateFunc: validation.IntInSlice([]int{4, 6}),
+				Optional:     true,
+				Default:      4,
+			},
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+	}
+}
+
+func resourceNetboxDevicePrimaryIPCreate(d *schema.ResourceData, m interface{}) error {
+	d.SetId(strconv.Itoa(d.Get("device_id").(int)))
+
+	return resourceNetboxDevicePrimaryIPUpdate(d, m)
+}
+
+func resourceNetboxDevicePrimaryIPRead(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+	id, _ := strconv.ParseInt(d.Id(), 10, 64)
+	params := dcim.NewDcimDevicesReadParams().WithID(id)
+
+	res, err := api.Dcim.DcimDevicesRead(params, nil)
+	if err != nil {
+		if errresp, ok := err.(*dcim.DcimDevicesReadDefault); ok {
+			errorcode := errresp.Code()
+			if errorcode == 404 {
+				// If the ID is updated to blank, this tells Terraform the resource no longer exists (maybe it was destroyed out of band). Just like the destroy callback, the Read function should gracefully handle this case. https://www.terraform.io/docs/extend/writing-custom-providers.html
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+
+	IPAddressVersion := d.Get("ip_address_version")
+	d.Set("ip_address_version", IPAddressVersion)
+
+	if IPAddressVersion == 4 && res.GetPayload().PrimaryIp4 != nil {
+		d.Set("ip_address_id", res.GetPayload().PrimaryIp4.ID)
+	} else if IPAddressVersion == 6 && res.GetPayload().PrimaryIp6 != nil {
+		d.Set("ip_address_id", res.GetPayload().PrimaryIp6.ID)
+	} else {
+		// if the device exists, but has no primary ip, consider this element deleted
+		d.SetId("")
+		return nil
+	}
+	d.Set("device_id", res.GetPayload().ID)
+	return nil
+}
+
+func resourceNetboxDevicePrimaryIPUpdate(d *schema.ResourceData, m interface{}) error {
+	api := m.(*client.NetBoxAPI)
+
+	deviceID := int64(d.Get("device_id").(int))
+	IPAddressID := int64(d.Get("ip_address_id").(int))
+	IPAddressVersion := int64(d.Get("ip_address_version").(int))
+
+	// because the go-netbox library does not have patch support atm, we have to get the whole object and re-put it
+
+	// first, get the device
+	readParams := dcim.NewDcimDevicesReadParams().WithID(deviceID)
+	res, err := api.Dcim.DcimDevicesRead(readParams, nil)
+	if err != nil {
+		return err
+	}
+
+	device := res.GetPayload()
+
+	// then update the FULL device with ALL tracked attributes
+	data := models.WritableDeviceWithConfigContext{}
+	data.Name = device.Name
+	data.Tags = device.Tags
+	// the netbox API sends the URL property as part of NestedTag, but it does not accept the URL property when we send it back
+	// so set it to empty
+	// display too
+	for _, tag := range data.Tags {
+		tag.URL = ""
+		tag.Display = ""
+	}
+
+	data.Comments = device.Comments
+	data.Serial = device.Serial
+
+	if device.DeviceType != nil {
+		data.DeviceType = &device.DeviceType.ID
+	}
+
+	if device.Cluster != nil {
+		data.Cluster = &device.Cluster.ID
+	}
+
+	if device.Site != nil {
+		data.Site = &device.Site.ID
+	}
+
+	if device.Location != nil {
+		data.Location = &device.Location.ID
+	}
+
+	if device.DeviceRole != nil {
+		data.DeviceRole = &device.DeviceRole.ID
+	}
+
+	if device.PrimaryIp4 != nil {
+		data.PrimaryIp4 = &device.PrimaryIp4.ID
+	}
+
+	if device.PrimaryIp6 != nil {
+		data.PrimaryIp6 = &device.PrimaryIp6.ID
+	}
+
+	if device.Platform != nil {
+		data.Platform = &device.Platform.ID
+	}
+
+	if device.Tenant != nil {
+		data.Tenant = &device.Tenant.ID
+	}
+
+	if device.Status != nil {
+		data.Status = *device.Status.Value
+	}
+
+	if device.Rack != nil {
+		data.Rack = &device.Rack.ID
+	}
+
+	if device.Face != nil {
+		data.Face = *device.Face.Value
+	}
+
+	if device.Position != nil {
+		data.Position = device.Position
+	}
+
+	// unset primary ip address if -1 is passed as id
+	if IPAddressID == -1 {
+		if IPAddressVersion == 4 {
+			data.PrimaryIp4 = nil
+		} else {
+			data.PrimaryIp6 = nil
+		}
+	} else {
+		if IPAddressVersion == 4 {
+			data.PrimaryIp4 = &IPAddressID
+		} else {
+			data.PrimaryIp6 = &IPAddressID
+		}
+	}
+
+	updateParams := dcim.NewDcimDevicesUpdateParams().WithID(deviceID).WithData(&data)
+
+	_, err = api.Dcim.DcimDevicesUpdate(updateParams, nil)
+	if err != nil {
+		return err
+	}
+	return resourceNetboxDevicePrimaryIPRead(d, m)
+}
+
+func resourceNetboxDevicePrimaryIPDelete(d *schema.ResourceData, m interface{}) error {
+	// Set ip_address_id to minus one and go to update. Update will set nil
+	d.Set("ip_address_id", -1)
+	return resourceNetboxDevicePrimaryIPUpdate(d, m)
+}

--- a/netbox/resource_netbox_device_primary_ip_test.go
+++ b/netbox/resource_netbox_device_primary_ip_test.go
@@ -1,0 +1,177 @@
+package netbox
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func testAccNetboxDevicePrimaryIPFullDependencies(testName string) string {
+	return fmt.Sprintf(`
+resource "netbox_tag" "test" {
+  name = "%[1]s"
+}
+
+resource "netbox_cluster_type" "test" {
+  name = "%[1]s"
+}
+
+resource "netbox_cluster" "test" {
+  name = "%[1]s"
+  cluster_type_id = netbox_cluster_type.test.id
+  site_id = netbox_site.test.id
+}
+
+resource "netbox_platform" "test" {
+  name = "%[1]s"
+}
+
+resource "netbox_tenant" "test" {
+  name = "%[1]s"
+}
+
+resource "netbox_device_role" "test" {
+  name = "%[1]s"
+  color_hex = "123456"
+}
+
+resource "netbox_manufacturer" "test" {
+  name = "%[1]s"
+}
+
+resource "netbox_device_type" "test" {
+  model = "%[1]s"
+  manufacturer_id = netbox_manufacturer.test.id
+}
+
+resource "netbox_location" "test" {
+	name = "%[1]s"
+	site_id =netbox_site.test.id
+}
+
+resource "netbox_rack" "test" {
+  name = "%[1]s"
+	site_id = netbox_site.test.id
+	status = "reserved"
+	width = 19
+	u_height = 48
+	tenant_id = netbox_tenant.test.id
+	location_id = netbox_location.test.id
+}
+
+resource "netbox_device" "test" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+	tenant_id = netbox_tenant.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+	platform_id = netbox_platform.test.id
+	location_id = netbox_location.test.id
+	comments = "thisisacomment"
+	status = "planned"
+	rack_id = netbox_rack.test.id
+	rack_face = "front"
+	rack_position = 10
+
+	tags = [netbox_tag.test.name]
+}
+
+resource "netbox_site" "test" {
+  name = "%[1]s"
+  status = "active"
+}
+
+resource "netbox_device_interface" "test" {
+  device_id = netbox_device.test.id
+  name = "%[1]s"
+	type = "1000base-t"
+}
+
+resource "netbox_ip_address" "test_v4" {
+  ip_address = "1.1.1.1/32"
+  status = "active"
+  interface_id = netbox_device_interface.test.id
+	object_type = "dcim.interface"
+}
+
+resource "netbox_ip_address" "test_v6" {
+  ip_address = "2000::1/128"
+  status = "active"
+  interface_id = netbox_device_interface.test.id
+	object_type = "dcim.interface"
+}
+`, testName)
+}
+
+func TestAccNetboxDevicePrimaryIP4_basic(t *testing.T) {
+
+	testSlug := "pr_ip_basic"
+	testName := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + `
+resource "netbox_device_primary_ip" "test_v4" {
+  device_id = netbox_device.test.id
+  ip_address_id = netbox_ip_address.test_v4.id
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4", "device_id", "netbox_device.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4", "ip_address_id", "netbox_ip_address.test_v4", "id"),
+
+					resource.TestCheckResourceAttr("netbox_device.test", "name", testName),
+					resource.TestCheckResourceAttrPair("netbox_device.test", "cluster_id", "netbox_cluster.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test", "tenant_id", "netbox_tenant.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test", "platform_id", "netbox_platform.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test", "location_id", "netbox_location.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test", "role_id", "netbox_device_role.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test", "site_id", "netbox_site.test", "id"),
+					resource.TestCheckResourceAttr("netbox_device.test", "comments", "thisisacomment"),
+					resource.TestCheckResourceAttr("netbox_device.test", "tags.#", "1"),
+					resource.TestCheckResourceAttr("netbox_device.test", "tags.0", testName),
+					resource.TestCheckResourceAttr("netbox_device.test", "status", "planned"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetboxDevicePrimaryIP6_basic(t *testing.T) {
+
+	testSlug := "pr_ip_basic"
+	testName := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + `
+resource "netbox_device_primary_ip" "test_v6" {
+  device_id = netbox_device.test.id
+  ip_address_id = netbox_ip_address.test_v6.id
+  ip_address_version = 6
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v6", "device_id", "netbox_device.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v6", "ip_address_id", "netbox_ip_address.test_v6", "id"),
+
+					resource.TestCheckResourceAttr("netbox_device.test", "name", testName),
+					resource.TestCheckResourceAttrPair("netbox_device.test", "cluster_id", "netbox_cluster.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test", "tenant_id", "netbox_tenant.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test", "platform_id", "netbox_platform.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test", "location_id", "netbox_location.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test", "role_id", "netbox_device_role.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test", "site_id", "netbox_site.test", "id"),
+					resource.TestCheckResourceAttr("netbox_device.test", "comments", "thisisacomment"),
+					resource.TestCheckResourceAttr("netbox_device.test", "tags.#", "1"),
+					resource.TestCheckResourceAttr("netbox_device.test", "tags.0", testName),
+					resource.TestCheckResourceAttr("netbox_device.test", "status", "planned"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
In a similar way as netbox_device_interface, add a dedicated resource to be able to set the primary ipv4/6 address on devices.

This resource is mostly a copy of the netbox_primary_ip resource, but adjusted for devices.