### PR TITLE
Add contains filter and field to data_source_netbox_prefixes

### DIFF
--- a/netbox/data_source_netbox_prefixes.go
+++ b/netbox/data_source_netbox_prefixes.go
@@ -25,7 +25,7 @@ func dataSourceNetboxPrefixes() *schema.Resource {
 						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The name of the field to filter on. Supported fields are: `prefix`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `site_id`, & `tag`.",
+							Description: "The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `site_id`, & `tag`.",
 						},
 						"value": {
 							Type:        schema.TypeString,
@@ -107,6 +107,8 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 					return err
 				}
 				params.VlanVid = &float
+			case "contains":
+				params.Contains = &vString
 			case "vrf_id":
 				params.VrfID = &vString
 			case "vlan_id":

--- a/netbox/data_source_netbox_prefixes.go
+++ b/netbox/data_source_netbox_prefixes.go
@@ -59,6 +59,10 @@ func dataSourceNetboxPrefixes() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"site_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 						"vlan_vid": {
 							Type:     schema.TypeFloat,
 							Computed: true,
@@ -145,6 +149,9 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 		}
 		if v.Vrf != nil {
 			mapping["vrf_id"] = v.Vrf.ID
+		}
+		if v.Site != nil {
+			mapping["site_id"] = v.Site.ID
 		}
 		mapping["status"] = v.Status.Value
 		mapping["tags"] = getTagListFromNestedTagList(v.Tags)

--- a/netbox/data_source_netbox_prefixes_test.go
+++ b/netbox/data_source_netbox_prefixes_test.go
@@ -49,9 +49,15 @@ resource "netbox_prefix" "with_site_id" {
   site_id = netbox_site.test.id
 }
 
+resource "netbox_site" "test2" {
+  name = "site2-%[1]s"
+  timezone = "Europe/Berlin"
+}
+
 resource "netbox_prefix" "with_container" {
-  prefix = "%[8]s"
-  status = "container"
+  prefix  = "%[8]s"
+  status  = "container"
+  site_id = netbox_site.test2.id
 }
 
 resource "netbox_vrf" "test_vrf" {
@@ -143,6 +149,7 @@ data "netbox_prefixes" "find_prefix_with_contains" {
 					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_site_id", "prefixes.0.prefix", "10.0.7.0/24"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_contains", "prefixes.#", "1"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_contains", "prefixes.0.prefix", "10.0.8.0/24"),
+					resource.TestCheckResourceAttrSet("data.netbox_prefixes.find_prefix_with_contains", "prefixes.0.site_id"),
 				),
 			},
 		},


### PR DESCRIPTION
[Add contains filter to data_source_netbox_prefixes](https://github.com/e-breuninger/terraform-provider-netbox/pull/617/commits/ae3654259181e2cf86238f86c3053322ec21dc84) 

It is helpful to be able to look up the prefix by an IP address within
the prefix. The contains filter can be used for this.

If you specify an IP within a prefix, it will return that prefix.

[Add site_id as a returned field to netbox_prefixes data source](https://github.com/e-breuninger/terraform-provider-netbox/pull/617/commits/ac1fbfbb73e7f80dd20986431f04b732f12ea93d) 

It can be helpful to know the ID of the site that the prefixes are
assigned to. This allows us to reference it within in our TF code.