### PR TITLE
fix: add vm context field to primary_ip update func

### DIFF
--- a/netbox/resource_netbox_primary_ip.go
+++ b/netbox/resource_netbox_primary_ip.go
@@ -147,6 +147,10 @@ func resourceNetboxPrimaryIPUpdate(d *schema.ResourceData, m interface{}) error 
 		data.Device = &vm.Device.ID
 	}
 
+	if vm.LocalContextData != nil {
+		data.LocalContextData = vm.LocalContextData
+	}
+
 	// unset primary ip address if -1 is passed as id
 	if IPAddressID == -1 {
 		if IPAddressVersion == 4 {

--- a/netbox/resource_netbox_primary_ip_test.go
+++ b/netbox/resource_netbox_primary_ip_test.go
@@ -71,6 +71,7 @@ resource "netbox_virtual_machine" "test" {
   vcpus = "4"
   status = "planned"
   device_id = netbox_device.test.id
+  local_context_data = jsonencode({"context_string"="context_value"})
 
   tags = [netbox_tag.test.name]
 }
@@ -125,6 +126,7 @@ resource "netbox_primary_ip" "test_v4" {
 					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "tags.#", "1"),
 					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "tags.0", testName),
 					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "status", "planned"),
+					resource.TestCheckResourceAttr("netbox_virtual_machine.test", "local_context_data", "{\"context_string\":\"context_value\"}"),
 				),
 			},
 		},


### PR DESCRIPTION
When the local context was added to the vm resource, the fields were not added to the primary ip update function, which caused the local context field to be unset when the `resource_netbox_primary_ip` resource was used.