### PR TITLE
chore: specify disk size unit in virtual disk resource

### DIFF
--- a/docs/resources/virtual_disk.md
+++ b/docs/resources/virtual_disk.md
@@ -40,7 +40,7 @@ resource "netbox_virtual_disk" "example" {
 ### Required
 
 - `name` (String)
-- `size` (Number)
+- `size_gb` (Number)
 - `virtual_machine_id` (Number)
 
 ### Optional

--- a/netbox/resource_netbox_virtual_disk.go
+++ b/netbox/resource_netbox_virtual_disk.go
@@ -30,7 +30,7 @@ func resourceNetboxVirtualDisks() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"size": {
+			"size_gb": {
 				Type:     schema.TypeInt,
 				Required: true,
 			},
@@ -51,7 +51,7 @@ func resourceNetboxVirtualDisksCreate(ctx context.Context, d *schema.ResourceDat
 	api := m.(*client.NetBoxAPI)
 
 	name := d.Get("name").(string)
-	size := d.Get("size").(int)
+	size := d.Get("size_gb").(int)
 	virtualMachineID := d.Get("virtual_machine_id").(int)
 
 	data := models.WritableVirtualDisk{
@@ -110,7 +110,7 @@ func resourceNetboxVirtualDisksRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("description", VirtualDisks.Description)
 
 	if VirtualDisks.Size != nil {
-		d.Set("size", *VirtualDisks.Size)
+		d.Set("size_gb", *VirtualDisks.Size)
 	}
 	if VirtualDisks.VirtualMachine != nil {
 		d.Set("virtual_machine_id", VirtualDisks.VirtualMachine.ID)
@@ -132,7 +132,7 @@ func resourceNetboxVirtualDisksUpdate(ctx context.Context, d *schema.ResourceDat
 	data := models.WritableVirtualDisk{}
 
 	name := d.Get("name").(string)
-	size := int64(d.Get("size").(int))
+	size := int64(d.Get("size_gb").(int))
 	virtualMachineID := int64(d.Get("virtual_machine_id").(int))
 
 	data.Name = &name

--- a/netbox/resource_netbox_virtual_disk_test.go
+++ b/netbox/resource_netbox_virtual_disk_test.go
@@ -37,7 +37,7 @@ resource "netbox_virtual_machine" "test" {
 resource "netbox_virtual_disk" "test" {
 	name = "%[1]s"
 	description = "description"
-	size = 30
+	size_gb = 30
 	virtual_machine_id = netbox_virtual_machine.test.id
 	tags = [netbox_tag.tag_a.name]
 }
@@ -60,7 +60,7 @@ resource "netbox_virtual_machine" "test" {
 resource "netbox_virtual_disk" "test" {
 	name = "%[1]s_updated"
 	description = "description updated"
-	size = 60
+	size_gb = 60
 	virtual_machine_id = netbox_virtual_machine.test.id
 	tags = [netbox_tag.tag_a.name]
 }


### PR DESCRIPTION
@Ikke I just realized (after merging :grimacing: ) that the size attribute did not have a unit suffix. From a user perspective, I find it very convenient when I do not have to wonder "ok and what unit is this exactly?" when using a resource. I did the same in the virtual machine resource itself, which also makes this consistent.