### PR TITLE
Fix validate custom_field on JSON value instead of label

### DIFF
--- a/netbox/resource_netbox_custom_field.go
+++ b/netbox/resource_netbox_custom_field.go
@@ -40,7 +40,7 @@ func resourceCustomField() *schema.Resource {
 					models.CustomFieldTypeValueURL,
 					models.CustomFieldTypeValueSelect,
 					models.CustomFieldTypeValueMultiselect,
-					models.CustomFieldTypeLabelJSON,
+					models.CustomFieldTypeValueJSON,
 				}, false),
 			},
 			"content_types": {

--- a/netbox/resource_netbox_custom_field_test.go
+++ b/netbox/resource_netbox_custom_field_test.go
@@ -36,6 +36,34 @@ resource "netbox_custom_field" "test" {
 	})
 }
 
+func TestAccNetboxCustomField_json(t *testing.T) {
+	testSlug := "custom_fields_json"
+	testName := strings.ReplaceAll(testAccGetTestName(testSlug), "-", "_")
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_custom_field" "test" {
+  name = "%s"
+  type = "json"
+  content_types = ["virtualization.vminterface"]
+  group_name = "mygroup"
+  weight = 100
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_custom_field.test", "name", testName),
+					resource.TestCheckResourceAttr("netbox_custom_field.test", "type", "json"),
+					resource.TestCheckTypeSetElemAttr("netbox_custom_field.test", "content_types.*", "virtualization.vminterface"),
+					resource.TestCheckResourceAttr("netbox_custom_field.test", "group_name", "mygroup"),
+					resource.TestCheckResourceAttr("netbox_custom_field.test", "weight", "100"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetboxCustomField_integer(t *testing.T) {
 	testSlug := "custom_fields_integer"
 	testName := strings.ReplaceAll(testAccGetTestName(testSlug), "-", "_")


### PR DESCRIPTION
Terraform validate currently only allows the labelJSON on custom_fields, which is 'JSON'. See example below:
```
$ terraform validate
│ Error: expected type to be one of [text integer boolean date url select multiselect JSON], got json
│ 
│   with netbox_custom_field
```

But the actual netbox API when deploying a custom_field is expecting the valueJSON 'json'. See example below:
```
│ Error: [POST /extras/custom-fields/][400] extras_custom-fields_create default  map[type:[JSON is not a valid choice.]]
│ 
│   with module.am_netbox_tenants.netbox_custom_field,
```

Looking also at the other validators on L36-L42, this seems like a typo/mistake