### PR TITLE
netbox_webhook: add additional attributes

### DIFF
--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -39,6 +39,7 @@ resource "netbox_webhook" "test" {
 
 - `additional_headers` (String)
 - `body_template` (String)
+- `conditions` (String)
 - `enabled` (Boolean)
 - `http_content_type` (String) The complete list of official content types is available [here](https://www.iana.org/assignments/media-types/media-types.xhtml). Defaults to `application/json`.
 - `http_method` (String) Valid values are `GET`, `POST`, `PUT`, `PATCH` and `DELETE`. Defaults to `POST`.

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -37,6 +37,7 @@ resource "netbox_webhook" "test" {
 
 ### Optional
 
+- `additional_headers` (String)
 - `body_template` (String)
 - `enabled` (Boolean)
 - `http_content_type` (String) The complete list of official content types is available [here](https://www.iana.org/assignments/media-types/media-types.xhtml). Defaults to `application/json`.

--- a/netbox/resource_netbox_webhook.go
+++ b/netbox/resource_netbox_webhook.go
@@ -70,6 +70,10 @@ func resourceNetboxWebhook() *schema.Resource {
 				Description: "The complete list of official content types is available [here](https://www.iana.org/assignments/media-types/media-types.xhtml).",
 				Default:     "application/json",
 			},
+			"additional_headers": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -100,6 +104,7 @@ func resourceNetboxWebhookCreate(d *schema.ResourceData, m interface{}) error {
 	data.BodyTemplate = bodyTemplate
 	data.HTTPMethod = getOptionalStr(d, "http_method", false)
 	data.HTTPContentType = getOptionalStr(d, "http_content_type", false)
+	data.AdditionalHeaders = getOptionalStr(d, "additional_headers", false)
 
 	params := extras.NewExtrasWebhooksCreateParams().WithData(data)
 
@@ -141,6 +146,7 @@ func resourceNetboxWebhookRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("body_template", webhook.BodyTemplate)
 	d.Set("http_method", webhook.HTTPMethod)
 	d.Set("http_content_type", webhook.HTTPContentType)
+	d.Set("additional_headers", webhook.AdditionalHeaders)
 
 	return nil
 }
@@ -172,6 +178,7 @@ func resourceNetboxWebhookUpdate(d *schema.ResourceData, m interface{}) error {
 	data.BodyTemplate = bodyTemplate
 	data.HTTPMethod = getOptionalStr(d, "http_method", false)
 	data.HTTPContentType = getOptionalStr(d, "http_content_type", false)
+	data.AdditionalHeaders = getOptionalStr(d, "additional_headers", false)
 
 	params := extras.NewExtrasWebhooksUpdateParams().WithID(id).WithData(&data)
 

--- a/netbox/resource_netbox_webhook.go
+++ b/netbox/resource_netbox_webhook.go
@@ -57,6 +57,11 @@ func resourceNetboxWebhook() *schema.Resource {
 			"body_template": {
 				Type:     schema.TypeString,
 				Optional: true,
+				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+					equal, _ := jsonSemanticCompare(oldValue, newValue)
+					return equal
+				},
+				DiffSuppressOnRefresh: true,
 			},
 			"http_method": {
 				Type:         schema.TypeString,

--- a/netbox/resource_netbox_webhook_test.go
+++ b/netbox/resource_netbox_webhook_test.go
@@ -87,7 +87,9 @@ resource "netbox_webhook" "test" {
 	trigger_on_delete = "%s"
 	payload_url       = "%s"
 	content_types     = ["%s"]
-	body_template     = "{\"text\": \"This is a sample json\"}"
+	body_template        = <<-EOT
+	{"text": "This is a sample json"}
+	EOT
         http_method       = "%s"
         http_content_type = "%s"
   }`, testName, testEnabled, triggerOnCreate, triggerOnUpdate, triggerOnDelete, testPayloadURL, testContentType, testHTTPMethod, testHTTPContentType),
@@ -115,7 +117,9 @@ resource "netbox_webhook" "test" {
   trigger_on_delete    = "%s"
   payload_url          = "%s"
   content_types        = ["%s", "%s"]
-  body_template        = "{\"text\": \"This is a sample json\"}"
+  body_template        = <<-EOT
+  {"text": "This is a sample json"}
+  EOT
 }`, testName, testEnabled, triggerOnCreate, triggerOnUpdate, triggerOnDelete, testPayloadURL, testContentType, testContentType1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_webhook.test", "name", testName+"_updated"),

--- a/netbox/resource_netbox_webhook_test.go
+++ b/netbox/resource_netbox_webhook_test.go
@@ -20,6 +20,7 @@ func TestAccNetboxWebhook_basic(t *testing.T) {
 	testPayloadURL := "https://example.com/webhook"
 	testContentType := "dcim.site"
 	testBodyTemplate := "Sample Body"
+	testAdditionalHeaders := "Authentication: Bearer abcdef123456"
 	resource.ParallelTest(t, resource.TestCase{
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckNetBoxWebhookDestroy,
@@ -27,13 +28,14 @@ func TestAccNetboxWebhook_basic(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 resource "netbox_webhook" "test" {
-  name              = "%s"
-  enabled           = "%s"
-  trigger_on_create = "%s"
-  payload_url       = "%s"
-  content_types     = ["%s"]
-  body_template     = "%s"
-}`, testName, testEnabled, triggerOnCreate, testPayloadURL, testContentType, testBodyTemplate),
+  name               = "%s"
+  enabled            = "%s"
+  trigger_on_create  = "%s"
+  payload_url        = "%s"
+  content_types      = ["%s"]
+  body_template      = "%s"
+  additional_headers = "%s"
+}`, testName, testEnabled, triggerOnCreate, testPayloadURL, testContentType, testBodyTemplate, testAdditionalHeaders),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_webhook.test", "name", testName),
 					resource.TestCheckResourceAttr("netbox_webhook.test", "enabled", testEnabled),
@@ -42,6 +44,7 @@ resource "netbox_webhook" "test" {
 					resource.TestCheckResourceAttr("netbox_webhook.test", "content_types.#", "1"),
 					resource.TestCheckTypeSetElemAttr("netbox_webhook.test", "content_types.*", testContentType),
 					resource.TestCheckResourceAttr("netbox_webhook.test", "body_template", testBodyTemplate),
+					resource.TestCheckResourceAttr("netbox_webhook.test", "additional_headers", testAdditionalHeaders),
 				),
 			},
 			{

--- a/netbox/resource_netbox_webhook_test.go
+++ b/netbox/resource_netbox_webhook_test.go
@@ -35,6 +35,9 @@ resource "netbox_webhook" "test" {
   content_types      = ["%s"]
   body_template      = "%s"
   additional_headers = "%s"
+  conditions         = <<-JSON
+    {"and": [{"attr": "status.value", "value": "active"}]}
+  JSON
 }`, testName, testEnabled, triggerOnCreate, testPayloadURL, testContentType, testBodyTemplate, testAdditionalHeaders),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_webhook.test", "name", testName),
@@ -45,6 +48,7 @@ resource "netbox_webhook" "test" {
 					resource.TestCheckTypeSetElemAttr("netbox_webhook.test", "content_types.*", testContentType),
 					resource.TestCheckResourceAttr("netbox_webhook.test", "body_template", testBodyTemplate),
 					resource.TestCheckResourceAttr("netbox_webhook.test", "additional_headers", testAdditionalHeaders),
+					resource.TestCheckResourceAttr("netbox_webhook.test", "conditions", `{"and":[{"attr":"status.value","value":"active"}]}`),
 				),
 			},
 			{

--- a/netbox/util.go
+++ b/netbox/util.go
@@ -1,7 +1,9 @@
 package netbox
 
 import (
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -109,4 +111,24 @@ func getOptionalInt(d *schema.ResourceData, key string) *int64 {
 
 func getOptionalFloat(d *schema.ResourceData, key string) *float64 {
 	return getOptionalVal[float64, float64](d, key)
+}
+
+// jsonSemanticCompare returns true when 2 json strings encode the same
+// structure, regardless of whitespace differences. This can be used in
+// DiffSuppressFunc implementations to prevent terraform showing whitespace
+// changes as differences on refresh.
+func jsonSemanticCompare(a, b string) (equal bool, err error) {
+	var aDecoded, bDecoded any
+
+	err = json.Unmarshal([]byte(a), &aDecoded)
+	if err != nil {
+		return false, fmt.Errorf("could not decode a: %w", err)
+	}
+
+	err = json.Unmarshal([]byte(b), &bDecoded)
+	if err != nil {
+		return false, fmt.Errorf("could not decode b: %w", err)
+	}
+
+	return reflect.DeepEqual(aDecoded, bDecoded), nil
 }

--- a/netbox/util_test.go
+++ b/netbox/util_test.go
@@ -56,3 +56,31 @@ func TestBuildValidValueDescription(t *testing.T) {
 		})
 	}
 }
+
+func TestJsonSemanticCompareEqual(t *testing.T) {
+	a := `{"a": [{ "b": [1, 2, 3]}]}`
+	b := `{"a":[{"b":[1,2,3]}]}`
+
+	equal, err := jsonSemanticCompare(a, b)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if !equal {
+		t.Errorf("expected 'a' and 'b' to be semantically equal\n\na: %s\nb: %s\n", a, b)
+	}
+}
+
+func TestJsonSemanticCompareUnequal(t *testing.T) {
+	a := `{"a": [{ "b": [1, 2, 3]}]}`
+	b := `{"a": [{ "b": [1, 2, 4]}]}`
+
+	equal, err := jsonSemanticCompare(a, b)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if equal {
+		t.Errorf("expected 'a' and 'b' to be semantically unequal\n\na: %s\nb: %s\n", a, b)
+	}
+}


### PR DESCRIPTION
This adds support for 2 additional attributes for the `netbox_webhook` resource:

- `additional_headers`
- `conditions`

This also fixes an issue with the `body_template` attribute, where terraform may keep showing changes to this field due to differences in json encoding:

```terraform
~ body_template     = jsonencode( # whitespace changes
      {
          text = "This is a sample json"
      }
  )
```