### PR TITLE
Do not force recreation of device interface on MAC change

### DIFF
--- a/netbox/resource_netbox_device_interface.go
+++ b/netbox/resource_netbox_device_interface.go
@@ -47,7 +47,6 @@ func resourceNetboxDeviceInterface() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.IsMACAddress,
-				ForceNew:     true,
 				// Netbox converts MAC addresses always to uppercase
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return strings.EqualFold(old, new)


### PR DESCRIPTION
Forcing the recreating on device interface when the MAC is change causes all attached cables to be lost and is unnecessary. 