### PR TITLE
feat: support setting virtual_chassis on device

### DIFF
--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -73,6 +73,10 @@ resource "netbox_device" "test" {
 - `status` (String) Valid values are `offline`, `active`, `planned`, `staged`, `failed` and `inventory`. Defaults to `active`.
 - `tags` (Set of String)
 - `tenant_id` (Number)
+- `virtual_chassis_id` (Number) Required when `virtual_chassis_master` and `virtual_chassis_id` is set.
+- `virtual_chassis_master` (Boolean) Required when `virtual_chassis_master` and `virtual_chassis_id` is set.
+- `virtual_chassis_position` (Number)
+- `virtual_chassis_priority` (Number)
 
 ### Read-Only
 


### PR DESCRIPTION
This allows a device to be marked as part of a virtual chassis, it's position, priority, and whether it's the master or not.

Setting the master is done on the device itself to avoid circular dependencies (the device needing to know the virtual cluster and the cluster needing to know a device to set as master).

Updating the master device of a virtual chassis is ideally done with a PATCH request where only the id and the master are provided, but `WritableVirtualChassis` struct does handle that properly:

1. `Master` is a pointer with `omitempty` set, so you cannot send a json `null` value to remove it
2. `Name` and `Tags` do not have `omitempty`, so you always have to provide values for them (otherwise the API complains)

So for now, the entire virtual chassis is retrieved and updated with PUT instead.

A device that is marked as a master on a virtual chassis cannot be deleted, so before we can remove such a device, we remove it as a master from the virtual chassis (a chassis does not need to have a master), after which it can be properly removed.