### PR TITLE
fix: avoid override of device's values on primary ip creation and update

### DIFF
--- a/netbox/resource_netbox_device.go
+++ b/netbox/resource_netbox_device.go
@@ -464,18 +464,6 @@ func resourceNetboxDeviceUpdate(ctx context.Context, d *schema.ResourceData, m i
 		data.ConfigTemplate = &configTemplateID
 	}
 
-	primaryIP4Value, ok := d.GetOk("primary_ipv4")
-	if ok {
-		primaryIP4 := int64(primaryIP4Value.(int))
-		data.PrimaryIp4 = &primaryIP4
-	}
-
-	primaryIP6Value, ok := d.GetOk("primary_ipv6")
-	if ok {
-		primaryIP6 := int64(primaryIP6Value.(int))
-		data.PrimaryIp6 = &primaryIP6
-	}
-
 	data.Rack = getOptionalInt(d, "rack_id")
 	data.Face = getOptionalStr(d, "rack_face", false)
 	data.Position = getOptionalFloat(d, "rack_position")

--- a/netbox/resource_netbox_device_primary_ip.go
+++ b/netbox/resource_netbox_device_primary_ip.go
@@ -101,6 +101,7 @@ func resourceNetboxDevicePrimaryIPUpdate(d *schema.ResourceData, m interface{}) 
 
 	// then update the FULL device with ALL tracked attributes
 	data := models.WritableDeviceWithConfigContext{}
+
 	data.Name = device.Name
 	data.Tags = device.Tags
 	// the netbox API sends the URL property as part of NestedTag, but it does not accept the URL property when we send it back
@@ -111,23 +112,12 @@ func resourceNetboxDevicePrimaryIPUpdate(d *schema.ResourceData, m interface{}) 
 		tag.Display = ""
 	}
 
-	data.Comments = device.Comments
-	data.Serial = device.Serial
-
 	if device.DeviceType != nil {
 		data.DeviceType = &device.DeviceType.ID
 	}
 
-	if device.Cluster != nil {
-		data.Cluster = &device.Cluster.ID
-	}
-
 	if device.Site != nil {
 		data.Site = &device.Site.ID
-	}
-
-	if device.Location != nil {
-		data.Location = &device.Location.ID
 	}
 
 	if device.Role != nil {
@@ -140,30 +130,6 @@ func resourceNetboxDevicePrimaryIPUpdate(d *schema.ResourceData, m interface{}) 
 
 	if device.PrimaryIp6 != nil {
 		data.PrimaryIp6 = &device.PrimaryIp6.ID
-	}
-
-	if device.Platform != nil {
-		data.Platform = &device.Platform.ID
-	}
-
-	if device.Tenant != nil {
-		data.Tenant = &device.Tenant.ID
-	}
-
-	if device.Status != nil {
-		data.Status = *device.Status.Value
-	}
-
-	if device.Rack != nil {
-		data.Rack = &device.Rack.ID
-	}
-
-	if device.Face != nil {
-		data.Face = *device.Face.Value
-	}
-
-	if device.Position != nil {
-		data.Position = device.Position
 	}
 
 	// unset primary ip address if -1 is passed as id
@@ -181,9 +147,9 @@ func resourceNetboxDevicePrimaryIPUpdate(d *schema.ResourceData, m interface{}) 
 		}
 	}
 
-	updateParams := dcim.NewDcimDevicesUpdateParams().WithID(deviceID).WithData(&data)
+	updateParams := dcim.NewDcimDevicesPartialUpdateParams().WithID(deviceID).WithData(&data)
 
-	_, err = api.Dcim.DcimDevicesUpdate(updateParams, nil)
+	_, err = api.Dcim.DcimDevicesPartialUpdate(updateParams, nil)
 	if err != nil {
 		return err
 	}

--- a/netbox/resource_netbox_device_primary_ip_test.go
+++ b/netbox/resource_netbox_device_primary_ip_test.go
@@ -172,3 +172,271 @@ resource "netbox_device_primary_ip" "test_v6" {
 		},
 	})
 }
