### PR TITLE
feat: allow filtering vms by tenant_id

### DIFF
--- a/netbox/data_source_netbox_virtual_machines.go
+++ b/netbox/data_source_netbox_virtual_machines.go
@@ -158,34 +158,28 @@ func dataSourceNetboxVirtualMachineRead(d *schema.ResourceData, m interface{}) e
 		for _, f := range filterParams.List() {
 			k := f.(map[string]interface{})["name"]
 			v := f.(map[string]interface{})["value"]
+			vString := v.(string)
 			switch k {
 			case "cluster_id":
-				var clusterString = v.(string)
-				params.ClusterID = &clusterString
+				params.ClusterID = &vString
 			case "cluster_group":
-				var clusterGroupString = v.(string)
-				params.ClusterGroup = &clusterGroupString
+				params.ClusterGroup = &vString
 			case "device_id":
-				var deviceIDstring = v.(string)
-				params.Name = &deviceIDstring
+				params.Name = &vString
 			case "device":
-				var deviceString = v.(string)
-				params.Name = &deviceString
+				params.Name = &vString
 			case "name":
-				var nameString = v.(string)
-				params.Name = &nameString
+				params.Name = &vString
 			case "region":
-				var regionString = v.(string)
-				params.Region = &regionString
+				params.Region = &vString
 			case "role":
-				var roleString = v.(string)
-				params.Role = &roleString
+				params.Role = &vString
 			case "site":
-				var siteString = v.(string)
-				params.Site = &siteString
+				params.Site = &vString
+			case "tenant_id":
+				params.TenantID = &vString
 			case "tag":
-				var tagString = v.(string)
-				tags = append(tags, tagString)
+				tags = append(tags, vString)
 				params.Tag = tags
 			default:
 				return fmt.Errorf("'%s' is not a supported filter parameter", k)

--- a/netbox/data_source_netbox_virtual_machines_test.go
+++ b/netbox/data_source_netbox_virtual_machines_test.go
@@ -45,7 +45,7 @@ func TestAccNetboxVirtualMachinesDataSource_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: dependencies + testAccNetboxVirtualMachineDataSourceFilterTenantId,
+				Config: dependencies + testAccNetboxVirtualMachineDataSourceFilterTenantID,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_virtual_machines.test", "vms.#", "1"),
 					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.0.cluster_id", "netbox_cluster.test", "id"),
@@ -184,7 +184,7 @@ data "netbox_virtual_machines" "test" {
   }
 }`
 
-const testAccNetboxVirtualMachineDataSourceFilterTenantId = `
+const testAccNetboxVirtualMachineDataSourceFilterTenantID = `
 data "netbox_virtual_machines" "test" {
   filter {
     name  = "tenant_id"

--- a/netbox/data_source_netbox_virtual_machines_test.go
+++ b/netbox/data_source_netbox_virtual_machines_test.go
@@ -45,6 +45,14 @@ func TestAccNetboxVirtualMachinesDataSource_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: dependencies + testAccNetboxVirtualMachineDataSourceFilterTenantId,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_virtual_machines.test", "vms.#", "1"),
+					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.0.cluster_id", "netbox_cluster.test", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.0.name", "netbox_virtual_machine.test0", "name"),
+				),
+			},
+			{
 				Config: dependencies + testAccNetboxVirtualMachineDataSourceNameRegex,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_virtual_machines.test", "vms.#", "2"),
@@ -173,6 +181,14 @@ data "netbox_virtual_machines" "test" {
   filter {
     name  = "cluster_id"
     value = netbox_cluster.test.id
+  }
+}`
+
+const testAccNetboxVirtualMachineDataSourceFilterTenantId = `
+data "netbox_virtual_machines" "test" {
+  filter {
+    name  = "tenant_id"
+    value = netbox_tenant.test.id
   }
 }`
 


### PR DESCRIPTION
Allows filtering `vms` by `tenant_id`.

Similar like this providers does many other places.
A tiny refactor on the switch case also.