### PR TITLE
Overhaul Custom Fields for Devices to support any underlying type

### DIFF
--- a/docs/data-sources/devices.md
+++ b/docs/data-sources/devices.md
@@ -45,6 +45,7 @@ Read-Only:
 - `comments` (String)
 - `custom_fields` (Map of String)
 - `description` (String)
+- `custom_fields` (String)
 - `device_id` (Number)
 - `device_type_id` (Number)
 - `location_id` (Number)

--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -64,6 +64,7 @@ resource "netbox_device" "test" {
 - `custom_fields` (Map of String)
 - `description` (String)
 - `local_context_data` (String) This is best managed through the use of `jsonencode` and a map of settings.
+- `custom_fields` (String) A JSON string that defines the custom fields as defined under the `custom_fields` key in the object's api.This is best managed with the `jsonencode()` & `jsondecode()` functions.
 - `location_id` (Number)
 - `platform_id` (Number)
 - `rack_face` (String) Valid values are `front` and `rear`. Required when `rack_position` is set.

--- a/netbox/custom_fields.go
+++ b/netbox/custom_fields.go
@@ -1,7 +1,11 @@
 package netbox
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 const customFieldsKey = "custom_fields"
@@ -22,4 +26,83 @@ func getCustomFields(cf interface{}) map[string]interface{} {
 		return nil
 	}
 	return cfm
+}
+
+// customFieldsSchemaFunc is a function that returns the schema for all custom
+// fields.
+func customFieldsSchemaFunc() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		Description: "A JSON string that defines the custom fields as defined under the `custom_fields` key in the object's api." +
+			"This is best managed with the `jsonencode()` & `jsondecode()` functions.",
+		ValidateFunc: validation.StringIsJSON,
+	}
+}
+
+// handleCustomFieldUpdate is a function that takes in the old and new values returned
+// from a terraform d.GetChange() function and returns a map with the values to be sent
+// in the custom_fields field on an update to the netbox api.
+// This function handles setting the custom_field fields to null when needed. It does
+// this by comparing the custom fields that were previously in terraform state, and
+// compares them with then new state. It then sets any fields that were previously
+// set to nil, if the new state does not include them.
+func handleCustomFieldUpdate(old, new interface{}) (map[string]interface{}, error) {
+	ret := make(map[string]interface{})
+	var newData map[string]interface{}
+
+	if new.(string) != "" {
+		err := json.Unmarshal([]byte(new.(string)), &newData)
+		if err != nil {
+			return nil, fmt.Errorf("err1: %w", err)
+		}
+		for k, v := range newData {
+			ret[k] = v
+		}
+	}
+	var oldData map[string]interface{}
+	if old.(string) != "" {
+		err := json.Unmarshal([]byte(old.(string)), &oldData)
+		if err != nil {
+			return nil, fmt.Errorf("err2: %w", err)
+		}
+		for k := range oldData {
+			if val, ok := ret[k]; !ok {
+				ret[k] = nil
+			} else {
+				ret[k] = val
+			}
+		}
+	}
+	return ret, nil
+}
+
+// handleCustomFieldRead is a function that take an input of the interface
+// from the CustomField struct field, and returns a string with the value
+// to set for terraform and an error.
+// This function checks the number of keys in the map, and if the number of
+// nil fields equal the number of fields, it returns an empty string. Since
+// this means the custom fields are not managed. Otherwise, it will return
+// the result of unmarshalling the field to a json string.
+// This allows the custom_field field to be set to empty and have an empty plan
+// even though the api still has the custom fields with null values.
+func handleCustomFieldRead(cf interface{}) (string, error) {
+	cfMap, ok := cf.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("cannot cast %v to map[string]interface{}", cf)
+	}
+	numNull := 0
+	for k := range cfMap {
+		if cfMap[k] == nil {
+			numNull += 1
+		}
+	}
+	if len(cfMap) == 0 || numNull == len(cfMap) {
+		return "", nil
+	}
+	b, err := json.Marshal(cf)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }

