### PR TITLE
Prefixes filter improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-openapi/strfmt v0.21.7
 	github.com/goware/urlx v0.3.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0
+	github.com/iancoleman/strcase v0.2.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=

--- a/netbox/data_source_netbox_prefixes.go
+++ b/netbox/data_source_netbox_prefixes.go
@@ -121,6 +121,12 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 				} else {
 					params.Tag = append(params.Tag, vString)
 				}
+			case "tag__n":
+				params.Tagn = &vString
+			case "mask_length":
+				params.MaskLength = &vString
+			case "children__lt":
+				params.ChildrenLt = &vString
 			default:
 				return fmt.Errorf("'%s' is not a supported filter parameter", k)
 			}

--- a/netbox/data_source_netbox_prefixes.go
+++ b/netbox/data_source_netbox_prefixes.go
@@ -116,7 +116,11 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 			case "site_id":
 				params.SiteID = &vString
 			case "tag":
-				params.Tag = []string{vString}
+				if params.Tag == nil {
+					params.Tag = []string{vString}
+				} else {
+					params.Tag = append(params.Tag, vString)
+				}
 			default:
 				return fmt.Errorf("'%s' is not a supported filter parameter", k)
 			}


### PR DESCRIPTION
Enables all standard fields in the prefixes API within the data. netbox_prefixes datasource.  this also includes allowing multiple tags to be specified.

Notably, custom fields are still not supported, which will be more complex to implement.