### PR TITLE
added parent_id to locations

### DIFF
--- a/docs/data-sources/location.md
+++ b/docs/data-sources/location.md
@@ -18,6 +18,7 @@ description: |-
 ### Optional
 
 - `name` (String)
+- `parent_id` (Number)
 - `site_id` (Number)
 - `slug` (String)
 

--- a/docs/resources/location.md
+++ b/docs/resources/location.md
@@ -46,6 +46,7 @@ resource "netbox_location" "test" {
 
 - `custom_fields` (Map of String)
 - `description` (String)
+- `parent_id` (Number)
 - `site_id` (Number)
 - `slug` (String)
 - `tags` (Set of String)

--- a/netbox/data_source_netbox_location.go
+++ b/netbox/data_source_netbox_location.go
@@ -32,6 +32,11 @@ func dataSourceNetboxLocation() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"parent_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
 			"tenant_id": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -67,13 +72,19 @@ func dataSourceNetboxLocationRead(d *schema.ResourceData, m interface{}) error {
 		siteID := fmt.Sprintf("%v", site)
 		params.SetSiteID(&siteID)
 	}
+
+	if parent, ok := d.Get("parent_id").(int); ok && parent != 0 {
+		parentID := fmt.Sprintf("%v", parent)
+		params.SetParentID(&parentID)
+	}
+
 	res, err := api.Dcim.DcimLocationsList(params, nil)
 
 	if err != nil {
 		return err
 	}
 	if count := *res.GetPayload().Count; count != 1 {
-		return fmt.Errorf("expected one site, but got %d", count)
+		return fmt.Errorf("expected one location, but got %d", count)
 	}
 
 	location := res.GetPayload().Results[0]

--- a/netbox/data_source_netbox_location_test.go
+++ b/netbox/data_source_netbox_location_test.go
@@ -58,6 +58,59 @@ data "netbox_location" "by_slug" {
 					resource.TestCheckResourceAttrPair("data.netbox_location.by_name", "tenant_id", "netbox_location.test", "tenant_id"),
 				),
 			},
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_site" "test" {
+  name = "%[1]s"
+}
+
+resource "netbox_tenant" "test" {
+  name = "%[1]s"
+}
+
+resource "netbox_location" "test" {
+  name        = "%[1]s"
+  description = "my-description"
+  site_id     = netbox_site.test.id
+  tenant_id   = netbox_tenant.test.id
+}
+
+resource "netbox_location" "test_child" {
+  name        = "%[1]s"
+  site_id     = netbox_site.test.id
+  parent_id   = netbox_location.test.id
+}
+
+data "netbox_location" "by_name_and_parent" {
+  name = netbox_location.test.name
+  parent_id = null
+}
+
+data "netbox_location" "by_name_and_site_and_parent_id" {
+  name    = netbox_location.test.name
+  site_id = netbox_site.test.id
+  parent_id = null
+}
+
+data "netbox_location" "by_id" {
+  id = netbox_location.test.id
+}
+
+data "netbox_location" "by_slug" {
+  slug = netbox_location.test.slug
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("data.netbox_location.by_name_and_parent", "id", "netbox_location.test", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_location.by_id", "id", "netbox_location.test", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_location.by_slug", "id", "netbox_location.test", "id"),
+					resource.TestCheckResourceAttr("data.netbox_location.by_name_and_parent", "name", testName),
+					resource.TestCheckResourceAttrPair("data.netbox_location.by_name_and_parent", "id", "netbox_location.test", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_location.by_name_and_parent", "description", "netbox_location.test", "description"),
+					resource.TestCheckResourceAttrPair("data.netbox_location.by_name_and_parent", "site_id", "netbox_location.test", "site_id"),
+					resource.TestCheckResourceAttrPair("data.netbox_location.by_name_and_site_and_parent_id", "site_id", "netbox_location.test", "site_id"),
+					resource.TestCheckResourceAttrPair("data.netbox_location.by_name_and_parent", "tenant_id", "netbox_location.test", "tenant_id"),
+				),
+			},
 		},
 	})
 }

