### PR TITLE
feat: add more filters on netbox_ip_addresses data resource

### DIFF
--- a/netbox/data_source_netbox_ip_addresses.go
+++ b/netbox/data_source_netbox_ip_addresses.go
@@ -162,6 +162,14 @@ func dataSourceNetboxIPAddressesRead(d *schema.ResourceData, m interface{}) erro
 				params.Address = &vString
 			case "vm_interface_id":
 				params.VminterfaceID = &vString
+			case "role":
+				params.Role = &vString
+			case "status":
+				params.Status = &vString
+			case "vrf":
+				params.Vrf = &vString
+			case "tenant":
+				params.Tenant = &vString
 			default:
 				return fmt.Errorf("'%s' is not a supported filter parameter", k)
 			}


### PR DESCRIPTION
A few Netbox attributes which are available to filter on was missing in this check.

This PR allows more attributes to be filtered on, which improves the usability of this data resource. 