### PR TITLE
feat: Support querying sites by facility

### DIFF
--- a/netbox/data_source_netbox_site.go
+++ b/netbox/data_source_netbox_site.go
@@ -27,6 +27,11 @@ func dataSourceNetboxSite() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"facility": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"asn_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -84,6 +89,9 @@ func dataSourceNetboxSiteRead(d *schema.ResourceData, m interface{}) error {
 	if id, ok := d.Get("id").(string); ok && id != "0" {
 		params.SetID(&id)
 	}
+	if facility, ok := d.Get("facility").(string); ok && facility != "" {
+		params.SetFacility(&facility)
+	}
 
 	res, err := api.Dcim.DcimSitesList(params, nil)
 	if err != nil {
@@ -103,6 +111,7 @@ func dataSourceNetboxSiteRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("site_id", site.ID)
 	d.Set("slug", site.Slug)
 	d.Set("time_zone", site.TimeZone)
+	d.Set("facility", site.Facility)
 
 	if site.Group != nil {
 		d.Set("group_id", site.Group.ID)

--- a/netbox/data_source_netbox_site_test.go
+++ b/netbox/data_source_netbox_site_test.go
@@ -34,6 +34,7 @@ resource "netbox_site" "test" {
   region_id = netbox_region.test.id
   tenant_id = netbox_tenant.test.id
   timezone = "Europe/Berlin"
+  facility = "Facility"
 }`, testName)
 }
 
@@ -60,6 +61,13 @@ func testAccNetboxSiteByID() string {
 	return `
 data "netbox_site" "test" {
   id = netbox_site.test.id
+}`
+}
+
+func testAccNetboxSiteByFacility() string {
+	return `
+data "netbox_site" "test" {
+  facility = netbox_site.test.facility
 }`
 }
 
@@ -100,6 +108,12 @@ func TestAccNetboxSiteDataSource_basic(t *testing.T) {
 			},
 			{
 				Config: setUp + testAccNetboxSiteByID(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("data.netbox_site.test", "id", "netbox_site.test", "id"),
+				),
+			},
+			{
+				Config: setUp + testAccNetboxSiteByFacility(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("data.netbox_site.test", "id", "netbox_site.test", "id"),
 				),


### PR DESCRIPTION
Add support for the facility field to the site datasource so that it can be used to find sites by facility if it's unique, or retrieve the facility for a site.