### PR TITLE
fix: make site data_source optional fields computed

### DIFF
--- a/netbox/data_source_netbox_site.go
+++ b/netbox/data_source_netbox_site.go
@@ -17,10 +17,12 @@ func dataSourceNetboxSite() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"slug": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"id": {
 				Type:     schema.TypeString,
@@ -34,7 +36,7 @@ func dataSourceNetboxSite() *schema.Resource {
 			},
 			"asn_ids": {
 				Type:     schema.TypeSet,
-				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeInt,
 				},


### PR DESCRIPTION
We have an issue when trying to reference the name of a site from a data source lookup, where the site name is null during a plan.

This causes issues for templating fields, as we get the following error:

```sh
Error: Invalid template interpolation value
│
│   on .terraform/module/main.tf line 53, in data "netbox_prefixes" "this":
│   53:       error_message = "The site provided with name ${data.netbox_site.this.name} does not contain any prefixes."
│     ├────────────────
│     │ data.netbox_site.this.name is null
│
│ The expression result is null. Cannot include a null value in a string
│ template.
```

This happens because some of the fields that are optional and can be used for lookup of the site are not set as computed. This leads to a data structure that looks like below during the plan.

```sh
site = {
      + asn_ids     = null
      + comments    = (known after apply)
      + description = (known after apply)
      + facility    = "TS-L2SB"
      + group_id    = (known after apply)
      + id          = (known after apply)
      + name        = null
      + region_id   = (known after apply)
      + site_id     = (known after apply)
      + slug        = null
      + status      = (known after apply)
      + tenant_id   = (known after apply)
      + time_zone   = (known after apply)
    }
```

This changes all optional fields to also be computed, so that if they are not set, they can get the values and be "unknown" during a plan, which avoids the above mentioned error.

Also changed `asn_ids` to be computed only, as that is how the field was used before, since it's not used for lookup, only for providing data:
https://github.com/e-breuninger/terraform-provider-netbox/commit/467b7a89f8a809f1e820c5d4de407dda2cb98bea