### PR TITLE
Add manufacturer_id to `netbox_platform` data and resource blocks

### DIFF
--- a/docs/data-sources/platform.md
+++ b/docs/data-sources/platform.md
@@ -29,5 +29,6 @@ data "netbox_platform" "PANOS" {
 
 - `id` (String) The ID of this resource.
 - `slug` (String)
+- `manufacturer_id` (String)
 
 

--- a/docs/resources/platform.md
+++ b/docs/resources/platform.md
@@ -32,6 +32,7 @@ resource "netbox_platform" "PANOS" {
 ### Optional
 
 - `slug` (String)
+- `manufacturer_id` (String)
 
 ### Read-Only
 

--- a/netbox/data_source_netbox_platform.go
+++ b/netbox/data_source_netbox_platform.go
@@ -22,6 +22,10 @@ func dataSourceNetboxPlatform() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"manufacturer_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -50,5 +54,8 @@ func dataSourceNetboxPlatformRead(d *schema.ResourceData, m interface{}) error {
 	d.SetId(strconv.FormatInt(result.ID, 10))
 	d.Set("name", result.Name)
 	d.Set("slug", result.Slug)
+	if result.Manufacturer != nil {
+		d.Set("manufacturer_id", result.Manufacturer.ID)
+	}
 	return nil
 }

--- a/netbox/data_source_netbox_platform_test.go
+++ b/netbox/data_source_netbox_platform_test.go
@@ -29,3 +29,32 @@ data "netbox_platform" "test" {
 		},
 	})
 }
+
+func TestAccNetboxPlatformDataSource_manufacturer(t *testing.T) {
+	testSlug := "pltf_ds_manufacturer"
+	testName := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_manufacturer" "test" {
+  name = "%[1]s"
+}
+
+resource "netbox_platform" "test" {
+  name = "%[1]s"
+  manufacturer_id = netbox_manufacturer.test.id
+}
+data "netbox_platform" "test" {
+  depends_on = [netbox_platform.test]
+  name = "%[1]s"
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("data.netbox_platform.test", "id", "netbox_platform.test", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_platform.test", "manufacturer_id", "netbox_manufacturer.test", "id"),
+				),
+			},
+		},
+	})
+}

--- a/netbox/resource_netbox_platform.go
+++ b/netbox/resource_netbox_platform.go
@@ -32,6 +32,10 @@ func resourceNetboxPlatform() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
+			"manufacturer_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -53,13 +57,18 @@ func resourceNetboxPlatformCreate(d *schema.ResourceData, m interface{}) error {
 		slug = slugValue.(string)
 	}
 
-	params := dcim.NewDcimPlatformsCreateParams().WithData(
-		&models.WritablePlatform{
-			Name: &name,
-			Slug: &slug,
-			Tags: []*models.NestedTag{},
-		},
-	)
+	data := models.WritablePlatform{
+		Name: &name,
+		Slug: &slug,
+		Tags: []*models.NestedTag{},
+	}
+
+	manufacturerIDValue, ok := d.GetOk("manufacturer_id")
+	if ok {
+		data.Manufacturer = int64ToPtr(int64(manufacturerIDValue.(int)))
+	}
+
+	params := dcim.NewDcimPlatformsCreateParams().WithData(&data)
 
 	res, err := api.Dcim.DcimPlatformsCreate(params, nil)
 	if err != nil {
@@ -91,8 +100,13 @@ func resourceNetboxPlatformRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.Set("name", res.GetPayload().Name)
-	d.Set("slug", res.GetPayload().Slug)
+	result := res.GetPayload()
+
+	d.Set("name", result.Name)
+	d.Set("slug", result.Slug)
+	if result.Manufacturer != nil {
+		d.Set("manufacturer_id", result.Manufacturer.ID)
+	}
 	return nil
 }
 
@@ -116,6 +130,11 @@ func resourceNetboxPlatformUpdate(d *schema.ResourceData, m interface{}) error {
 	data.Slug = &slug
 	data.Name = &name
 	data.Tags = []*models.NestedTag{}
+
+	manufacturerIDValue, ok := d.GetOk("manufacturer_id")
+	if ok {
+		data.Manufacturer = int64ToPtr(int64(manufacturerIDValue.(int)))
+	}
 
 	params := dcim.NewDcimPlatformsPartialUpdateParams().WithID(id).WithData(&data)
 

--- a/netbox/resource_netbox_platform_test.go
+++ b/netbox/resource_netbox_platform_test.go
@@ -39,6 +39,41 @@ resource "netbox_platform" "test" {
 	})
 }
 
+func TestAccNetboxPlatform_manufacturer(t *testing.T) {
+	testSlug := "platform_manufacturer"
+	testName := testAccGetTestName(testSlug)
+	testManufacturer := "manu_test"
+	randomSlug := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_manufacturer" "test" {
+  name = "%[3]s"
+}
+
+resource "netbox_platform" "test" {
+  name = "%[1]s"
+  slug = "%[2]s"
+  manufacturer_id = netbox_manufacturer.test.id
+}`, testName, randomSlug, testManufacturer),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_platform.test", "name", testName),
+					resource.TestCheckResourceAttr("netbox_platform.test", "slug", randomSlug),
+					resource.TestCheckResourceAttrPair("netbox_platform.test", "manufacturer_id", "netbox_manufacturer.test", "id"),
+				),
+			},
+			{
+				ResourceName:      "netbox_platform.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccNetboxPlatform_defaultSlug(t *testing.T) {
 	testSlug := "platform_defSlug"
 	testName := testAccGetTestName(testSlug)


### PR DESCRIPTION
Add manufacturer_id to `netbox_platfrom` data and resource blocks.

Just trying to add stuff as I come across it missing :sweat_smile: 

Let me know if any changes are required, thanks!