### PR TITLE
Actually set the `enabled` field for device_interface

### DIFF
--- a/netbox/resource_netbox_device_interface.go
+++ b/netbox/resource_netbox_device_interface.go
@@ -251,6 +251,10 @@ func resourceNetboxDeviceInterfaceUpdate(ctx context.Context, d *schema.Resource
 		Vdcs:         []int64{},
 	}
 
+	if d.HasChange("enabled") {
+		enabled := d.Get("enabled").(bool)
+		data.Enabled = enabled
+	}
 	if d.HasChange("mac_address") {
 		macAddress := d.Get("mac_address").(string)
 		data.MacAddress = &macAddress

--- a/netbox/resource_netbox_device_interface.go
+++ b/netbox/resource_netbox_device_interface.go
@@ -44,8 +44,8 @@ func resourceNetboxDeviceInterface() *schema.Resource {
 				Default:  true,
 			},
 			"lag_device_interface_id": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
 				Description: "If this device is a member of a LAG group, you can reference the LAG interface here.",
 			},
 			"mac_address": {
@@ -73,8 +73,8 @@ func resourceNetboxDeviceInterface() *schema.Resource {
 				ValidateFunc: validation.IntBetween(1, 65536),
 			},
 			"parent_device_interface_id": {
-				Type:     schema.TypeInt,
-				Optional: true,
+				Type:        schema.TypeInt,
+				Optional:    true,
 				Description: "The netbox_device_interface id of the parent interface. Useful if this interface is a logical interface.",
 			},
 			"speed": {


### PR DESCRIPTION
Previously, the netbox provider only set its internal state of the `enabled` field in `netbox_device_interface`. If interfaces got disabled via terraform configuration, it resulted in a never-finished state, since terraform's state never matched production.

Honestly the new tests cannot test the actual condition (because the tests do only check the terraform state and not the Netbox settings). I'm currently missing here some understanding to contact Netbox.