### PR TITLE
fix: add better error handling for one object data sources

### DIFF
--- a/netbox/data_source_netbox_asn.go
+++ b/netbox/data_source_netbox_asn.go
@@ -1,7 +1,7 @@
 package netbox
 
 import (
-	"fmt"
+	"errors"
 	"strconv"
 
 	"github.com/fbreckle/go-netbox/netbox/client"
@@ -69,10 +69,12 @@ func dataSourceNetboxAsnRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	if count := *res.GetPayload().Count; count != int64(1) {
-		return fmt.Errorf("expected one ASN, but got %d", count)
+	if *res.GetPayload().Count > int64(1) {
+		return errors.New("more than one asn returned, specify a more narrow filter")
 	}
-
+	if *res.GetPayload().Count == int64(0) {
+		return errors.New("no asn found matching filter")
+	}
 	result := res.GetPayload().Results[0]
 	d.Set("id", result.ID)
 	d.Set("asn", strconv.FormatInt(*result.Asn, 10))

--- a/netbox/data_source_netbox_asn_test.go
+++ b/netbox/data_source_netbox_asn_test.go
@@ -58,7 +58,7 @@ func TestAccNetboxAsnDataSource_basic(t *testing.T) {
 			},
 			{
 				Config:      setUp + testAccNetboxAsnNoResult,
-				ExpectError: regexp.MustCompile("expected one ASN, but got 0"),
+				ExpectError: regexp.MustCompile("no asn found matching filter"),
 			},
 			{
 				Config: setUp + testAccNetboxAsnByAsn(),

--- a/netbox/data_source_netbox_cluster_group.go
+++ b/netbox/data_source_netbox_cluster_group.go
@@ -41,10 +41,10 @@ func dataSourceNetboxClusterGroupRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one cluster group returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no cluster group found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.Set("cluster_group_id", result.ID)

--- a/netbox/data_source_netbox_cluster_type.go
+++ b/netbox/data_source_netbox_cluster_type.go
@@ -41,10 +41,10 @@ func dataSourceNetboxClusterTypeRead(d *schema.ResourceData, m interface{}) erro
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one cluster type returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no cluster type found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.Set("cluster_type_id", result.ID)

--- a/netbox/data_source_netbox_contact.go
+++ b/netbox/data_source_netbox_contact.go
@@ -55,10 +55,10 @@ func dataSourceNetboxContactRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one contact returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no contact found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))

--- a/netbox/data_source_netbox_contact_group.go
+++ b/netbox/data_source_netbox_contact_group.go
@@ -49,10 +49,10 @@ func dataSourceNetboxContactGroupRead(d *schema.ResourceData, m interface{}) err
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one contact group returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no contact group found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))

--- a/netbox/data_source_netbox_contact_role.go
+++ b/netbox/data_source_netbox_contact_role.go
@@ -47,10 +47,10 @@ func dataSourceNetboxContactRoleRead(d *schema.ResourceData, m interface{}) erro
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one contact role returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no contact role found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))

--- a/netbox/data_source_netbox_device_role.go
+++ b/netbox/data_source_netbox_device_role.go
@@ -46,10 +46,10 @@ func dataSourceNetboxDeviceRoleRead(d *schema.ResourceData, m interface{}) error
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one device role returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no device role found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))

--- a/netbox/data_source_netbox_device_type.go
+++ b/netbox/data_source_netbox_device_type.go
@@ -1,7 +1,7 @@
 package netbox
 
 import (
-	"fmt"
+	"errors"
 	"strconv"
 
 	"github.com/fbreckle/go-netbox/netbox/client"
@@ -68,10 +68,13 @@ func dataSourceNetboxDeviceTypeRead(d *schema.ResourceData, m interface{}) error
 	if err != nil {
 		return err
 	}
-	if count := *res.GetPayload().Count; count != int64(1) {
-		return fmt.Errorf("expected one device type, but got %d", count)
-	}
 
+	if *res.GetPayload().Count > int64(1) {
+		return errors.New("more than one device type returned, specify a more narrow filter")
+	}
+	if *res.GetPayload().Count == int64(0) {
+		return errors.New("no device type found matching filter")
+	}
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))
 	d.Set("is_full_depth", result.IsFullDepth)

--- a/netbox/data_source_netbox_device_type_test.go
+++ b/netbox/data_source_netbox_device_type_test.go
@@ -22,7 +22,7 @@ func TestAccNetboxDeviceTypeDataSource_basic(t *testing.T) {
 			},
 			{
 				Config:      setUp + testAccNetboxDeviceTypeDataNoResult,
-				ExpectError: regexp.MustCompile("expected one device type, but got 0"),
+				ExpectError: regexp.MustCompile("no device type found matching filter"),
 			},
 			{
 				Config: setUp + testAccNetboxDeviceTypeDataByModel(testName),

--- a/netbox/data_source_netbox_ip_range.go
+++ b/netbox/data_source_netbox_ip_range.go
@@ -45,10 +45,10 @@ func dataSourceNetboxIPRangeRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one ip range returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no ip range found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.Set("id", result.ID)

--- a/netbox/data_source_netbox_ipam_role.go
+++ b/netbox/data_source_netbox_ipam_role.go
@@ -51,10 +51,10 @@ func dataSourceNetboxIPAMRoleRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one ipam role returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no ipam role found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))

