### PR TITLE
Fix type conversion on ID when updating tunnel termination

### DIFF
--- a/netbox/resource_netbox_vpn_tunnel_termination.go
+++ b/netbox/resource_netbox_vpn_tunnel_termination.go
@@ -140,7 +140,8 @@ func resourceNetboxVpnTunnelTerminationUpdate(d *schema.ResourceData, m interfac
 	id, _ := strconv.ParseInt(d.Id(), 10, 64)
 	data := models.WritableTunnelTermination{}
 
-	data.Tunnel = int64ToPtr(d.Get("tunnel_id").(int64))
+	tunnelID := int64(d.Get("tunnel_id").(int))
+	data.Tunnel = &tunnelID
 	data.Role = d.Get("role").(string)
 
 	vmInterfaceID := getOptionalInt(d, "virtual_machine_interface_id")

--- a/netbox/resource_netbox_vpn_tunnel_termination_test.go
+++ b/netbox/resource_netbox_vpn_tunnel_termination_test.go
@@ -115,6 +115,33 @@ resource "netbox_vpn_tunnel_termination" "vm" {
 				),
 			},
 			{
+				Config: testAccNetboxVpnTunnelTerminationFullDependencies(testName) + `
+resource "netbox_ip_address" "outside_ip" {
+	ip_address = "203.0.113.2/24"
+	status = "active"
+}
+
+resource "netbox_vpn_tunnel_termination" "device" {
+	role = "peer"
+	tunnel_id = netbox_vpn_tunnel.test.id
+	device_interface_id = netbox_device_interface.test.id
+	outside_ip_address_id = netbox_ip_address.outside_ip.id
+
+	tags = [netbox_tag.test.name]
+}
+resource "netbox_vpn_tunnel_termination" "vm" {
+	role = "peer"
+	tunnel_id = netbox_vpn_tunnel.test.id
+	virtual_machine_interface_id = netbox_interface.test.id
+
+	outside_ip_address_id = netbox_ip_address.vm_1.id
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_vpn_tunnel_termination.device", "tunnel_id", "netbox_vpn_tunnel.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_vpn_tunnel_termination.device", "outside_ip_address_id", "netbox_ip_address.outside_ip", "id"),
+				),
+			},
+			{
 				ResourceName:      "netbox_vpn_tunnel.test",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/netbox/resource_netbox_vpn_tunnel_termination_test.go
+++ b/netbox/resource_netbox_vpn_tunnel_termination_test.go
@@ -10,6 +10,79 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+func testAccNetboxVpnTunnelTerminationFullDependencies(testName string) string {
+	return fmt.Sprintf(`
+	resource "netbox_site" "test" {
+		name = "%[1]s"
+	}
+	resource "netbox_device_role" "test" {
+		name = "%[1]s"
+		color_hex = "ff00ff"
+	}
+	resource "netbox_manufacturer" "test" {
+		name = "%[1]s"
+	}
+	resource "netbox_device_type" "test" {
+		model = "%[1]s"
+		manufacturer_id = netbox_manufacturer.test.id
+	}
+	resource "netbox_device" "test" {
+		name = "%[1]s"
+		device_type_id = netbox_device_type.test.id
+		role_id = netbox_device_role.test.id
+		site_id = netbox_site.test.id
+	}
+	resource "netbox_device_interface" "test" {
+		name = "eth0"
+		device_id = netbox_device.test.id
+		type = "virtual"
+	}
+	resource "netbox_ip_address" "device_1" {
+		ip_address = "2.2.2.0/32"
+		status = "active"
+		device_interface_id = netbox_device_interface.test.id
+	}
+	resource "netbox_ip_address" "device_2" {
+		ip_address = "2.2.2.1/32"
+		status = "active"
+		device_interface_id = netbox_device_interface.test.id
+	}
+
+	resource "netbox_virtual_machine" "test" {
+		name = "%[1]s"
+		site_id = netbox_site.test.id
+	}
+	resource "netbox_interface" "test" {
+		name = "eth0"
+		virtual_machine_id = netbox_virtual_machine.test.id
+	}
+	resource "netbox_ip_address" "vm_1" {
+		ip_address = "2.2.2.2/32"
+		status = "active"
+		virtual_machine_interface_id = netbox_interface.test.id
+	}
+	resource "netbox_ip_address" "vm_2" {
+		ip_address = "2.2.2.3/32"
+		status = "active"
+		virtual_machine_interface_id = netbox_interface.test.id
+	}
+
+	resource "netbox_vpn_tunnel_group" "test" {
+		name = "%[1]s"
+		description = "%[1]s"
+	}
+	resource "netbox_tag" "test" {
+		name = "%[1]s"
+	}
+	resource "netbox_vpn_tunnel" "test" {
+		name = "%[1]s"
+		encapsulation = "ipsec-transport"
+		status = "active"
+		tunnel_group_id = netbox_vpn_tunnel_group.test.id
+	}
+	`, testName)
+}
+
 func TestAccNetboxVpnTunnelTermination_basic(t *testing.T) {
 	testSlug := "vpnterm_basic"
 	testName := testAccGetTestName(testSlug)
@@ -18,90 +91,21 @@ func TestAccNetboxVpnTunnelTermination_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(`
-resource "netbox_site" "test" {
-  name = "%[1]s"
-}
-resource "netbox_device_role" "test" {
-  name = "%[1]s"
-  color_hex = "ff00ff"
-}
-resource "netbox_manufacturer" "test" {
-  name = "%[1]s"
-}
-resource "netbox_device_type" "test" {
-  model = "%[1]s"
-  manufacturer_id = netbox_manufacturer.test.id
-}
-resource "netbox_device" "test" {
-  name = "%[1]s"
-  device_type_id = netbox_device_type.test.id
-  role_id = netbox_device_role.test.id
-  site_id = netbox_site.test.id
-}
-resource "netbox_device_interface" "test" {
-  name = "eth0"
-  device_id = netbox_device.test.id
-  type = "virtual"
-}
-resource "netbox_ip_address" "device_1" {
-  ip_address = "2.2.2.0/32"
-  status = "active"
-  device_interface_id = netbox_device_interface.test.id
-}
-resource "netbox_ip_address" "device_2" {
-  ip_address = "2.2.2.1/32"
-  status = "active"
-  device_interface_id = netbox_device_interface.test.id
-}
-
-resource "netbox_virtual_machine" "test" {
-  name = "%[1]s"
-  site_id = netbox_site.test.id
-}
-resource "netbox_interface" "test" {
-  name = "eth0"
-  virtual_machine_id = netbox_virtual_machine.test.id
-}
-resource "netbox_ip_address" "vm_1" {
-  ip_address = "2.2.2.2/32"
-  status = "active"
-  virtual_machine_interface_id = netbox_interface.test.id
-}
-resource "netbox_ip_address" "vm_2" {
-  ip_address = "2.2.2.3/32"
-  status = "active"
-  virtual_machine_interface_id = netbox_interface.test.id
-}
-
-resource "netbox_vpn_tunnel_group" "test" {
-  name = "%[1]s"
-  description = "%[1]s"
-}
-resource "netbox_tag" "test" {
-  name = "%[1]s"
-}
-resource "netbox_vpn_tunnel" "test" {
-  name = "%[1]s"
-  encapsulation = "ipsec-transport"
-  status = "active"
-  tunnel_group_id = netbox_vpn_tunnel_group.test.id
-}
+				Config: testAccNetboxVpnTunnelTerminationFullDependencies(testName) + `
 resource "netbox_vpn_tunnel_termination" "device" {
-  role = "peer"
-  tunnel_id = netbox_vpn_tunnel.test.id
-  device_interface_id = netbox_device_interface.test.id
+	role = "peer"
+	tunnel_id = netbox_vpn_tunnel.test.id
+	device_interface_id = netbox_device_interface.test.id
 
-  tags = [netbox_tag.test.name]
+	tags = [netbox_tag.test.name]
 }
 resource "netbox_vpn_tunnel_termination" "vm" {
-  role = "peer"
-  tunnel_id = netbox_vpn_tunnel.test.id
-  virtual_machine_interface_id = netbox_interface.test.id
+	role = "peer"
+	tunnel_id = netbox_vpn_tunnel.test.id
+	virtual_machine_interface_id = netbox_interface.test.id
 
-  outside_ip_address_id = netbox_ip_address.vm_1.id
-}
-`, testName),
+	outside_ip_address_id = netbox_ip_address.vm_1.id
+}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("netbox_vpn_tunnel_termination.device", "tunnel_id", "netbox_vpn_tunnel.test", "id"),
 					resource.TestCheckResourceAttrPair("netbox_vpn_tunnel_termination.vm", "tunnel_id", "netbox_vpn_tunnel.test", "id"),


