### PR TITLE
fix: set virtual chassis master after setting vc

### DIFF
--- a/netbox/resource_netbox_device.go
+++ b/netbox/resource_netbox_device.go
@@ -518,6 +518,13 @@ func resourceNetboxDeviceUpdate(ctx context.Context, d *schema.ResourceData, m i
 		data.Serial = serial
 	}
 
+	params := dcim.NewDcimDevicesUpdateParams().WithID(id).WithData(&data)
+
+	_, err := api.Dcim.DcimDevicesUpdate(params, nil)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	if d.HasChange("virtual_chassis_master") && data.VirtualChassis != nil {
 		var err error
 		if vcMaster, ok := d.GetOk("virtual_chassis_master"); ok {
@@ -533,13 +540,6 @@ func resourceNetboxDeviceUpdate(ctx context.Context, d *schema.ResourceData, m i
 		if err != nil {
 			return diag.FromErr(err)
 		}
-	}
-
-	params := dcim.NewDcimDevicesUpdateParams().WithID(id).WithData(&data)
-
-	_, err := api.Dcim.DcimDevicesUpdate(params, nil)
-	if err != nil {
-		return diag.FromErr(err)
 	}
 
 	return resourceNetboxDeviceRead(ctx, d, m)

--- a/netbox/resource_netbox_device_test.go
+++ b/netbox/resource_netbox_device_test.go
@@ -311,6 +311,25 @@ platform_id = netbox_platform.test.id
 				),
 			},
 			{
+				Config: testAccNetboxDeviceFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_virtual_chassis" "test" {
+name = "%[1]s"
+}
+resource "netbox_device" "test" {
+name = "%[1]s"
+role_id = netbox_device_role.test.id
+device_type_id = netbox_device_type.test.id
+site_id = netbox_site.test.id
+platform_id = netbox_platform.test.id
+virtual_chassis_id = netbox_virtual_chassis.test.id
+virtual_chassis_position = 1
+virtual_chassis_master = true
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device.test", "virtual_chassis_id", "netbox_virtual_chassis.test", "id"),
+				),
+			},
+			{
 				ResourceName:      "netbox_device.test",
 				ImportState:       true,
 				ImportStateVerify: true,


### PR DESCRIPTION
When updating an existing device, it tries to set the device as a master before updating the device to be part of a virtual chassis. This results in the error:

```
The selected master (test-device_virtual_chassis-opff9n4aao) is not assigned to this virtual chassis.
```

Fix this by updating the device before updating the master status on the virtual chassis.