+
+func TestAccNetboxDevicePrimaryIP4_removePrimary(t *testing.T) {
+	testSlug := "pr_ip_removePrimary"
+	testName := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test2" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "thisisacomment"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test2" {
+  device_id = netbox_device.test2.id
+  name = "%[1]s"
+  type = "1000base-t"
+}
+
+resource "netbox_ip_address" "test_v4_2" {
+  ip_address = "1.1.1.16/32"
+  status = "active"
+  interface_id = netbox_device_interface.test2.id
+  object_type = "dcim.interface"
+}
+
+resource "netbox_device_primary_ip" "test_v4_2" {
+  device_id = netbox_device.test2.id
+  ip_address_id = netbox_ip_address.test_v4_2.id
+}`, testName),
+			},
+			// A repeated second step is required, so that the resource "netbox_device" "test2" goes through a resourceNetboxDeviceRead cycle
+			// This is needed because adding a netbox_device_primary_ip updates the netbox_device
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test2" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "thisisacomment"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test2" {
+  device_id = netbox_device.test2.id
+  name = "%[1]s"
+  type = "1000base-t"
+}
+
+resource "netbox_ip_address" "test_v4_2" {
+  ip_address = "1.1.1.16/32"
+  status = "active"
+  interface_id = netbox_device_interface.test2.id
+  object_type = "dcim.interface"
+}
+
+resource "netbox_device_primary_ip" "test_v4_2" {
+  device_id = netbox_device.test2.id
+  ip_address_id = netbox_ip_address.test_v4_2.id
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_2", "device_id", "netbox_device.test2", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_2", "ip_address_id", "netbox_ip_address.test_v4_2", "id"),
+				),
+			},
+			// Now we do 2 things: modify netbox_device.test2 (changing the comment value), AND we remove the IP and primary IP
+			// This fails with:
+			//        Error: [PUT /dcim/devices/{id}/][400] dcim_devices_update default {"primary_ip4":["Related object not found using the provided numeric ID: 14"]}
+			// because (I think) that the device is doing 1) a read of the current state, 2) the deletion of the primary IP then modifies the device, 3) the device then tries to write its changes, but its now out of date
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test2" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "thisisacomment with changes"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test2" {
+  device_id = netbox_device.test2.id
+  name = "%[1]s"
+  type = "1000base-t"
+}
+`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_device.test2", "name", testName),
+					resource.TestCheckResourceAttr("netbox_device.test2", "primary_ipv4", "0"),
+					resource.TestCheckResourceAttr("netbox_device.test2", "tags.#", "1"),
+					resource.TestCheckResourceAttr("netbox_device.test2", "tags.0", testName),
+					resource.TestCheckResourceAttr("netbox_device.test2", "status", "planned"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetboxDevicePrimaryIP4_updateDevice(t *testing.T) {
+	testSlug := "pr_ip_updateDevice"
+	testName := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test3" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "comment1"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test3" {
+  device_id = netbox_device.test3.id
+  name = "%[1]s"
+  type = "1000base-t"
+}
+
+resource "netbox_ip_address" "test_v4_3" {
+  ip_address = "1.1.1.18/32"
+  status = "active"
+  interface_id = netbox_device_interface.test3.id
+  object_type = "dcim.interface"
+}
+
+resource "netbox_device_primary_ip" "test_v4_3" {
+  device_id = netbox_device.test3.id
+  ip_address_id = netbox_ip_address.test_v4_3.id
+}`, testName),
+			},
+			// A repeated second step is required, so that the resource "netbox_device" "test2" goes through a resourceNetboxDeviceRead cycle
+			// This is needed because adding a netbox_device_primary_ip updates the netbox_device
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test3" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "comment1"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test3" {
+  device_id = netbox_device.test3.id
+  name = "%[1]s"
+  type = "1000base-t"
+}
+
+resource "netbox_ip_address" "test_v4_3" {
+  ip_address = "1.1.1.18/32"
+  status = "active"
+  interface_id = netbox_device_interface.test3.id
+  object_type = "dcim.interface"
+}
+
+resource "netbox_device_primary_ip" "test_v4_3" {
+  device_id = netbox_device.test3.id
+  ip_address_id = netbox_ip_address.test_v4_3.id
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_3", "device_id", "netbox_device.test3", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_3", "ip_address_id", "netbox_ip_address.test_v4_3", "id"),
+				),
+			},
+			// Now we do 2 things: modify netbox_device.test3 (changing the comment value), AND we remove the IP and primary IP
+			// This fails with:
+			//        Error: [PUT /dcim/devices/{id}/][400] dcim_devices_update default {"primary_ip4":["Related object not found using the provided numeric ID: 14"]}
+			// because (I think) that the device is doing 1) a read of the current state, 2) the deletion of the primary IP then modifies the device, 3) the device then tries to write its changes, but its now out of date
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test3" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "comment2"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test3" {
+  device_id = netbox_device.test3.id
+  name = "%[1]s"
+  type = "1000base-t"
+}
+
+resource "netbox_ip_address" "test_v4_3" {
+  ip_address = "1.1.1.18/32"
+  status = "active"
+  interface_id = netbox_device_interface.test3.id
+  object_type = "dcim.interface"
+}
+
+resource "netbox_device_primary_ip" "test_v4_3" {
+  device_id = netbox_device.test3.id
+  ip_address_id = netbox_ip_address.test_v4_3.id
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_device.test3", "name", testName),
+					resource.TestCheckResourceAttr("netbox_device.test3", "tags.#", "1"),
+					resource.TestCheckResourceAttr("netbox_device.test3", "tags.0", testName),
+					resource.TestCheckResourceAttr("netbox_device.test3", "status", "planned"),
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_3", "device_id", "netbox_device.test3", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_3", "ip_address_id", "netbox_ip_address.test_v4_3", "id"),
+				),
+			},
+		},
+	})
+}

--- a/netbox/resource_netbox_device_primary_ip_test.go
+++ b/netbox/resource_netbox_device_primary_ip_test.go
@@ -301,7 +301,7 @@ resource "netbox_device_interface" "test2" {
 	})
 }
 
-func TestAccNetboxDevicePrimaryIP4_updateDevice(t *testing.T) {
+func TestAccNetboxDevicePrimaryIP4_simpleUpdateDevice(t *testing.T) {
 	testSlug := "pr_ip_updateDevice"
 	testName := testAccGetTestName(testSlug)
 	resource.ParallelTest(t, resource.TestCase{
@@ -334,7 +334,7 @@ resource "netbox_device_interface" "test3" {
 }
 
 resource "netbox_ip_address" "test_v4_3" {
-  ip_address = "1.1.1.18/32"
+  ip_address = "1.1.1.101/32"
   status = "active"
   interface_id = netbox_device_interface.test3.id
   object_type = "dcim.interface"
@@ -345,53 +345,7 @@ resource "netbox_device_primary_ip" "test_v4_3" {
   ip_address_id = netbox_ip_address.test_v4_3.id
 }`, testName),
 			},
-			// A repeated second step is required, so that the resource "netbox_device" "test2" goes through a resourceNetboxDeviceRead cycle
-			// This is needed because adding a netbox_device_primary_ip updates the netbox_device
-			{
-				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
-resource "netbox_device" "test3" {
-  name = "%[1]s"
-  role_id = netbox_device_role.test.id
-  site_id = netbox_site.test.id
-  device_type_id = netbox_device_type.test.id
-  cluster_id = netbox_cluster.test.id
-  platform_id = netbox_platform.test.id
-  location_id = netbox_location.test.id
-  comments = "comment1"
-  status = "planned"
-  rack_id = netbox_rack.test.id
-  rack_face = "front"
-  rack_position = 11
-
-  tags = [netbox_tag.test.name]
-}
-
-resource "netbox_device_interface" "test3" {
-  device_id = netbox_device.test3.id
-  name = "%[1]s"
-  type = "1000base-t"
-}
-
-resource "netbox_ip_address" "test_v4_3" {
-  ip_address = "1.1.1.18/32"
-  status = "active"
-  interface_id = netbox_device_interface.test3.id
-  object_type = "dcim.interface"
-}
-
-resource "netbox_device_primary_ip" "test_v4_3" {
-  device_id = netbox_device.test3.id
-  ip_address_id = netbox_ip_address.test_v4_3.id
-}`, testName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_3", "device_id", "netbox_device.test3", "id"),
-					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_3", "ip_address_id", "netbox_ip_address.test_v4_3", "id"),
-				),
-			},
-			// Now we do 2 things: modify netbox_device.test3 (changing the comment value), AND we remove the IP and primary IP
-			// This fails with:
-			//        Error: [PUT /dcim/devices/{id}/][400] dcim_devices_update default {"primary_ip4":["Related object not found using the provided numeric ID: 14"]}
-			// because (I think) that the device is doing 1) a read of the current state, 2) the deletion of the primary IP then modifies the device, 3) the device then tries to write its changes, but its now out of date
+			// Update the device and check the primary ip value
 			{
 				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
 resource "netbox_device" "test3" {
@@ -414,11 +368,11 @@ resource "netbox_device" "test3" {
 resource "netbox_device_interface" "test3" {
   device_id = netbox_device.test3.id
   name = "%[1]s"
-  type = "1000base-t"
+  type = "virtual"
 }
 
 resource "netbox_ip_address" "test_v4_3" {
-  ip_address = "1.1.1.18/32"
+  ip_address = "1.1.1.101/32"
   status = "active"
   interface_id = netbox_device_interface.test3.id
   object_type = "dcim.interface"
@@ -429,12 +383,476 @@ resource "netbox_device_primary_ip" "test_v4_3" {
   ip_address_id = netbox_ip_address.test_v4_3.id
 }`, testName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("netbox_device.test3", "name", testName),
-					resource.TestCheckResourceAttr("netbox_device.test3", "tags.#", "1"),
-					resource.TestCheckResourceAttr("netbox_device.test3", "tags.0", testName),
-					resource.TestCheckResourceAttr("netbox_device.test3", "status", "planned"),
 					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_3", "device_id", "netbox_device.test3", "id"),
 					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_3", "ip_address_id", "netbox_ip_address.test_v4_3", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test3", "primary_ipv4", "netbox_ip_address.test_v4_3", "id"),
+				),
+			},
+			// Update the device and the interface and check the primary ip value
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test3" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "comment3"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test3" {
+  device_id = netbox_device.test3.id
+  name = "%[1]s"
+  type = "1000base-t"
+}
+
+resource "netbox_ip_address" "test_v4_3" {
+  ip_address = "1.1.1.101/32"
+  status = "active"
+  interface_id = netbox_device_interface.test3.id
+  object_type = "dcim.interface"
+}
+
+resource "netbox_device_primary_ip" "test_v4_3" {
+  device_id = netbox_device.test3.id
+  ip_address_id = netbox_ip_address.test_v4_3.id
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_3", "device_id", "netbox_device.test3", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_3", "ip_address_id", "netbox_ip_address.test_v4_3", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test3", "primary_ipv4", "netbox_ip_address.test_v4_3", "id"),
+				),
+			},
+			// Update the device, the interface and the IP address, then check the primary ip
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test3" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "comment4"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test3" {
+  device_id = netbox_device.test3.id
+  name = "%[1]s"
+  type = "virtual"
+}
+
+resource "netbox_ip_address" "test_v4_3" {
+  ip_address = "1.1.1.102/32"
+  status = "active"
+  interface_id = netbox_device_interface.test3.id
+  object_type = "dcim.interface"
+}
+
+resource "netbox_device_primary_ip" "test_v4_3" {
+  device_id = netbox_device.test3.id
+  ip_address_id = netbox_ip_address.test_v4_3.id
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_3", "device_id", "netbox_device.test3", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_3", "ip_address_id", "netbox_ip_address.test_v4_3", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test3", "primary_ipv4", "netbox_ip_address.test_v4_3", "id"),
+				),
+			},
+			// Force a read at the end
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test3" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "commnent4"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test3" {
+  device_id = netbox_device.test3.id
+  name = "%[1]s"
+  type = "virtual"
+}
+
+resource "netbox_ip_address" "test_v4_3" {
+  ip_address = "1.1.1.102/32"
+  status = "active"
+  interface_id = netbox_device_interface.test3.id
+  object_type = "dcim.interface"
+}
+
+resource "netbox_device_primary_ip" "test_v4_3" {
+  device_id = netbox_device.test3.id
+  ip_address_id = netbox_ip_address.test_v4_3.id
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_3", "device_id", "netbox_device.test3", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_3", "ip_address_id", "netbox_ip_address.test_v4_3", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test3", "primary_ipv4", "netbox_ip_address.test_v4_3", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetboxDevicePrimaryIP4_refsUpdateDevice(t *testing.T) {
+	testSlug := "pr_ip_refUpdateDevice"
+	testName := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test4" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "comment1"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test4" {
+  device_id = netbox_device.test4.id
+  name = "%[1]s"
+  type = "1000base-t"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "netbox_ip_address" "test_v4_4" {
+  ip_address = "1.1.2.101/32"
+  status = "active"
+  interface_id = netbox_device_interface.test4.id
+  object_type = "dcim.interface"
+}
+
+resource "netbox_device_primary_ip" "test_v4_4" {
+  device_id = netbox_device.test4.id
+  ip_address_id = netbox_ip_address.test_v4_4.id
+}`, testName),
+			},
+			// Switch the interface for a new one
+			// the create_before_destroy lifecycle ensures the interface exists at all times
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test4" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "comment1"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test4_2" {
+  device_id = netbox_device.test4.id
+  name = "%[1]s-2"
+  type = "1000base-t"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "netbox_ip_address" "test_v4_4" {
+  ip_address = "1.1.2.101/32"
+  status = "active"
+  interface_id = netbox_device_interface.test4_2.id
+  object_type = "dcim.interface"
+}
+
+resource "netbox_device_primary_ip" "test_v4_4" {
+  device_id = netbox_device.test4.id
+  ip_address_id = netbox_ip_address.test_v4_4.id
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_4", "device_id", "netbox_device.test4", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_4", "ip_address_id", "netbox_ip_address.test_v4_4", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test4", "primary_ipv4", "netbox_ip_address.test_v4_4", "id"),
+				),
+			},
+			// switch the ip address for a new one
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test4" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "comment1"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test4_2" {
+  device_id = netbox_device.test4.id
+  name = "%[1]s-2"
+  type = "1000base-t"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "netbox_ip_address" "test_v4_4_2" {
+  ip_address = "1.1.2.102/32"
+  status = "active"
+  interface_id = netbox_device_interface.test4_2.id
+  object_type = "dcim.interface"
+}
+
+resource "netbox_device_primary_ip" "test_v4_4" {
+  device_id = netbox_device.test4.id
+  ip_address_id = netbox_ip_address.test_v4_4_2.id
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_4", "device_id", "netbox_device.test4", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_4", "ip_address_id", "netbox_ip_address.test_v4_4_2", "id"),
+					// Needs another read on the device for the field to be accurate
+					//resource.TestCheckResourceAttrPair("netbox_device.test4", "primary_ipv4", "netbox_ip_address.test_v4_4_2", "id"),
+				),
+			},
+			// Force another read to update device
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test4" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "comment1"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test4_2" {
+  device_id = netbox_device.test4.id
+  name = "%[1]s-2"
+  type = "1000base-t"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "netbox_ip_address" "test_v4_4_2" {
+  ip_address = "1.1.2.102/32"
+  status = "active"
+  interface_id = netbox_device_interface.test4_2.id
+  object_type = "dcim.interface"
+}
+
+resource "netbox_device_primary_ip" "test_v4_4" {
+  device_id = netbox_device.test4.id
+  ip_address_id = netbox_ip_address.test_v4_4_2.id
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_4", "device_id", "netbox_device.test4", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_4", "ip_address_id", "netbox_ip_address.test_v4_4_2", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test4", "primary_ipv4", "netbox_ip_address.test_v4_4_2", "id"),
+				),
+			},
+			// Switch both the interface and the ip address at the same time
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test4" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "comment1"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test4_3" {
+  device_id = netbox_device.test4.id
+  name = "%[1]s-3"
+  type = "virtual"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "netbox_ip_address" "test_v4_4_3" {
+  ip_address = "1.1.2.103/32"
+  status = "active"
+  interface_id = netbox_device_interface.test4_3.id
+  object_type = "dcim.interface"
+}
+
+resource "netbox_device_primary_ip" "test_v4_4" {
+  device_id = netbox_device.test4.id
+  ip_address_id = netbox_ip_address.test_v4_4_3.id
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_4", "device_id", "netbox_device.test4", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_4", "ip_address_id", "netbox_ip_address.test_v4_4_3", "id"),
+					// Require another read
+					//resource.TestCheckResourceAttrPair("netbox_device.test4", "primary_ipv4", "netbox_ip_address.test_v4_4_3", "id"),
+				),
+			},
+			// Force another read
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test4" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "comment1"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test4_3" {
+  device_id = netbox_device.test4.id
+  name = "%[1]s-3"
+  type = "virtual"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "netbox_ip_address" "test_v4_4_3" {
+  ip_address = "1.1.2.103/32"
+  status = "active"
+  interface_id = netbox_device_interface.test4_3.id
+  object_type = "dcim.interface"
+}
+
+resource "netbox_device_primary_ip" "test_v4_4" {
+  device_id = netbox_device.test4.id
+  ip_address_id = netbox_ip_address.test_v4_4_3.id
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_4", "device_id", "netbox_device.test4", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_4", "ip_address_id", "netbox_ip_address.test_v4_4_3", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test4", "primary_ipv4", "netbox_ip_address.test_v4_4_3", "id"),
+				),
+			},
+			// Make a new primary IP
+			{
+				Config: testAccNetboxDevicePrimaryIPFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_device" "test4" {
+  name = "%[1]s"
+  role_id = netbox_device_role.test.id
+  site_id = netbox_site.test.id
+  device_type_id = netbox_device_type.test.id
+  cluster_id = netbox_cluster.test.id
+  platform_id = netbox_platform.test.id
+  location_id = netbox_location.test.id
+  comments = "comment1"
+  status = "planned"
+  rack_id = netbox_rack.test.id
+  rack_face = "front"
+  rack_position = 11
+
+  tags = [netbox_tag.test.name]
+}
+
+resource "netbox_device_interface" "test4_3" {
+  device_id = netbox_device.test4.id
+  name = "%[1]s-3"
+  type = "virtual"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "netbox_ip_address" "test_v4_4_3" {
+  ip_address = "1.1.2.103/32"
+  status = "active"
+  interface_id = netbox_device_interface.test4_3.id
+  object_type = "dcim.interface"
+}
+
+resource "netbox_device_primary_ip" "test_v4_4_2" {
+  device_id = netbox_device.test4.id
+  ip_address_id = netbox_ip_address.test_v4_4_3.id
+  ip_address_version = 4
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_4_2", "device_id", "netbox_device.test4", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device_primary_ip.test_v4_4_2", "ip_address_id", "netbox_ip_address.test_v4_4_3", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device.test4", "primary_ipv4", "netbox_ip_address.test_v4_4_3", "id"),
 				),
 			},
 		},


### PR DESCRIPTION
The netbox_device_primary_ip was badly implemented, by using a device update call assigning each parameter of a device one by one, even if it needs to add only two parameters. Thus if one adds a new parameter to the netbox_device resource (e.g. #604), the parameter should also be added to the netbox_device_primary_ip, even though there is no logical link between the two.

To fix this, I simply changed from an update to a partial update call, to avoid overriding any data.