### PR TITLE
fix: netbox_permission plan constraint diff

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/e-breuninger/terraform-provider-netbox
 go 1.19
 
 require (
-	github.com/fbreckle/go-netbox v0.0.0-20230326103042-6505ee5a8182
+	github.com/fbreckle/go-netbox v0.0.0-20230720154332-dd0b7c4220dc
 	github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3
 	github.com/go-openapi/runtime v0.26.0
 	github.com/go-openapi/strfmt v0.21.7

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
-github.com/fbreckle/go-netbox v0.0.0-20230326103042-6505ee5a8182 h1:w93VlhspTdzC+sIl9BmOke6R3iPKLIk+4fTO3K4j9Bg=
-github.com/fbreckle/go-netbox v0.0.0-20230326103042-6505ee5a8182/go.mod h1:3U3/m/hna9Ntd3sbHBYwZ1IqbP2+coRzoXw3mCfu3kM=
+github.com/fbreckle/go-netbox v0.0.0-20230720154332-dd0b7c4220dc h1:DL0GXuJGsR7FMUhzS7DQQl/PYBZ9ADNnH+uGQQ4itYw=
+github.com/fbreckle/go-netbox v0.0.0-20230720154332-dd0b7c4220dc/go.mod h1:3U3/m/hna9Ntd3sbHBYwZ1IqbP2+coRzoXw3mCfu3kM=
 github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3 h1:DMSpM0btVedE2Tt1vfDHWQhf2obzjAe1F0/j8/CyfW4=
 github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3/go.mod h1:j3HmJySEjx6hOAOPDjGzmzpVNDQq9SNnnF+Vm22d2rs=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=

--- a/netbox/resource_netbox_permission.go
+++ b/netbox/resource_netbox_permission.go
@@ -77,7 +77,6 @@ func resourceNetboxPermission() *schema.Resource {
 				Description: "A JSON string of an arbitrary filter used to limit the granted action(s) to a specific subset of objects. " +
 					"For more information on correct syntax, see https://docs.netbox.dev/en/stable/administration/permissions/#constraints ",
 				Optional:     true,
-				Default:      nil,
 				ValidateFunc: validation.StringIsJSON,
 			},
 		},
@@ -164,6 +163,11 @@ func resourceNetboxPermissionRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("users", users)
 
 	d.Set("actions", res.GetPayload().Actions)
+
+	if res.GetPayload().Constraints == nil {
+		d.Set("constraints", "")
+		return nil
+	}
 
 	b, err := json.Marshal(res.GetPayload().Constraints)
 	if err != nil {

--- a/netbox/resource_netbox_permission_test.go
+++ b/netbox/resource_netbox_permission_test.go
@@ -55,6 +55,36 @@ resource "netbox_permission" "test_basic" {
 	})
 }
 
+func TestAccNetboxPermission_noConstraint(t *testing.T) {
+	testSlug := "user_perms_nocnstrnt"
+	testName := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_permission" "test_basic" {
+  name = "%s"
+  description = "This is a terraform test."
+  enabled = true
+  object_types = ["ipam.prefix"]
+  actions = ["add", "change"]
+  users = [1]
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_permission.test_basic", "name", testName),
+				),
+			},
+			{
+				ResourceName:      "netbox_permission.test_basic",
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
 func init() {
 	resource.AddTestSweepers("netbox_permission", &resource.Sweeper{
 		Name:         "netbox_permission",


### PR DESCRIPTION
Every run of the `netbox_permission` resource when there was no
constraint set would output the following diff:
```
netbox_permission.ipaddress_rw_permission will be updated in-place
  ~ resource "netbox_permission" "ipaddress_rw_permission" {
      - constraints  = "null" -> null
        id           = "3"
        name         = "ipaddress_rw_permissions"
```

There are inherently two issues that cause the problem. We cannot null
the field, because of the issue fixed here:
https://github.com/fbreckle/go-netbox/pull/30

Second, want the constraint field to be set to an empty string when
a read of constraint is empty. So we check if nil, and if so we
set constraint to "", and then return the function. Otherwise, we
Marshal it to JSON to fill the tf state.