### PR TITLE
feat: add family filter to netbox_prefix data source

### DIFF
--- a/docs/data-sources/prefix.md
+++ b/docs/data-sources/prefix.md
@@ -17,17 +17,18 @@ description: |-
 
 ### Optional
 
-- `cidr` (String, Deprecated) At least one of `description`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given. Conflicts with `prefix`.
-- `description` (String) Description to include in the data source filter. At least one of `description`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given.
-- `prefix` (String) At least one of `description`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given. Conflicts with `cidr`.
-- `site_id` (Number) At least one of `description`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given.
-- `tag` (String) Tag to include in the data source filter (must match the tag's slug). At least one of `description`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given.
+- `cidr` (String, Deprecated) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given. Conflicts with `prefix`.
+- `description` (String) Description to include in the data source filter. At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given.
+- `family` (Number) The IP family of the prefix. One of 4 or 6. At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given.
+- `prefix` (String) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given. Conflicts with `cidr`.
+- `site_id` (Number) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given.
+- `tag` (String) Tag to include in the data source filter (must match the tag's slug). At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given.
 - `tag__n` (String) Tag to exclude from the data source filter (must match the tag's slug).
 Refer to [Netbox's documentation](https://demo.netbox.dev/static/docs/rest-api/filtering/#lookup-expressions)
 for more information on available lookup expressions.
-- `vlan_id` (Number) At least one of `description`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given.
-- `vlan_vid` (Number) At least one of `description`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given.
-- `vrf_id` (Number) At least one of `description`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given.
+- `vlan_id` (Number) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given.
+- `vlan_vid` (Number) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given.
+- `vrf_id` (Number) At least one of `description`, `family`, `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `site_id`, `cidr` or `tag` must be given.
 
 ### Read-Only
 

--- a/netbox/data_source_netbox_prefix.go
+++ b/netbox/data_source_netbox_prefix.go
@@ -25,47 +25,55 @@ func dataSourceNetboxPrefix() *schema.Resource {
 				Deprecated:    "The `cidr` parameter is deprecated in favor of the canonical `prefix` attribute.",
 				ConflictsWith: []string{"prefix"},
 				ValidateFunc:  validation.IsCIDR,
-				AtLeastOneOf:  []string{"description", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf:  []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
 			},
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				AtLeastOneOf: []string{"description", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
 				Description:  "Description to include in the data source filter.",
+			},
+			"family": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				ValidateFunc: validation.IntInSlice([]int{4, 6}),
+				Description:  "The IP family of the prefix. One of 4 or 6",
 			},
 			"prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ValidateFunc:  validation.IsCIDR,
 				ConflictsWith: []string{"cidr"},
-				AtLeastOneOf:  []string{"description", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf:  []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
 			},
 			"vlan_vid": {
 				Type:         schema.TypeFloat,
 				Optional:     true,
-				AtLeastOneOf: []string{"description", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
 				ValidateFunc: validation.FloatBetween(1, 4094),
 			},
 			"vrf_id": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				AtLeastOneOf: []string{"description", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
 			},
 			"vlan_id": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				AtLeastOneOf: []string{"description", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
 			},
 			"site_id": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				AtLeastOneOf: []string{"description", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
 			},
 			"tag": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				AtLeastOneOf: []string{"description", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
 				Description:  "Tag to include in the data source filter (must match the tag's slug).",
 			},
 			"tag__n": {
@@ -99,6 +107,11 @@ func dataSourceNetboxPrefixRead(d *schema.ResourceData, m interface{}) error {
 
 	if description, ok := d.Get("description").(string); ok && description != "" {
 		params.Description = &description
+	}
+
+	if family, ok := d.Get("family").(int); ok && family != 0 {
+		familyFloat := float64(family)
+		params.Family = &familyFloat
 	}
 
 	if prefix, ok := d.Get("prefix").(string); ok && prefix != "" {
@@ -146,6 +159,7 @@ func dataSourceNetboxPrefixRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("prefix", result.Prefix)
 	d.Set("status", result.Status.Value)
 	d.Set("description", result.Description)
+	d.Set("family", int(*result.Family.Value))
 	d.Set("tags", getTagListFromNestedTagList(result.Tags))
 
 	if result.Vrf != nil {

--- a/netbox/data_source_netbox_prefix_test.go
+++ b/netbox/data_source_netbox_prefix_test.go
@@ -9,7 +9,8 @@ import (
 
 func TestAccNetboxPrefixDataSource_basic(t *testing.T) {
 
-	testPrefix := "10.0.0.0/24"
+	testv4Prefix := "10.0.0.0/24"
+	testv6Prefix := "2000::/64"
 	testSlug := "prefix_ds_basic"
 	testVlanVid := 4090
 	testName := testAccGetTestName(testSlug)
@@ -24,64 +25,84 @@ resource "netbox_vrf" "test" {
 
 resource "netbox_vlan" "test" {
   name = "%[1]s_vlan_test_id"
-  vid  = %[3]d
+  vid  = %[4]d
 }
 
 resource "netbox_site" "test" {
   name = "%[1]s_site"
 }
 
-resource "netbox_prefix" "test" {
+resource "netbox_prefix" "testv4" {
   prefix = "%[2]s"
   status = "active"
   vrf_id = netbox_vrf.test.id
   vlan_id = netbox_vlan.test.id
   site_id = netbox_site.test.id
-  description = "%[1]s_description_test_id"
+  description = "%[1]s_description_test_idv4"
+}
+
+resource "netbox_prefix" "testv6" {
+  prefix = "%[3]s"
+  status = "active"
+  vrf_id = netbox_vrf.test.id
+  vlan_id = netbox_vlan.test.id
+  site_id = netbox_site.test.id
+  description = "%[1]s_description_test_idv6"
 }
 
 data "netbox_prefix" "by_description" {
-  description = netbox_prefix.test.description
+  description = netbox_prefix.testv4.description
 }
 
 data "netbox_prefix" "by_cidr" {
-  depends_on = [netbox_prefix.test]
+  depends_on = [netbox_prefix.testv4]
   cidr = "%[2]s"
 }
 
 data "netbox_prefix" "by_vrf_id" {
-  depends_on = [netbox_prefix.test]
+  depends_on = [netbox_prefix.testv4]
   vrf_id = netbox_vrf.test.id
+  family = 4
 }
 
 data "netbox_prefix" "by_vlan_id" {
-  depends_on = [netbox_prefix.test]
+  depends_on = [netbox_prefix.testv4]
   vlan_id = netbox_vlan.test.id
+  family  = 4
 }
 
 data "netbox_prefix" "by_vlan_vid" {
-  depends_on = [netbox_prefix.test]
-  vlan_vid = %[3]d
+  depends_on = [netbox_prefix.testv4]
+  vlan_vid = %[4]d
+  family   = 4
 }
 
 data "netbox_prefix" "by_prefix" {
-  depends_on = [netbox_prefix.test]
+  depends_on = [netbox_prefix.testv4]
   prefix = "%[2]s"
 }
 
 data "netbox_prefix" "by_site_id" {
-  depends_on = [netbox_prefix.test]
+  depends_on = [netbox_prefix.testv4]
   site_id = netbox_site.test.id
+  family  = 4
 }
-`, testName, testPrefix, testVlanVid),
+
+data "netbox_prefix" "by_family" {
+  depends_on = [netbox_prefix.testv6]
+	family     = 6
+}
+
+`, testName, testv4Prefix, testv6Prefix, testVlanVid),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_prefix", "id", "netbox_prefix.test", "id"),
-					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_description", "id", "netbox_prefix.test", "id"),
-					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_cidr", "id", "netbox_prefix.test", "id"),
-					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_vrf_id", "id", "netbox_prefix.test", "id"),
-					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_vlan_id", "id", "netbox_prefix.test", "id"),
-					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_vlan_vid", "id", "netbox_prefix.test", "id"),
-					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_site_id", "id", "netbox_prefix.test", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_prefix", "id", "netbox_prefix.testv4", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_description", "id", "netbox_prefix.testv4", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_cidr", "id", "netbox_prefix.testv4", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_vrf_id", "id", "netbox_prefix.testv4", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_vlan_id", "id", "netbox_prefix.testv4", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_vlan_vid", "id", "netbox_prefix.testv4", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_site_id", "id", "netbox_prefix.testv4", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_family", "id", "netbox_prefix.testv6", "id"),
 				),
 			},
 		},


### PR DESCRIPTION
Adds the ability for the `netbox_prefix` data source to filter by IP family (v4 or v6)

fix #398 