### PR TITLE
Make MAC address checking case insensitive

### DIFF
--- a/netbox/resource_netbox_device_interface.go
+++ b/netbox/resource_netbox_device_interface.go
@@ -3,6 +3,7 @@ package netbox
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/fbreckle/go-netbox/netbox/client"
 	"github.com/fbreckle/go-netbox/netbox/client/dcim"
@@ -47,6 +48,10 @@ func resourceNetboxDeviceInterface() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.IsMACAddress,
 				ForceNew:     true,
+				// Netbox converts MAC addresses always to uppercase
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
 			},
 			"mgmtonly": {
 				Type:     schema.TypeBool,

--- a/netbox/resource_netbox_device_interface_test.go
+++ b/netbox/resource_netbox_device_interface_test.go
@@ -141,7 +141,8 @@ func TestAccNetboxDeviceInterface_basic(t *testing.T) {
 
 func TestAccNetboxDeviceInterface_opts(t *testing.T) {
 	testSlug := "iface_mac"
-	testMac := "00:01:02:03:04:05"
+	testMacUppercase := "0A:01:02:03:04:05"
+	testMacLowercase := "0a:01:02:03:04:05"
 	testName := testAccGetTestName(testSlug)
 	setUp := testAccNetboxDeviceInterfaceFullDependencies(testName)
 	resource.ParallelTest(t, resource.TestCase{
@@ -150,16 +151,22 @@ func TestAccNetboxDeviceInterface_opts(t *testing.T) {
 		CheckDestroy: testAccCheckDeviceInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: setUp + testAccNetboxDeviceInterfaceOpts(testName, testMac),
+				Config: setUp + testAccNetboxDeviceInterfaceOpts(testName, testMacLowercase),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_device_interface.test", "name", testName),
 					resource.TestCheckResourceAttr("netbox_device_interface.test", "type", "1000base-t"),
 					resource.TestCheckResourceAttr("netbox_device_interface.test", "description", testName),
 					resource.TestCheckResourceAttr("netbox_device_interface.test", "enabled", "true"),
 					resource.TestCheckResourceAttr("netbox_device_interface.test", "mgmtonly", "true"),
-					resource.TestCheckResourceAttr("netbox_device_interface.test", "mac_address", "00:01:02:03:04:05"),
+					resource.TestCheckResourceAttr("netbox_device_interface.test", "mac_address", "0a:01:02:03:04:05"),
 					resource.TestCheckResourceAttr("netbox_device_interface.test", "mtu", "1440"),
 					resource.TestCheckResourceAttrPair("netbox_device_interface.test", "device_id", "netbox_device.test", "id"),
+				),
+			},
+			{
+				Config: setUp + testAccNetboxDeviceInterfaceOpts(testName, testMacUppercase),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_device_interface.test", "mac_address", "0A:01:02:03:04:05"),
 				),
 			},
 			{

--- a/netbox/resource_netbox_interface.go
+++ b/netbox/resource_netbox_interface.go
@@ -3,6 +3,7 @@ package netbox
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"github.com/fbreckle/go-netbox/netbox/client"
 	"github.com/fbreckle/go-netbox/netbox/client/virtualization"
@@ -46,6 +47,10 @@ func resourceNetboxInterface() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.IsMACAddress,
+				// Netbox converts MAC addresses always to uppercase
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
 			},
 			"mode": {
 				Type:         schema.TypeString,


### PR DESCRIPTION
Since Netbox always converts MAC addresses to uppercase representation, this provider thinks there is an actual change and tries to recreate the interface, when given a lowercase MAC address.

By suppressing the diff, we ignore the diff for lowercase inputs.