### PR TITLE
Add support for custom fields in service resource

### DIFF
--- a/netbox/resource_netbox_service.go
+++ b/netbox/resource_netbox_service.go
@@ -55,6 +55,7 @@ func resourceNetboxService() *schema.Resource {
 					Type: schema.TypeInt,
 				},
 			},
+			customFieldsKey: customFieldsSchema,
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -94,6 +95,11 @@ func resourceNetboxServiceCreate(d *schema.ResourceData, m interface{}) error {
 	data.Tags = []*models.NestedTag{}
 	data.Ipaddresses = []int64{}
 
+	ct, ok := d.GetOk(customFieldsKey)
+	if ok {
+		data.CustomFields = ct
+	}
+
 	params := ipam.NewIpamServicesCreateParams().WithData(&data)
 	res, err := api.Ipam.IpamServicesCreate(params, nil)
 	if err != nil {
@@ -126,6 +132,11 @@ func resourceNetboxServiceRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("protocol", res.GetPayload().Protocol.Value)
 	d.Set("ports", res.GetPayload().Ports)
 	d.Set("virtual_machine_id", res.GetPayload().VirtualMachine.ID)
+
+	cf := getCustomFields(res.GetPayload().CustomFields)
+	if cf != nil {
+		d.Set(customFieldsKey, cf)
+	}
 
 	return nil
 }
@@ -160,6 +171,11 @@ func resourceNetboxServiceUpdate(d *schema.ResourceData, m interface{}) error {
 
 	dataVirtualMachineID := int64(d.Get("virtual_machine_id").(int))
 	data.VirtualMachine = &dataVirtualMachineID
+
+	cf, ok := d.GetOk(customFieldsKey)
+	if ok {
+		data.CustomFields = cf
+	}
 
 	params := ipam.NewIpamServicesUpdateParams().WithID(id).WithData(&data)
 	_, err := api.Ipam.IpamServicesUpdate(params, nil)


### PR DESCRIPTION
Adds support for custom fields on ipam service ressource.

I added a test for it, but i'm not sure it is enough:
```
make testacc
...
=== RUN   TestAccNetboxService_customFields
--- PASS: TestAccNetboxService_customFields (2.68s)
...
PASS
coverage: 73.6% of statements
ok  	command-line-arguments	214.713s	coverage: 73.6% of statements
```