### PR TITLE
`data.netbox_prefix`: add custom fields and role_id

### DIFF
--- a/netbox/data_source_netbox_prefix.go
+++ b/netbox/data_source_netbox_prefix.go
@@ -27,6 +27,7 @@ func dataSourceNetboxPrefix() *schema.Resource {
 				ValidateFunc:  validation.IsCIDR,
 				AtLeastOneOf:  []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
 			},
+			customFieldsKey: customFieldsSchema,
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -175,6 +176,13 @@ func dataSourceNetboxPrefixRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("family", int(*result.Family.Value))
 	d.Set("tags", getTagListFromNestedTagList(result.Tags))
 
+	cf := getCustomFields(result.CustomFields)
+	if cf != nil {
+		d.Set(customFieldsKey, cf)
+	}
+	if result.Role != nil {
+		d.Set("role_id", result.Role.ID)
+	}
 	if result.Vrf != nil {
 		d.Set("vrf_id", result.Vrf.ID)
 	}

--- a/netbox/data_source_netbox_prefix.go
+++ b/netbox/data_source_netbox_prefix.go
@@ -25,55 +25,61 @@ func dataSourceNetboxPrefix() *schema.Resource {
 				Deprecated:    "The `cidr` parameter is deprecated in favor of the canonical `prefix` attribute.",
 				ConflictsWith: []string{"prefix"},
 				ValidateFunc:  validation.IsCIDR,
-				AtLeastOneOf:  []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf:  []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
 			},
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
 				Description:  "Description to include in the data source filter.",
 			},
 			"family": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
-				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
 				ValidateFunc: validation.IntInSlice([]int{4, 6}),
 				Description:  "The IP family of the prefix. One of 4 or 6",
+			},
+			"role_id": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
 			},
 			"prefix": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ValidateFunc:  validation.IsCIDR,
 				ConflictsWith: []string{"cidr"},
-				AtLeastOneOf:  []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf:  []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
 			},
 			"vlan_vid": {
 				Type:         schema.TypeFloat,
 				Optional:     true,
-				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
 				ValidateFunc: validation.FloatBetween(1, 4094),
 			},
 			"vrf_id": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
 			},
 			"vlan_id": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
 			},
 			"site_id": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
 			},
 			"tag": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "cidr", "tag"},
+				AtLeastOneOf: []string{"description", "family", "prefix", "vlan_vid", "vrf_id", "vlan_id", "site_id", "role_id", "cidr", "tag"},
 				Description:  "Tag to include in the data source filter (must match the tag's slug).",
 			},
 			"tag__n": {
@@ -112,6 +118,10 @@ func dataSourceNetboxPrefixRead(d *schema.ResourceData, m interface{}) error {
 	if family, ok := d.Get("family").(int); ok && family != 0 {
 		familyFloat := float64(family)
 		params.Family = &familyFloat
+	}
+
+	if roleID, ok := d.Get("role_id").(int); ok && roleID != 0 {
+		params.RoleID = strToPtr(strconv.Itoa(roleID))
 	}
 
 	if prefix, ok := d.Get("prefix").(string); ok && prefix != "" {

--- a/netbox/data_source_netbox_prefix_test.go
+++ b/netbox/data_source_netbox_prefix_test.go
@@ -31,12 +31,17 @@ resource "netbox_site" "test" {
   name = "%[1]s_site"
 }
 
+resource "netbox_ipam_role" "test" {
+  name        = "%[1]s_role"
+}
+
 resource "netbox_prefix" "testv4" {
   prefix = "%[2]s"
   status = "active"
   vrf_id = netbox_vrf.test.id
   vlan_id = netbox_vlan.test.id
   site_id = netbox_site.test.id
+  role_id = netbox_ipam_role.test.id
   description = "%[1]s_description_test_idv4"
 }
 
@@ -87,6 +92,11 @@ data "netbox_prefix" "by_site_id" {
   family  = 4
 }
 
+data "netbox_prefix" "by_role_id" {
+  depends_on = [netbox_prefix.testv4]
+  role_id = netbox_ipam_role.test.id
+}
+
 data "netbox_prefix" "by_family" {
   depends_on = [netbox_prefix.testv6]
 	family     = 6
@@ -101,6 +111,7 @@ data "netbox_prefix" "by_family" {
 					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_vlan_id", "id", "netbox_prefix.testv4", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_vlan_vid", "id", "netbox_prefix.testv4", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_site_id", "id", "netbox_prefix.testv4", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_role_id", "id", "netbox_prefix.testv4", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_prefix.by_family", "id", "netbox_prefix.testv6", "id"),
 				),
 			},


### PR DESCRIPTION
This PR contains two bits of work related to `data.netbox_prefix`.

1. Adds `role_id` as a field returned by `data.netbox_prefix`, and allows searching by `role_id`.
2. Return any `custom_fields` defined on `data.netbox_prefix`

Thanks!