### PR TITLE
Add asset tags to netbox_device

### DIFF
--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -54,6 +54,7 @@ resource "netbox_device" "test" {
 
 ### Optional
 
+- `asset_tag` (String)
 - `cluster_id` (Number)
 - `comments` (String)
 - `custom_fields` (Map of String)

--- a/netbox/resource_netbox_device.go
+++ b/netbox/resource_netbox_device.go
@@ -67,6 +67,10 @@ func resourceNetboxDevice() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"asset_tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -123,6 +127,11 @@ func resourceNetboxDeviceCreate(ctx context.Context, d *schema.ResourceData, m i
 	if ok {
 		typeID := int64(typeIDValue.(int))
 		data.DeviceType = &typeID
+	}
+
+	if assetTagValue, ok := d.GetOk("asset_tag"); ok {
+		assetTag := string(assetTagValue.(string))
+		data.AssetTag = &assetTag
 	}
 
 	data.Comments = d.Get("comments").(string)
@@ -281,6 +290,8 @@ func resourceNetboxDeviceRead(ctx context.Context, d *schema.ResourceData, m int
 		d.Set(customFieldsKey, cf)
 	}
 
+	d.Set("asset_tag", device.AssetTag)
+
 	d.Set("comments", device.Comments)
 
 	d.Set("description", device.Description)
@@ -383,6 +394,16 @@ func resourceNetboxDeviceUpdate(ctx context.Context, d *schema.ResourceData, m i
 	}
 
 	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+
+	if d.HasChanges("asset_tag") {
+		if assetTagValue, ok := d.GetOk("asset_tag"); ok {
+			assetTag := assetTagValue.(string)
+			data.AssetTag = &assetTag
+		} else {
+			assetTag := " "
+			data.AssetTag = &assetTag
+		}
+	}
 
 	if d.HasChanges("comments") {
 		// check if comment is set

--- a/netbox/resource_netbox_device_test.go
+++ b/netbox/resource_netbox_device_test.go
@@ -93,6 +93,7 @@ func TestAccNetboxDevice_basic(t *testing.T) {
 				Config: testAccNetboxDeviceFullDependencies(testName) + fmt.Sprintf(`
 resource "netbox_device" "test" {
   name = "%[1]s"
+  asset_tag = "TAGGEDITAGGEDITAG"
   comments = "thisisacomment"
   description = "thisisadescription"
   tenant_id = netbox_tenant.test.id
@@ -105,9 +106,9 @@ resource "netbox_device" "test" {
   location_id = netbox_location.test.id
   status = "staged"
   serial = "ABCDEF"
-	rack_id = netbox_rack.test.id
-	rack_face = "front"
-	rack_position = 10
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 10
 }`, testName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_device.test", "name", testName),
@@ -118,6 +119,7 @@ resource "netbox_device" "test" {
 					resource.TestCheckResourceAttrPair("netbox_device.test", "site_id", "netbox_site.test", "id"),
 					resource.TestCheckResourceAttrPair("netbox_device.test", "cluster_id", "netbox_cluster.test", "id"),
 					resource.TestCheckResourceAttrPair("netbox_device.test", "rack_id", "netbox_rack.test", "id"),
+					resource.TestCheckResourceAttr("netbox_device.test", "asset_tag", "TAGGEDITAGGEDITAG"),
 					resource.TestCheckResourceAttr("netbox_device.test", "comments", "thisisacomment"),
 					resource.TestCheckResourceAttr("netbox_device.test", "description", "thisisadescription"),
 					resource.TestCheckResourceAttr("netbox_device.test", "status", "staged"),
@@ -132,6 +134,7 @@ resource "netbox_device" "test" {
 				Config: testAccNetboxDeviceFullDependencies(testName) + fmt.Sprintf(`
 resource "netbox_device" "test" {
   name = "%[1]s"
+  asset_tag = "TAGGEDITAGGEDITAG_TAGGEDITAGGEDITAGGEDITAG"
   comments = "thisisacomment"
   description = "thisisadescription"
   tenant_id = netbox_tenant.test.id
@@ -142,7 +145,7 @@ resource "netbox_device" "test" {
   site_id = netbox_site.test.id
   cluster_id = netbox_cluster.test.id
   location_id = netbox_location.test.id
-	rack_id = netbox_rack.test.id
+  rack_id = netbox_rack.test.id
   status = "staged"
   serial = "ABCDEF"
 }`, testName),
@@ -155,6 +158,7 @@ resource "netbox_device" "test" {
 					resource.TestCheckResourceAttrPair("netbox_device.test", "site_id", "netbox_site.test", "id"),
 					resource.TestCheckResourceAttrPair("netbox_device.test", "cluster_id", "netbox_cluster.test", "id"),
 					resource.TestCheckResourceAttrPair("netbox_device.test", "rack_id", "netbox_rack.test", "id"),
+					resource.TestCheckResourceAttr("netbox_device.test", "asset_tag", "TAGGEDITAGGEDITAG_TAGGEDITAGGEDITAGGEDITAG"),
 					resource.TestCheckResourceAttr("netbox_device.test", "comments", "thisisacomment"),
 					resource.TestCheckResourceAttr("netbox_device.test", "description", "thisisadescription"),
 					resource.TestCheckResourceAttr("netbox_device.test", "status", "staged"),
@@ -169,6 +173,7 @@ resource "netbox_device" "test" {
 				Config: testAccNetboxDeviceFullDependencies(testName) + fmt.Sprintf(`
 resource "netbox_device" "test" {
   name = "%[1]s"
+  asset_tag = "TAGGEDITAGGEDITAG"
   comments = "thisisacomment"
   description = "thisisadescription"
   tenant_id = netbox_tenant.test.id
@@ -190,6 +195,7 @@ resource "netbox_device" "test" {
 					resource.TestCheckResourceAttrPair("netbox_device.test", "role_id", "netbox_device_role.test", "id"),
 					resource.TestCheckResourceAttrPair("netbox_device.test", "site_id", "netbox_site.test", "id"),
 					resource.TestCheckResourceAttrPair("netbox_device.test", "cluster_id", "netbox_cluster.test", "id"),
+					resource.TestCheckResourceAttr("netbox_device.test", "asset_tag", "TAGGEDITAGGEDITAG"),
 					resource.TestCheckResourceAttr("netbox_device.test", "comments", "thisisacomment"),
 					resource.TestCheckResourceAttr("netbox_device.test", "description", "thisisadescription"),
 					resource.TestCheckResourceAttr("netbox_device.test", "status", "staged"),


### PR DESCRIPTION
This PR adds `asset_tag` to `netbox_device`. It also adds tests.

This PR replaces #373 

Fixes #353 