### PR TITLE
Provide resource for finding available interface by name

### DIFF
--- a/netbox/provider.go
+++ b/netbox/provider.go
@@ -74,6 +74,7 @@ func Provider() *schema.Provider {
 	provider := &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
 			"netbox_available_ip_address":       resourceNetboxAvailableIPAddress(),
+			"netbox_available_interface":        resourceNetboxAvailableInterface(),
 			"netbox_virtual_machine":            resourceNetboxVirtualMachine(),
 			"netbox_cluster_type":               resourceNetboxClusterType(),
 			"netbox_cluster":                    resourceNetboxCluster(),

--- a/netbox/resource_netbox_available_interface.go
+++ b/netbox/resource_netbox_available_interface.go
@@ -1,0 +1,104 @@
+package netbox
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strconv"
+	"strings"
+
+	"github.com/fbreckle/go-netbox/netbox/client"
+	"github.com/fbreckle/go-netbox/netbox/client/dcim"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceNetboxAvailableInterface() *schema.Resource {
+	// schema is extended from `netbox_device_interface`
+	resourceSchema := maps.Clone(resourceNetboxDeviceInterfaceSchema)
+	resourceSchema["name"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+	resourceSchema["prefix"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		ForceNew:    true,
+		Description: "Prefix to use for the new interface",
+	}
+
+	return &schema.Resource{
+		CreateContext: resourceNetboxAvailableInterfaceCreate,
+		ReadContext:   resourceNetboxAvailableInterfaceRead,
+		UpdateContext: resourceNetboxAvailableInterfaceUpdate,
+		DeleteContext: resourceNetboxAvailableInterfaceDelete,
+
+		Description: `:meta:subcategory:Data Center Inventory Management (DCIM):From the [official documentation](https://docs.netbox.dev/en/stable/features/device/#interface):
+
+> Interfaces in NetBox represent network interfaces used to exchange data with connected devices. On modern networks, these are most commonly Ethernet, but other types are supported as well. IP addresses and VLANs can be assigned to interfaces.
+
+This is a special resource that is able to allocate a free interface name based on existing interfaces and keep it stable through the Terraform state.`,
+		Schema: resourceSchema,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+	}
+}
+
+func resourceNetboxAvailableInterfaceCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	api := m.(*client.NetBoxAPI)
+
+	deviceID := int64(d.Get("device_id").(int))
+	prefix := d.Get("prefix").(string)
+
+	// secret column that enables natural ordering
+	// see https://github.com/netbox-community/netbox/issues/11279#issuecomment-1367394944
+	ordering := "_name"
+
+	deviceIDStr := strconv.FormatInt(deviceID, 10)
+	p := dcim.DcimInterfacesListParams{
+		DeviceID: &deviceIDStr,
+		NameIsw:  &prefix, // case-insensitive starts with
+		Ordering: &ordering,
+	}
+	res, err := api.Dcim.DcimInterfacesList(&p, nil)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// look for the first suffix that doesn't clash with an existing interface
+	var currentSuffix int64 = 0 // interfaces start with 0
+	for _, intf := range res.GetPayload().Results {
+		ifSuffix, ok := strings.CutPrefix(*intf.Name, prefix)
+		if !ok {
+			continue // just for safety, this should not happen
+		}
+		suffixNum, err := strconv.ParseInt(ifSuffix, 10, 64)
+		if err != nil {
+			// ignore suffixes that are not integers
+			continue
+		}
+		if suffixNum != currentSuffix {
+			// we found a spot
+			break
+		}
+		currentSuffix++
+	}
+
+	ifName := fmt.Sprintf("%s%d", prefix, currentSuffix)
+	d.Set("name", ifName)
+
+	return resourceNetboxDeviceInterfaceCreate(ctx, d, m)
+}
+
+func resourceNetboxAvailableInterfaceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return resourceNetboxDeviceInterfaceRead(ctx, d, m)
+}
+
+func resourceNetboxAvailableInterfaceUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return resourceNetboxDeviceInterfaceUpdate(ctx, d, m)
+}
+
+func resourceNetboxAvailableInterfaceDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return resourceNetboxDeviceInterfaceDelete(ctx, d, m)
+}

