### PR TITLE
Fix Virtual Chassis Master Update Function for Tag Input

### DIFF
--- a/netbox/resource_netbox_device_test.go
+++ b/netbox/resource_netbox_device_test.go
@@ -258,6 +258,7 @@ func TestAccNetboxDevice_virtual_chassis(t *testing.T) {
 				Config: testAccNetboxDeviceFullDependencies(testName) + fmt.Sprintf(`
 resource "netbox_virtual_chassis" "test" {
   name = "%[1]s"
+	tags = [netbox_tag.test_a.name]
 }
 
 resource "netbox_device" "test" {
@@ -280,6 +281,7 @@ resource "netbox_device" "test" {
 				Config: testAccNetboxDeviceFullDependencies(testName) + fmt.Sprintf(`
 resource "netbox_virtual_chassis" "test" {
   name = "%[1]s"
+	tags = [netbox_tag.test_a.name]
 }
 
 resource "netbox_device" "test" {
@@ -300,6 +302,7 @@ resource "netbox_device" "test" {
 				Config: testAccNetboxDeviceFullDependencies(testName) + fmt.Sprintf(`
 resource "netbox_virtual_chassis" "test" {
   name = "%[1]s"
+	tags = [netbox_tag.test_a.name]
 }
 
 resource "netbox_device" "test" {
@@ -317,6 +320,7 @@ resource "netbox_device" "test" {
 				Config: testAccNetboxDeviceFullDependencies(testName) + fmt.Sprintf(`
 resource "netbox_virtual_chassis" "test" {
   name = "%[1]s"
+	tags = [netbox_tag.test_a.name]
 }
 
 resource "netbox_device" "test" {

--- a/netbox/resource_netbox_virtual_chassis.go
+++ b/netbox/resource_netbox_virtual_chassis.go
@@ -207,6 +207,13 @@ func virtualChassisUpdateMaster(api *client.NetBoxAPI, id int64, master *int64) 
 	}
 	vcData := vcRes.GetPayload()
 	vcData.Master = nil
+	newTags := make([]*models.NestedTag, 0)
+	for _, Tag := range vcData.Tags {
+		Tag.Display = ""
+		Tag.ID = 0
+		Tag.URL = ""
+		newTags = append(newTags,Tag)
+	}
 
 	// Need to manually copy data because there is no automatic method to convert
 	// from VirtualChassis to WritableVirtualChassis
@@ -216,7 +223,7 @@ func virtualChassisUpdateMaster(api *client.NetBoxAPI, id int64, master *int64) 
 		Domain:      vcData.Domain,
 		Name:        vcData.Name,
 		Comments:    vcData.Comments,
-		Tags:        vcData.Tags,
+		Tags:        newTags,
 		Master:      master,
 	}
 


### PR DESCRIPTION
An error occurs when we update the virtual chassis to set the master position. The function that updates the master reads the API to get the current values of the virtual chassis. The tag object that is received includes values that are not expected to be sent on a PUT to the API. This commit modifies the virtual chassis update code so that only the expected values for tags are sent, the rest of the values are either zero-ed out or nullified.

This only seems to happen when a virtual chassis has a tag.

Error message:
```
Error: [PUT /dcim/virtual-chassis/{id}/][400] dcim_virtual-chassis_update
default  map[tags:[[Cannot resolve keyword 'display' into field.
Choices are: aggregate, asn, asnrange, cable, circuit, circuittermination,
circuittype, cluster, clustergroup, clustertype, color, configtemplate,
consoleport, consoleserverport, contact, contactassignment, contactgroup,
contactrole, created, datasource, description, device, devicebay, devicerole,
devicetype, extras_taggeditem_items, fhrpgroup, frontport, id, interface,
inventoryitem, inventoryitemrole, ipaddress, iprange, journalentry, l2vpn,
l2vpntermination, last_updated, location, manufacturer, module, modulebay,
moduletype, name, object_types, platform, powerfeed, poweroutlet, powerpanel,
powerport, prefix, provider, provideraccount, providernetwork, rack,
rackreservation, rackrole, rearport, region, rir, role, routetarget,
service, servicetemplate, site, sitegroup, slug, tenant, tenantgroup,
virtualchassis, virtualdevicecontext, virtualmachine, vlan, vlangroup,
vminterface, vrf, webhook, wirelesslan, wirelesslangroup, wirelesslink]]]
```