### PR TITLE
feat: add 'is_private' field to 'netbox_rir' resource

### DIFF
--- a/docs/resources/rir.md
+++ b/docs/resources/rir.md
@@ -32,6 +32,7 @@ resource "netbox_rir" "test" {
 ### Optional
 
 - `description` (String)
+- `is_private` (Boolean) Defaults to `false`.
 - `slug` (String)
 
 ### Read-Only

--- a/netbox/resource_netbox_rir.go
+++ b/netbox/resource_netbox_rir.go
@@ -36,12 +36,18 @@ func resourceNetboxRir() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"is_private": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 	}
 }
+
 func resourceNetboxRirCreate(d *schema.ResourceData, m interface{}) error {
 	api := m.(*client.NetBoxAPI)
 	data := models.RIR{}
@@ -60,6 +66,7 @@ func resourceNetboxRirCreate(d *schema.ResourceData, m interface{}) error {
 	data.Slug = &slug
 	data.Description = getOptionalStr(d, "description", true)
 	data.Tags = []*models.NestedTag{}
+	data.IsPrivate = d.Get("is_private").(bool)
 
 	params := ipam.NewIpamRirsCreateParams().WithData(&data)
 	res, err := api.Ipam.IpamRirsCreate(params, nil)
@@ -94,6 +101,7 @@ func resourceNetboxRirRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("name", rir.Name)
 	d.Set("slug", rir.Slug)
 	d.Set("description", rir.Description)
+	d.Set("is_private", rir.IsPrivate)
 
 	return nil
 }
@@ -117,6 +125,7 @@ func resourceNetboxRirUpdate(d *schema.ResourceData, m interface{}) error {
 	data.Slug = &slug
 	data.Description = getOptionalStr(d, "description", true)
 	data.Tags = []*models.NestedTag{}
+	data.IsPrivate = d.Get("is_private").(bool)
 
 	params := ipam.NewIpamRirsUpdateParams().WithID(id).WithData(&data)
 	_, err := api.Ipam.IpamRirsUpdate(params, nil)

--- a/netbox/resource_netbox_rir_test.go
+++ b/netbox/resource_netbox_rir_test.go
@@ -41,6 +41,57 @@ resource "netbox_rir" "test_basic" {
 	})
 }
 
+func TestAccNetboxRir_privacy(t *testing.T) {
+	testSlug := "rir_privacy"
+	testName := testAccGetTestName(testSlug)
+	randomSlug := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_rir" "test_privacy" {
+  name        = "%s"
+  slug        = "%s"
+  is_private  = false
+}`, testName, randomSlug),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_rir.test_privacy", "name", testName),
+					resource.TestCheckResourceAttr("netbox_rir.test_privacy", "slug", randomSlug),
+					resource.TestCheckResourceAttr("netbox_rir.test_privacy", "is_private", "false"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_rir" "test_privacy" {
+  name        = "%s"
+  slug        = "%s"
+  is_private  = true
+}`, testName, randomSlug),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_rir.test_privacy", "name", testName),
+					resource.TestCheckResourceAttr("netbox_rir.test_privacy", "slug", randomSlug),
+					resource.TestCheckResourceAttr("netbox_rir.test_privacy", "is_private", "true"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_rir" "test_privacy" {
+  name        = "%s"
+  slug        = "%s"
+  is_private  = false
+}`, testName, randomSlug),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_rir.test_privacy", "name", testName),
+					resource.TestCheckResourceAttr("netbox_rir.test_privacy", "slug", randomSlug),
+					resource.TestCheckResourceAttr("netbox_rir.test_privacy", "is_private", "false"),
+				),
+			},
+		},
+	})
+}
+
 func init() {
 	resource.AddTestSweepers("netbox_rir", &resource.Sweeper{
 		Name:         "netbox_rir",


### PR DESCRIPTION
Adds the `is_private` field to rirs. However the test don't pass as it seems there's a bug in go-netbox (i tested it separately) . I can successfully add a rir with `is_private` set to true or false, I can update it from false to true, but nothing happens when trying to update it from true to false.