--- a/netbox/resource_netbox_available_interface_test.go
+++ b/netbox/resource_netbox_available_interface_test.go
@@ -1,0 +1,196 @@
+package netbox
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func testAccNetboxAvailableInterfaceFullDependencies(testName string) string {
+	return fmt.Sprintf(`
+	resource "netbox_manufacturer" "test" {
+		name = "%[1]s"
+	}
+
+	resource "netbox_device_type" "test" {
+		model = "%[1]s"
+		manufacturer_id = netbox_manufacturer.test.id
+	}
+
+	resource "netbox_device_role" "test" {
+		name = "%[1]s"
+		color_hex = "123456"
+	}
+
+	resource "netbox_site" "test" {
+		name = "%[1]s"
+		status = "active"
+	}
+
+	resource "netbox_device" "test" {
+		name = "%[1]s"
+		device_type_id = netbox_device_type.test.id
+		role_id = netbox_device_role.test.id
+		site_id = netbox_site.test.id
+	}`, testName)
+}
+
+func testAccNetboxAvailableInterfaceMultipleInterfaces(names ...string) string {
+	var config strings.Builder
+
+	for _, name := range names {
+		_, _ = fmt.Fprintf(&config, `
+resource "netbox_device_interface" "%[1]s" {
+	name      = "%[1]s"
+	device_id = netbox_device.test.id
+	type      = "1000base-t"
+}`, name)
+	}
+
+	return config.String()
+}
+
+func TestAccNetboxAvailableInterface_basic(t *testing.T) {
+	testSlug := "available_interface_basic"
+	testName := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`%s
+
+resource "netbox_available_interface" "test" {
+	device_id = netbox_device.test.id
+	prefix    = "tun"
+	type      = "1000base-t"
+}`, testAccNetboxAvailableInterfaceFullDependencies(testName)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_available_interface.test", "name", "tun0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetboxAvailableInterface_gap(t *testing.T) {
+	testSlug := "available_interface_gap"
+	testName := testAccGetTestName(testSlug)
+
+	initial :=
+		testAccNetboxAvailableInterfaceFullDependencies(testName) +
+			testAccNetboxAvailableInterfaceMultipleInterfaces("tun0", "tun1", "tun3", "tun10")
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: initial,
+			},
+			{
+				Config: initial + `
+
+resource "netbox_available_interface" "test" {
+	device_id = netbox_device.test.id
+	prefix    = "tun"
+	type      = "1000base-t"
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_available_interface.test", "name", "tun2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetboxAvailableInterface_last(t *testing.T) {
+	testSlug := "available_interface_last"
+	testName := testAccGetTestName(testSlug)
+
+	initial :=
+		testAccNetboxAvailableInterfaceFullDependencies(testName) +
+			testAccNetboxAvailableInterfaceMultipleInterfaces(
+				"tun0", "tun1", "tun2", "tun3", "tun4", "tun5",
+				"tun6", "tun7", "tun8", "tun9", "tun10", "tun11",
+			)
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: initial,
+			},
+			{
+				Config: initial + `
+
+resource "netbox_available_interface" "test" {
+	device_id = netbox_device.test.id
+	prefix    = "tun"
+	type      = "1000base-t"
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_available_interface.test", "name", "tun12"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetboxAvailableInterface_prefixChange(t *testing.T) {
+	testSlug := "available_interface_prefixChange"
+	testName := testAccGetTestName(testSlug)
+
+	initial :=
+		testAccNetboxAvailableInterfaceFullDependencies(testName) +
+			testAccNetboxAvailableInterfaceMultipleInterfaces("tun0", "tun1")
+
+	var resourceID string
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: initial,
+			},
+			{
+				Config: initial + `
+
+resource "netbox_available_interface" "test" {
+	device_id = netbox_device.test.id
+	prefix    = "tun"
+	type      = "1000base-t"
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_available_interface.test", "name", "tun2"),
+					func(s *terraform.State) error {
+						// record resource ID
+						resourceID = s.RootModule().Resources["netbox_available_interface.test"].Primary.Attributes["id"]
+						return nil
+					},
+				),
+			},
+			{
+				Config: initial + `
+
+resource "netbox_available_interface" "test" {
+	device_id = netbox_device.test.id
+	prefix    = "dummy"
+	type      = "1000base-t"
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					func(s *terraform.State) error {
+						newID := s.RootModule().Resources["netbox_available_interface.test"].Primary.Attributes["id"]
+						if newID == resourceID {
+							return errors.New("resource has not been recreated")
+						}
+						return nil
+					},
+					resource.TestCheckResourceAttr("netbox_available_interface.test", "name", "dummy0"),
+				),
+			},
+		},
+	})
+}