--- a/netbox/custom_fields_test.go
+++ b/netbox/custom_fields_test.go
@@ -1,0 +1,118 @@
+package netbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_handleCustomFieldUpdate(t *testing.T) {
+	type args struct {
+		old interface{}
+		new interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]interface{}
+		wantErr bool
+	}{
+		{
+			name: "create new custom field",
+			args: args{
+				old: "",
+				new: "{\"a\": \"b\", \"c\": true, \"d\": {\"e\": \"f\"}}",
+			},
+			want: map[string]interface{}{
+				"a": "b",
+				"c": true,
+				"d": map[string]interface{}{
+					"e": "f",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "update custom fields",
+			args: args{
+				old: "{\"a\": \"b\", \"c\": true, \"d\": {\"e\": \"f\"}}",
+				new: "{\"a\": \"q\", \"c\": false}",
+			},
+			want: map[string]interface{}{
+				"a": "q",
+				"c": false,
+				"d": nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "remove custom fields",
+			args: args{
+				old: "{\"a\": \"b\", \"c\": true, \"d\": {\"e\": \"f\"}}",
+				new: "",
+			},
+			want: map[string]interface{}{
+				"a": nil,
+				"c": nil,
+				"d": nil,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := handleCustomFieldUpdate(tt.args.old, tt.args.new)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handleCustomFieldUpdate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_handleCustomFieldRead(t *testing.T) {
+	tests := []struct {
+		name    string
+		cf      interface{}
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "all fields are nil",
+			cf: map[string]interface{}{
+				"a": nil,
+				"c": nil,
+				"d": nil,
+			},
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "one field is valid",
+			cf: map[string]interface{}{
+				"a": nil,
+				"c": true,
+				"d": nil,
+			},
+			want:    "{\"a\":null,\"c\":true,\"d\":null}",
+			wantErr: false,
+		},
+		{
+			name:    "cannot marshal nil",
+			cf:      nil,
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := handleCustomFieldRead(tt.cf)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handleCustomFieldRead() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/netbox/data_source_netbox_devices.go
+++ b/netbox/data_source_netbox_devices.go
@@ -64,8 +64,10 @@ func dataSourceNetboxDevices() *schema.Resource {
 							Computed: true,
 						},
 						"custom_fields": {
-							Type:     schema.TypeMap,
+							Type:     schema.TypeString,
 							Computed: true,
+							Description: "A JSON string that defines the custom fields as defined under the `custom_fields` key in the object's api." +
+								"The data can be accessed by using the `jsondecode()` function around the `custom_fields` attribute.",
 						},
 						"description": {
 							Type:     schema.TypeString,
@@ -268,9 +270,11 @@ func dataSourceNetboxDevicesRead(d *schema.ResourceData, m interface{}) error {
 		if device.Status != nil {
 			mapping["status"] = *device.Status.Value
 		}
-		if device.CustomFields != nil {
-			mapping["custom_fields"] = device.CustomFields
+		cf, err := handleCustomFieldRead(device.CustomFields)
+		if err != nil {
+			return err
 		}
+		mapping["custom_fields"] = cf
 		if device.Rack != nil {
 			mapping["rack_id"] = device.Rack.ID
 		}


### PR DESCRIPTION
## feat: allow any custom field type in netbox_device

Updates the `netbox_device` resource to allow for any custom field
type to be set. This is done by using a string field with the
`jsonencode()` and `jsondecode()` terraform functions.

This allows for any complex custom fields or data types that are needed,
since the underlying types don't matter and are unmarshalled using
map[string]interface{}.

To set custom fields using this new method, use the following syntax.

```terraform
resource "netbox_device" "test" {
  name = "device1"
  tenant_id = netbox_tenant.test.id
  role_id = netbox_device_role.test.id
  device_type_id = netbox_device_type.test.id
  site_id = netbox_site.test.id
	custom_fields = jsonencode({
		"text_field" = "81"
		"bool_field" = true
	})
}
```

## feat: allow any custom field type in netbox_devices data source

Update the data source `netbox_devices` to use the string based
schema for the `custom_fields` attribute.

This allows for any underlying type to be accessed by using the
`jsondecode()` terraform function.

For example, to access custom fields, the following code can be used.

```terraform
data "netbox_devices" "test" {
	filter {
		name  = "name"
		value = "device1"
	}
}

output "device_field" {
	value = jsondecode(data.netbox_devices.test[0].custom_fields).field1
}
```
## feat: Add funcs for custom fields of any type

Create functions for overahauling custom fields to support multiple
underlying types.

Create function for the schema with using TypeString instead of
TypeMap. This allows for complex json types using jsonencode/jsondecode.

Create handleCustomFieldUpdate function and tests for it. This function
takes in the results of a `d.GetChange` funtion `old` & `new`, which
allows us to compare old and new values, and update the `custom_fields`
field in the api. Add unit test to validate functionality.

handleCustomFieldRead and tests were added to handle the reading of
custom fields and setting the field to "" if all the custom fields
are nil. Adds tests to validate the functionality.

**These changes may be breaking, however have not fully tested that part. Not sure how best to do so.**

Fixes #416 
Fixes #409 