--- a/netbox/resource_netbox_location.go
+++ b/netbox/resource_netbox_location.go
@@ -38,6 +38,10 @@ Each location must have a name that is unique within its parent site and locatio
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"parent_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"site_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -72,6 +76,11 @@ func resourceNetboxLocationCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	data.Description = getOptionalStr(d, "description", true)
+
+	parentIDValue, ok := d.GetOk("parent_id")
+	if ok {
+		data.Parent = int64ToPtr(int64(parentIDValue.(int)))
+	}
 
 	siteIDValue, ok := d.GetOk("site_id")
 	if ok {
@@ -127,6 +136,12 @@ func resourceNetboxLocationRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("slug", location.Slug)
 	d.Set("description", location.Description)
 
+	if res.GetPayload().Parent != nil {
+		d.Set("parent_id", res.GetPayload().Parent.ID)
+	} else {
+		d.Set("parent_id", nil)
+	}
+
 	if res.GetPayload().Site != nil {
 		d.Set("site_id", res.GetPayload().Site.ID)
 	} else {
@@ -166,6 +181,11 @@ func resourceNetboxLocationUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	data.Description = getOptionalStr(d, "description", true)
+
+	parentIDValue, ok := d.GetOk("parent_id")
+	if ok {
+		data.Parent = int64ToPtr(int64(parentIDValue.(int)))
+	}
 
 	siteIDValue, ok := d.GetOk("site_id")
 	if ok {

--- a/netbox/resource_netbox_location_test.go
+++ b/netbox/resource_netbox_location_test.go
@@ -35,6 +35,12 @@ resource "netbox_location" "test" {
   description = "my-description"
   site_id     = netbox_site.test.id
   tenant_id   = netbox_tenant.test.id
+}
+
+resource "netbox_location" "test_child" {
+  name        = "%[1]s_child"
+  site_id     = netbox_site.test.id
+  parent_id   = netbox_location.test.id
 }`, testName, randomSlug),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_location.test", "name", testName),
@@ -42,6 +48,7 @@ resource "netbox_location" "test" {
 					resource.TestCheckResourceAttr("netbox_location.test", "description", "my-description"),
 					resource.TestCheckResourceAttrPair("netbox_location.test", "site_id", "netbox_site.test", "id"),
 					resource.TestCheckResourceAttrPair("netbox_location.test", "tenant_id", "netbox_tenant.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_location.test_child", "parent_id", "netbox_location.test", "id"),
 				),
 			},
 			{


### PR DESCRIPTION
Hey
I'm working on adding parent_id to locations and looking for an advise. 

There is an issue with parent_id=null for data sources. It is treated as "0" and hence "parent_id" is not added to the API query and we are reading multiple locations instead of one.  Failed test output:

```
 data_source_netbox_location_test.go:13: Step 2/2 error: Error running post-apply plan: exit status 1
        
        Error: expected one location, but got 2
        
          with data.netbox_location.by_name_and_parent,
          on terraform_plugin_test.tf line 24, in data "netbox_location" "by_name_and_parent":
          24: data "netbox_location" "by_name_and_parent" {
        
        
        Error: expected one location, but got 2
        
          with data.netbox_location.by_name_and_site_and_parent_id,
          on terraform_plugin_test.tf line 29, in data "netbox_location" "by_name_and_site_and_parent_id":
          29: data "netbox_location" "by_name_and_site_and_parent_id" {
        
        
        Error: expected one location, but got 2
        
          with data.netbox_location.by_slug,
          on terraform_plugin_test.tf line 39, in data "netbox_location" "by_slug":
          39: data "netbox_location" "by_slug" {
```


location name is unique only per parent. So we can have multiple locations beneath different parents.
parent_id=null means locations without parents (aka root locations).
