### PR TITLE
feature: add field 'parent_id' to Location Resource & Data Source

### DIFF
--- a/docs/data-sources/location.md
+++ b/docs/data-sources/location.md
@@ -18,6 +18,7 @@ description: |-
 ### Optional
 
 - `name` (String)
+- `parent_id` (Number)
 - `site_id` (Number)
 - `slug` (String)
 

--- a/docs/data-sources/locations.md
+++ b/docs/data-sources/locations.md
@@ -43,6 +43,7 @@ Read-Only:
 - `description` (String)
 - `id` (String)
 - `name` (String)
+- `parent_id` (Number)
 - `site_id` (Number)
 - `slug` (String)
 - `status` (String)

--- a/docs/resources/location.md
+++ b/docs/resources/location.md
@@ -46,6 +46,7 @@ resource "netbox_location" "test" {
 
 - `custom_fields` (Map of String)
 - `description` (String)
+- `parent_id` (Number)
 - `site_id` (Number)
 - `slug` (String)
 - `tags` (Set of String)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.3
 
 require (
-	github.com/fbreckle/go-netbox v0.0.0-20240129094642-97f73f7dfeb5
+	github.com/fbreckle/go-netbox v0.0.0-20240216113358-5684f8ef416b
 	github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3
 	github.com/go-openapi/runtime v0.27.1
 	github.com/go-openapi/strfmt v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
-github.com/fbreckle/go-netbox v0.0.0-20240129094642-97f73f7dfeb5 h1:C7JoMpqT+UBCqcONFeaW9b9KsVqQ+BpOniY7FUR0GRI=
-github.com/fbreckle/go-netbox v0.0.0-20240129094642-97f73f7dfeb5/go.mod h1:3U3/m/hna9Ntd3sbHBYwZ1IqbP2+coRzoXw3mCfu3kM=
+github.com/fbreckle/go-netbox v0.0.0-20240216113358-5684f8ef416b h1:MT8csDWYQvhJyA+mprXZshw94JODLOP1rZlL4Ym8rnk=
+github.com/fbreckle/go-netbox v0.0.0-20240216113358-5684f8ef416b/go.mod h1:3U3/m/hna9Ntd3sbHBYwZ1IqbP2+coRzoXw3mCfu3kM=
 github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3 h1:DMSpM0btVedE2Tt1vfDHWQhf2obzjAe1F0/j8/CyfW4=
 github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3/go.mod h1:j3HmJySEjx6hOAOPDjGzmzpVNDQq9SNnnF+Vm22d2rs=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=

--- a/netbox/data_source_netbox_location.go
+++ b/netbox/data_source_netbox_location.go
@@ -46,6 +46,11 @@ func dataSourceNetboxLocation() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"parent_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -68,6 +73,10 @@ func dataSourceNetboxLocationRead(d *schema.ResourceData, m interface{}) error {
 		siteID := fmt.Sprintf("%v", site)
 		params.SetSiteID(&siteID)
 	}
+	if parent, ok := d.Get("parent_id").(int); ok && parent != 0 {
+		parentID := fmt.Sprintf("%v", parent)
+		params.SetParentID(&parentID)
+	}
 	res, err := api.Dcim.DcimLocationsList(params, nil)
 
 	if err != nil {
@@ -88,6 +97,9 @@ func dataSourceNetboxLocationRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("site_id", location.Site.ID)
 	d.Set("slug", location.Slug)
 
+	if location.Parent != nil {
+		d.Set("parent_id", location.Parent.ID)
+	}
 	if location.Status != nil {
 		d.Set("status", location.Status.Value)
 	}

--- a/netbox/data_source_netbox_location_test.go
+++ b/netbox/data_source_netbox_location_test.go
@@ -49,7 +49,7 @@ data "netbox_location" "by_name_and_site" {
 }
 
 data "netbox_location" "sub_by_name" {
-  name = netbox_location.test-sub.name
+  name = netbox_location.test_sub.name
 }
 
 data "netbox_location" "by_id" {

--- a/netbox/data_source_netbox_location_test.go
+++ b/netbox/data_source_netbox_location_test.go
@@ -10,6 +10,7 @@ import (
 func TestAccNetboxLocationDataSource_basic(t *testing.T) {
 	testSlug := "location_ds_basic"
 	testName := testAccGetTestName(testSlug)
+	testNameSub := testAccGetTestName(testSlug)
 	resource.ParallelTest(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -30,6 +31,14 @@ resource "netbox_location" "test" {
   tenant_id   = netbox_tenant.test.id
 }
 
+resource "netbox_location" "test_sub" {
+  name        = "%[2]s"
+  description = "my-description"
+  site_id     = netbox_site.test.id
+  tenant_id   = netbox_tenant.test.id
+  parent_id   = netbox_location.test.id
+}
+
 data "netbox_location" "by_name" {
   name = netbox_location.test.name
 }
@@ -39,13 +48,17 @@ data "netbox_location" "by_name_and_site" {
   site_id = netbox_site.test.id
 }
 
+data "netbox_location" "sub_by_name" {
+  name = netbox_location.test-sub.name
+}
+
 data "netbox_location" "by_id" {
   id = netbox_location.test.id
 }
 
 data "netbox_location" "by_slug" {
   slug = netbox_location.test.slug
-}`, testName),
+}`, testName, testNameSub),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("data.netbox_location.by_name", "id", "netbox_location.test", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_location.by_id", "id", "netbox_location.test", "id"),
@@ -56,6 +69,7 @@ data "netbox_location" "by_slug" {
 					resource.TestCheckResourceAttrPair("data.netbox_location.by_name", "site_id", "netbox_location.test", "site_id"),
 					resource.TestCheckResourceAttrPair("data.netbox_location.by_name_and_site", "site_id", "netbox_location.test", "site_id"),
 					resource.TestCheckResourceAttrPair("data.netbox_location.by_name", "tenant_id", "netbox_location.test", "tenant_id"),
+					resource.TestCheckResourceAttrPair("data.netbox_location.sub_by_name", "parent_id", "netbox_location.test", "id"),
 				),
 			},
 		},

--- a/netbox/data_source_netbox_locations.go
+++ b/netbox/data_source_netbox_locations.go
@@ -83,6 +83,10 @@ func dataSourceNetboxLocations() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"parent_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -113,6 +117,8 @@ func dataSourceNetboxLocationsRead(d *schema.ResourceData, m interface{}) error 
 				params.Site = &vString
 			case "site_id":
 				params.SiteID = &vString
+			case "parent_id":
+				params.ParentID = &vString
 			case "tenant":
 				params.Tenant = &vString
 			case "tenant_id":
@@ -148,6 +154,10 @@ func dataSourceNetboxLocationsRead(d *schema.ResourceData, m interface{}) error 
 		mapping["slug"] = v.Slug
 		mapping["site_id"] = v.Site.ID
 		mapping["description"] = v.Description
+
+		if v.Parent != nil {
+			mapping["parent_id"] = v.Parent.ID
+		}
 
 		if v.Status != nil {
 			mapping["status"] = v.Status.Value

--- a/netbox/resource_netbox_location.go
+++ b/netbox/resource_netbox_location.go
@@ -42,6 +42,10 @@ Each location must have a name that is unique within its parent site and locatio
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"parent_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			tagsKey: tagsSchema,
 			"tenant_id": {
 				Type:     schema.TypeInt,
@@ -76,6 +80,11 @@ func resourceNetboxLocationCreate(d *schema.ResourceData, m interface{}) error {
 	siteIDValue, ok := d.GetOk("site_id")
 	if ok {
 		data.Site = int64ToPtr(int64(siteIDValue.(int)))
+	}
+
+	parentIDValue, ok := d.GetOk("parent_id")
+	if ok {
+		data.Parent = int64ToPtr(int64(parentIDValue.(int)))
 	}
 
 	tenantIDValue, ok := d.GetOk("tenant_id")
@@ -133,6 +142,12 @@ func resourceNetboxLocationRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("site_id", nil)
 	}
 
+	if res.GetPayload().Parent != nil {
+		d.Set("parent_id", res.GetPayload().Parent.ID)
+	} else {
+		d.Set("parent_id", nil)
+	}
+
 	if res.GetPayload().Tenant != nil {
 		d.Set("tenant_id", res.GetPayload().Tenant.ID)
 	} else {
@@ -170,6 +185,11 @@ func resourceNetboxLocationUpdate(d *schema.ResourceData, m interface{}) error {
 	siteIDValue, ok := d.GetOk("site_id")
 	if ok {
 		data.Site = int64ToPtr(int64(siteIDValue.(int)))
+	}
+
+	parentIDValue, ok := d.GetOk("parent_id")
+	if ok {
+		data.Parent = int64ToPtr(int64(parentIDValue.(int)))
 	}
 
 	tenantIDValue, ok := d.GetOk("tenant_id")

--- a/netbox/resource_netbox_location.go
+++ b/netbox/resource_netbox_location.go
@@ -187,9 +187,12 @@ func resourceNetboxLocationUpdate(d *schema.ResourceData, m interface{}) error {
 		data.Site = int64ToPtr(int64(siteIDValue.(int)))
 	}
 
-	parentIDValue, ok := d.GetOk("parent_id")
-	if ok {
-		data.Parent = int64ToPtr(int64(parentIDValue.(int)))
+	parentIDValue := d.Get("parent_id")
+	data.Parent = int64ToPtr(int64(parentIDValue.(int)))
+
+	// remove parent (set null) if we got zero ID
+	if parentIDValue == 0 {
+		data.Parent = nil
 	}
 
 	tenantIDValue, ok := d.GetOk("tenant_id")

--- a/netbox/resource_netbox_location_test.go
+++ b/netbox/resource_netbox_location_test.go
@@ -14,7 +14,9 @@ import (
 func TestAccNetboxLocation_basic(t *testing.T) {
 	testSlug := "location_basic"
 	testName := testAccGetTestName(testSlug)
+	testNameSub := testAccGetTestName(testSlug)
 	randomSlug := testAccGetTestName(testSlug)
+	randomSlugSub := testAccGetTestName(testSlug)
 	resource.ParallelTest(t, resource.TestCase{
 		Providers: testAccProviders,
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -35,13 +37,22 @@ resource "netbox_location" "test" {
   description = "my-description"
   site_id     = netbox_site.test.id
   tenant_id   = netbox_tenant.test.id
-}`, testName, randomSlug),
+}
+
+resource "netbox_location" "test-sub" {
+  name        = "%[3]s"
+  slug        = "%[4]s"
+  description = "my-description"
+  parent_id   = netbox_location.test.id
+  site_id     = netbox_site.test.id
+}`, testName, randomSlug, testNameSub, randomSlugSub),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_location.test", "name", testName),
 					resource.TestCheckResourceAttr("netbox_location.test", "slug", randomSlug),
 					resource.TestCheckResourceAttr("netbox_location.test", "description", "my-description"),
 					resource.TestCheckResourceAttrPair("netbox_location.test", "site_id", "netbox_site.test", "id"),
 					resource.TestCheckResourceAttrPair("netbox_location.test", "tenant_id", "netbox_tenant.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_location.test", "id", "netbox_location.test-sub", "parent_id"),
 				),
 			},
 			{

--- a/netbox/resource_netbox_location_test.go
+++ b/netbox/resource_netbox_location_test.go
@@ -90,6 +90,83 @@ resource "netbox_location" "test" {
 	})
 }
 
+func TestAccNetboxLocation_updateParent(t *testing.T) {
+	testSlug := "loc_upd_parent"
+	testName := testAccGetTestName(testSlug)
+	testNameSub := testAccGetTestName(testSlug)
+	randomSlug := testAccGetTestName(testSlug)
+	randomSlugSub := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxLocationUpdateParent1(testName, randomSlug, testNameSub, randomSlugSub),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_location.test", "name", testName),
+					resource.TestCheckResourceAttr("netbox_location.test", "slug", randomSlug),
+					resource.TestCheckResourceAttr("netbox_location.test", "description", "my-description"),
+					resource.TestCheckResourceAttrPair("netbox_location.test", "site_id", "netbox_site.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_location.test", "id", "netbox_location.test_sub", "parent_id"),
+				),
+			},
+			{
+				Config: testAccNetboxLocationUpdateParent2(testName, randomSlug, testNameSub, randomSlugSub),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_location.test", "name", testName),
+					resource.TestCheckResourceAttr("netbox_location.test", "slug", randomSlug),
+					resource.TestCheckResourceAttr("netbox_location.test", "description", "my-description"),
+					resource.TestCheckResourceAttr("netbox_location.test_sub", "parent_id", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetboxLocationUpdateParent1(testName string, randomSlug string, testNameSub string, randomSlugSub string) string {
+	return fmt.Sprintf(`
+resource "netbox_site" "test" {
+  name = "%[1]s"
+}
+
+resource "netbox_location" "test" {
+  name        = "%[1]s"
+  slug        = "%[2]s"
+  description = "my-description"
+  site_id     = netbox_site.test.id
+}
+
+resource "netbox_location" "test_sub" {
+  name        = "%[3]s"
+  slug        = "%[4]s"
+  description = "my-description"
+  parent_id   = netbox_location.test.id
+  site_id     = netbox_site.test.id
+}`, testName, randomSlug, testNameSub, randomSlugSub)
+}
+
+func testAccNetboxLocationUpdateParent2(testName string, randomSlug string, testNameSub string, randomSlugSub string) string {
+	return fmt.Sprintf(`
+resource "netbox_site" "test" {
+  name = "%[1]s"
+}
+
+resource "netbox_location" "test" {
+  name        = "%[1]s"
+  slug        = "%[2]s"
+  description = "my-description"
+  site_id     = netbox_site.test.id
+}
+
+resource "netbox_location" "test_sub" {
+  name        = "%[3]s"
+  slug        = "%[4]s"
+  description = "my-description"
+  parent_id   = "0"
+  site_id     = netbox_site.test.id
+}`, testName, randomSlug, testNameSub, randomSlugSub)
+}
+
 func init() {
 	resource.AddTestSweepers("netbox_location", &resource.Sweeper{
 		Name:         "netbox_location",


### PR DESCRIPTION
Hello there! 

We actively use Location nesting. And I really miss the ability to read and write the “parent_id” value in a DCIM model resource Location.

This PR is about the same as in #508. 

PTAL.