--- a/netbox/resource_netbox_device_interface.go
+++ b/netbox/resource_netbox_device_interface.go
@@ -15,6 +15,85 @@ import (
 
 var resourceNetboxDeviceInterfaceModeOptions = []string{"access", "tagged", "tagged-all"}
 
+// factored out for reuse in `resource_netbox_available_interface.go`
+var resourceNetboxDeviceInterfaceSchema = map[string]*schema.Schema{
+	"name": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+	"device_id": {
+		Type:     schema.TypeInt,
+		Required: true,
+	},
+	"description": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"label": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"enabled": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  true,
+	},
+	"lag_device_interface_id": {
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Description: "If this device is a member of a LAG group, you can reference the LAG interface here.",
+	},
+	"mac_address": {
+		Type:         schema.TypeString,
+		Optional:     true,
+		ValidateFunc: validation.IsMACAddress,
+		// Netbox converts MAC addresses always to uppercase
+		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			return strings.EqualFold(old, new)
+		},
+	},
+	"mgmtonly": {
+		Type:     schema.TypeBool,
+		Optional: true,
+	},
+	"mode": {
+		Type:         schema.TypeString,
+		Optional:     true,
+		ValidateFunc: validation.StringInSlice(resourceNetboxDeviceInterfaceModeOptions, false),
+		Description:  buildValidValueDescription(resourceNetboxDeviceInterfaceModeOptions),
+	},
+	"mtu": {
+		Type:         schema.TypeInt,
+		Optional:     true,
+		ValidateFunc: validation.IntBetween(1, 65536),
+	},
+	"parent_device_interface_id": {
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Description: "The netbox_device_interface id of the parent interface. Useful if this interface is a logical interface.",
+	},
+	"speed": {
+		Type:     schema.TypeInt,
+		Optional: true,
+	},
+	"type": {
+		Type:     schema.TypeString,
+		Required: true,
+	},
+	tagsKey: tagsSchema,
+	"tagged_vlans": {
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem: &schema.Schema{
+			Type: schema.TypeInt,
+		},
+	},
+	"untagged_vlan": {
+		Type:     schema.TypeInt,
+		Optional: true,
+	},
+}
+
 func resourceNetboxDeviceInterface() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceNetboxDeviceInterfaceCreate,
@@ -25,83 +104,7 @@ func resourceNetboxDeviceInterface() *schema.Resource {
 		Description: `:meta:subcategory:Data Center Inventory Management (DCIM):From the [official documentation](https://docs.netbox.dev/en/stable/features/device/#interface):
 
 > Interfaces in NetBox represent network interfaces used to exchange data with connected devices. On modern networks, these are most commonly Ethernet, but other types are supported as well. IP addresses and VLANs can be assigned to interfaces.`,
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"device_id": {
-				Type:     schema.TypeInt,
-				Required: true,
-			},
-			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"label": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"enabled": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"lag_device_interface_id": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "If this device is a member of a LAG group, you can reference the LAG interface here.",
-			},
-			"mac_address": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.IsMACAddress,
-				// Netbox converts MAC addresses always to uppercase
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return strings.EqualFold(old, new)
-				},
-			},
-			"mgmtonly": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
-			"mode": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.StringInSlice(resourceNetboxDeviceInterfaceModeOptions, false),
-				Description:  buildValidValueDescription(resourceNetboxDeviceInterfaceModeOptions),
-			},
-			"mtu": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				ValidateFunc: validation.IntBetween(1, 65536),
-			},
-			"parent_device_interface_id": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "The netbox_device_interface id of the parent interface. Useful if this interface is a logical interface.",
-			},
-			"speed": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-			"type": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			tagsKey: tagsSchema,
-			"tagged_vlans": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeInt,
-				},
-			},
-			"untagged_vlan": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-		},
+		Schema: resourceNetboxDeviceInterfaceSchema,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},


### PR DESCRIPTION
This resource is similar to `netbox_available_ip_address` as it allows creating a resource based on what other resources are present in a certain namespace.

In this case we're looking at all interfaces of a device with a certain prefix and create an interface with the lowest number suffix to a prefix so that it doesn't clash with an existing interface.

Notably, it doesn't use an existing API in Netbox to accomplish this, but instead does an API call to list the interfaces and constructs the name in the provider. This might be prone to race conditions when creating multiple interfaces for the same device with the same prefix at the same time.