### PR DESCRIPTION
Fixes this crash that i was able to reproduce in a regression test:

```
=== CONT  TestAccNetboxVpnTunnelTermination_basic
panic: interface conversion: interface {} is int, not int64

goroutine 1944 [running]:
github.com/e-breuninger/terraform-provider-netbox/netbox.resourceNetboxVpnTunnelTerminationUpdate(0x14000894c00, {0x105c46d60, 0x14000023290})
        /Users/marcus/src/ffddorf/terraform-provider-netbox/netbox/resource_netbox_vpn_tunnel_termination.go:143 +0x434
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).update(0x105f73320?, {0x105f73320?, 0x14000a80f30?}, 0xd?, {0x105c46d60?, 0x14000023290?})
        /Users/marcus/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/resource.go:828 +0x130
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0x1400027b0a0, {0x105f73320, 0x14000a80f30}, 0x1400093de10, 0x14000894a80, {0x105c46d60, 0x14000023290})
        /Users/marcus/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/resource.go:947 +0x670
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0x140006a0000, {0x105f73320?, 0x14000a80ea0?}, 0x1400090d1d0)
        /Users/marcus/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.34.0/helper/schema/grpc_provider.go:1153 +0xaa4
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0x140004c8500, {0x105f73320?, 0x14000a80690?}, 0x14000356620)
        /Users/marcus/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov5/tf5server/server.go:865 +0x2b4
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x105e96660, 0x140004c8500}, {0x105f73320, 0x14000a80690}, 0x14000894680, 0x0)
        /Users/marcus/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.23.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:518 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x14000452200, {0x105f73320, 0x14000a80600}, {0x105f79380, 0x14000970480}, 0x1400075f7a0, 0x140008189f0, 0x10700dbb8, 0x0)
        /Users/marcus/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1369 +0xb58
google.golang.org/grpc.(*Server).handleStream(0x14000452200, {0x105f79380, 0x14000970480}, 0x1400075f7a0)
        /Users/marcus/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1780 +0xb20
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        /Users/marcus/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1019 +0x8c
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 1832
        /Users/marcus/go/pkg/mod/google.golang.org/grpc@v1.63.2/server.go:1030 +0x13c
FAIL    github.com/e-breuninger/terraform-provider-netbox/netbox        5.509s
FAIL
```