--- a/netbox/data_source_netbox_location.go
+++ b/netbox/data_source_netbox_location.go
@@ -1,6 +1,7 @@
 package netbox
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -72,8 +73,11 @@ func dataSourceNetboxLocationRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	if count := *res.GetPayload().Count; count != 1 {
-		return fmt.Errorf("expected one site, but got %d", count)
+	if *res.GetPayload().Count > int64(1) {
+		return errors.New("more than one location returned, specify a more narrow filter")
+	}
+	if *res.GetPayload().Count == int64(0) {
+		return errors.New("no location found matching filter")
 	}
 
 	location := res.GetPayload().Results[0]

--- a/netbox/data_source_netbox_platform.go
+++ b/netbox/data_source_netbox_platform.go
@@ -41,10 +41,10 @@ func dataSourceNetboxPlatformRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one platform returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no platform found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))

--- a/netbox/data_source_netbox_prefix.go
+++ b/netbox/data_source_netbox_prefix.go
@@ -1,7 +1,7 @@
 package netbox
 
 import (
-	"fmt"
+	"errors"
 	"strconv"
 
 	"github.com/fbreckle/go-netbox/netbox/client"
@@ -149,8 +149,11 @@ func dataSourceNetboxPrefixRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	if count := *res.GetPayload().Count; count != int64(1) {
-		return fmt.Errorf("expected one prefix, but got %d", count)
+	if *res.GetPayload().Count > int64(1) {
+		return errors.New("more than prefix returned, specify a more narrow filter")
+	}
+	if *res.GetPayload().Count == int64(0) {
+		return errors.New("no prefix found matching filter")
 	}
 
 	result := res.GetPayload().Results[0]

--- a/netbox/data_source_netbox_rack_role.go
+++ b/netbox/data_source_netbox_rack_role.go
@@ -50,10 +50,10 @@ func dataSourceNetboxRackRoleRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one rack role returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no rack role found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))

--- a/netbox/data_source_netbox_region.go
+++ b/netbox/data_source_netbox_region.go
@@ -95,10 +95,10 @@ func dataSourceNetboxRegionRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one region returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no region found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))

--- a/netbox/data_source_netbox_route_target.go
+++ b/netbox/data_source_netbox_route_target.go
@@ -50,8 +50,11 @@ func dataSourceNetboxRouteTargetRead(d *schema.ResourceData, m interface{}) erro
 		return err
 	}
 
+	if *res.GetPayload().Count > int64(1) {
+		return errors.New("more than one route target returned, specify a more narrow filter")
+	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no route target found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))

--- a/netbox/data_source_netbox_site.go
+++ b/netbox/data_source_netbox_site.go
@@ -1,7 +1,7 @@
 package netbox
 
 import (
-	"fmt"
+	"errors"
 	"strconv"
 
 	"github.com/fbreckle/go-netbox/netbox/client"
@@ -97,8 +97,12 @@ func dataSourceNetboxSiteRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	if count := *res.GetPayload().Count; count != 1 {
-		return fmt.Errorf("expected one site, but got %d", count)
+
+	if *res.GetPayload().Count > int64(1) {
+		return errors.New("more than one site returned, specify a more narrow filter")
+	}
+	if *res.GetPayload().Count == int64(0) {
+		return errors.New("no site found matching filter")
 	}
 
 	site := res.GetPayload().Results[0]

--- a/netbox/data_source_netbox_site_group.go
+++ b/netbox/data_source_netbox_site_group.go
@@ -55,10 +55,10 @@ func dataSourceNetboxSiteGroupRead(d *schema.ResourceData, m interface{}) error 
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one site group returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no site group found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))

--- a/netbox/data_source_netbox_site_test.go
+++ b/netbox/data_source_netbox_site_test.go
@@ -85,7 +85,7 @@ func TestAccNetboxSiteDataSource_basic(t *testing.T) {
 			},
 			{
 				Config:      setUp + testAccNetboxSiteNoResult,
-				ExpectError: regexp.MustCompile("expected one site, but got 0"),
+				ExpectError: regexp.MustCompile("no site found matching filter"),
 			},
 			{
 				Config: setUp + testAccNetboxSiteByName(testName),

--- a/netbox/data_source_netbox_tag.go
+++ b/netbox/data_source_netbox_tag.go
@@ -45,10 +45,10 @@ func dataSourceNetboxTagRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one tag returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no tag found matching filter")
 	}
 
 	result := res.GetPayload().Results[0]

--- a/netbox/data_source_netbox_tenant.go
+++ b/netbox/data_source_netbox_tenant.go
@@ -59,10 +59,10 @@ func dataSourceNetboxTenantRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one tenant returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no tenant found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))

