### PR TITLE
Add custom field support in IPAM Prefix

### DIFF
--- a/docs/resources/prefix.md
+++ b/docs/resources/prefix.md
@@ -36,6 +36,7 @@ resource "netbox_prefix" "my_prefix" {
 
 ### Optional
 
+- `custom_fields` (Map of String)
 - `description` (String)
 - `is_pool` (Boolean)
 - `mark_utilized` (Boolean)

--- a/netbox/resource_netbox_prefix.go
+++ b/netbox/resource_netbox_prefix.go
@@ -69,7 +69,8 @@ func resourceNetboxPrefix() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			tagsKey: tagsSchema,
+			customFieldsKey: customFieldsSchema,
+			tagsKey:         tagsSchema,
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -112,6 +113,11 @@ func resourceNetboxPrefixCreate(d *schema.ResourceData, m interface{}) error {
 
 	if roleID, ok := d.GetOk("role_id"); ok {
 		data.Role = int64ToPtr(int64(roleID.(int)))
+	}
+
+	cf, ok := d.GetOk(customFieldsKey)
+	if ok {
+		data.CustomFields = cf
 	}
 
 	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
@@ -184,6 +190,11 @@ func resourceNetboxPrefixRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("role_id", nil)
 	}
 
+	cf := getCustomFields(res.GetPayload().CustomFields)
+	if cf != nil {
+		d.Set(customFieldsKey, cf)
+	}
+
 	d.Set(tagsKey, getTagListFromNestedTagList(res.GetPayload().Tags))
 	// FIGURE OUT NESTED VRF AND NESTED VLAN (from maybe interfaces?)
 
@@ -229,6 +240,10 @@ func resourceNetboxPrefixUpdate(d *schema.ResourceData, m interface{}) error {
 
 	if roleID, ok := d.GetOk("role_id"); ok {
 		data.Role = int64ToPtr(int64(roleID.(int)))
+	}
+
+	if cf, ok := d.GetOk(customFieldsKey); ok {
+		data.CustomFields = cf
 	}
 
 	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))


### PR DESCRIPTION
Add custom field support in IPAM Prefix
```
TEST_FUNC=TestAccNetboxPrefix_basic make testacc-specific-test
⌛ Startup acceptance tests on http://localhost:8001 with version v3.7.1
⌛ Testing function TestAccNetboxPrefix_basic
TF_ACC=1 go test -timeout 20m -v -cover netbox/*.go -run TestAccNetboxPrefix_basic
=== RUN   TestAccNetboxPrefix_basic
=== PAUSE TestAccNetboxPrefix_basic
=== CONT  TestAccNetboxPrefix_basic
--- PASS: TestAccNetboxPrefix_basic (13.82s)
PASS
coverage: 9.0% of statements
ok  	command-line-arguments	15.227s	coverage: 9.0% of statements
```