### PR TITLE
Allow netbox_custom_field to accept `object` as type, and specify `object_type`

### DIFF
--- a/netbox/resource_netbox_custom_field.go
+++ b/netbox/resource_netbox_custom_field.go
@@ -40,7 +40,12 @@ func resourceCustomField() *schema.Resource {
 					models.CustomFieldTypeValueSelect,
 					models.CustomFieldTypeValueMultiselect,
 					models.CustomFieldTypeValueJSON,
+					models.CustomFieldTypeValueObject,
 				}, false),
+			},
+			"object_type": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"content_types": {
 				Type:     schema.TypeSet,
@@ -108,6 +113,7 @@ func resourceNetboxCustomFieldUpdate(d *schema.ResourceData, m interface{}) erro
 	data := &models.WritableCustomField{
 		Name:            strToPtr(d.Get("name").(string)),
 		Type:            d.Get("type").(string),
+		ObjectType:      d.Get("object_type").(string),
 		Description:     d.Get("description").(string),
 		GroupName:       d.Get("group_name").(string),
 		Label:           d.Get("label").(string),
@@ -154,6 +160,7 @@ func resourceNetboxCustomFieldCreate(d *schema.ResourceData, m interface{}) erro
 	data := &models.WritableCustomField{
 		Name:            strToPtr(d.Get("name").(string)),
 		Type:            d.Get("type").(string),
+		ObjectType:      d.Get("object_type").(string),
 		Description:     d.Get("description").(string),
 		GroupName:       d.Get("group_name").(string),
 		Label:           d.Get("label").(string),
@@ -217,6 +224,7 @@ func resourceNetboxCustomFieldRead(d *schema.ResourceData, m interface{}) error 
 	customField := res.GetPayload()
 	d.Set("name", customField.Name)
 	d.Set("type", *customField.Type.Value)
+	d.Set("object_type", customField.ObjectType)
 
 	d.Set("content_types", customField.ContentTypes)
 

--- a/netbox/resource_netbox_custom_field_test.go
+++ b/netbox/resource_netbox_custom_field_test.go
@@ -64,6 +64,35 @@ resource "netbox_custom_field" "test" {
 	})
 }
 
+func TestAccNetboxCustomField_object(t *testing.T) {
+	testSlug := "custom_fields_object"
+	testName := strings.ReplaceAll(testAccGetTestName(testSlug), "-", "_")
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_custom_field" "test" {
+  name = "%s"
+  type = "object"
+  object_type = "ipam.prefix"
+  content_types = ["virtualization.vminterface"]
+  group_name = "mygroup"
+  weight = 100
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_custom_field.test", "name", testName),
+					resource.TestCheckResourceAttr("netbox_custom_field.test", "type", "object"),
+					resource.TestCheckTypeSetElemAttr("netbox_custom_field.test", "content_types.*", "virtualization.vminterface"),
+					resource.TestCheckResourceAttr("netbox_custom_field.test", "group_name", "mygroup"),
+					resource.TestCheckResourceAttr("netbox_custom_field.test", "weight", "100"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetboxCustomField_integer(t *testing.T) {
 	testSlug := "custom_fields_integer"
 	testName := strings.ReplaceAll(testAccGetTestName(testSlug), "-", "_")


### PR DESCRIPTION
go-netbox has these additional values defined: https://github.com/fbreckle/go-netbox/blob/2513e68359ff2e42cfc1deed72034bd8ff1dee8e/netbox/models/custom_field.go#L989-L999

But the provider rejects them as invalid.

Tested OK on my personal netbox.