--- a/netbox/data_source_netbox_tenant_group.go
+++ b/netbox/data_source_netbox_tenant_group.go
@@ -49,10 +49,10 @@ func dataSourceNetboxTenantGroupRead(d *schema.ResourceData, m interface{}) erro
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one tenant group returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no tenant group found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))

--- a/netbox/data_source_netbox_vlan.go
+++ b/netbox/data_source_netbox_vlan.go
@@ -1,7 +1,7 @@
 package netbox
 
 import (
-	"fmt"
+	"errors"
 	"strconv"
 
 	"github.com/fbreckle/go-netbox/netbox/client"
@@ -80,8 +80,11 @@ func dataSourceNetboxVlanRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	if count := *res.GetPayload().Count; count != int64(1) {
-		return fmt.Errorf("expected one device type, but got %d", count)
+	if *res.GetPayload().Count > int64(1) {
+		return errors.New("more than one vlan returned, specify a more narrow filter")
+	}
+	if *res.GetPayload().Count == int64(0) {
+		return errors.New("no vlan found matching filter")
 	}
 
 	vlan := res.GetPayload().Results[0]

--- a/netbox/data_source_netbox_vlan_group.go
+++ b/netbox/data_source_netbox_vlan_group.go
@@ -82,10 +82,10 @@ func dataSourceNetboxVlanGroupRead(d *schema.ResourceData, m interface{}) error 
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one vlan group returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no vlan group found matching filter")
 	}
 
 	result := res.GetPayload().Results[0]

--- a/netbox/data_source_netbox_vlan_group_test.go
+++ b/netbox/data_source_netbox_vlan_group_test.go
@@ -22,7 +22,7 @@ func TestAccNetboxVlanGroupDataSource_basic(t *testing.T) {
 			},
 			{
 				Config:      setUp + testAccNetboxVlanGroupDataNoResult,
-				ExpectError: regexp.MustCompile("no result"),
+				ExpectError: regexp.MustCompile("no vlan group found matching filter"),
 			},
 			{
 				Config: setUp + testAccNetboxVlanGroupDataByName(testName),
@@ -64,11 +64,11 @@ func TestAccNetboxVlanGroupDataSource_basic(t *testing.T) {
 			},
 			{
 				Config:      setUp + extendedSetUp + testAccNetboxVlanGroupDataByName(testName),
-				ExpectError: regexp.MustCompile("more than one result, specify a more narrow filter"),
+				ExpectError: regexp.MustCompile("more than one vlan group returned, specify a more narrow filter"),
 			},
 			{
 				Config:      setUp + extendedSetUp + testAccNetboxVlanGroupDataBySlug(testSlug),
-				ExpectError: regexp.MustCompile("more than one result, specify a more narrow filter"),
+				ExpectError: regexp.MustCompile("more than one vlan group returned, specify a more narrow filter"),
 			},
 		},
 	})

--- a/netbox/data_source_netbox_vlan_test.go
+++ b/netbox/data_source_netbox_vlan_test.go
@@ -21,7 +21,7 @@ func TestAccNetboxVlanDataSource_basic(t *testing.T) {
 			},
 			{
 				Config:      setUp + testAccNetboxVlanDataNoResult,
-				ExpectError: regexp.MustCompile("expected one device type, but got 0"),
+				ExpectError: regexp.MustCompile("no vlan found matching filter"),
 			},
 			{
 				Config: setUp + testAccNetboxVlanDataByName(testName),
@@ -56,11 +56,11 @@ func TestAccNetboxVlanDataSource_basic(t *testing.T) {
 			},
 			{
 				Config:      setUp + extendedSetUp + testAccNetboxVlanDataByName(testName),
-				ExpectError: regexp.MustCompile("expected one device type, but got 2"),
+				ExpectError: regexp.MustCompile("more than one vlan returned, specify a more narrow filter"),
 			},
 			{
 				Config:      setUp + extendedSetUp + testAccNetboxVlanDataByVid(testVid),
-				ExpectError: regexp.MustCompile("expected one device type, but got 2"),
+				ExpectError: regexp.MustCompile("more than one vlan returned, specify a more narrow filter"),
 			},
 		},
 	})

--- a/netbox/data_source_netbox_vrf.go
+++ b/netbox/data_source_netbox_vrf.go
@@ -41,10 +41,10 @@ func dataSourceNetboxVrfRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if *res.GetPayload().Count > int64(1) {
-		return errors.New("more than one result, specify a more narrow filter")
+		return errors.New("more than one vrf returned, specify a more narrow filter")
 	}
 	if *res.GetPayload().Count == int64(0) {
-		return errors.New("no result")
+		return errors.New("no vrf found matching filter")
 	}
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))


### PR DESCRIPTION
Many of the data sources are configured to only return one object, based on a filter. This change aims to improve the error messages that are returned by these objects.

Specifically, we want to make the return to be more than just `Error: no result`, which would make it more clear what was actually wrong for less familiar users.

By having a consistent error across these resources, it's easier for others to understand going forward.