### PR TITLE
Add support for device_type_id in data source

### DIFF
--- a/netbox/data_source_netbox_devices.go
+++ b/netbox/data_source_netbox_devices.go
@@ -174,6 +174,9 @@ func dataSourceNetboxDevicesRead(d *schema.ResourceData, m interface{}) error {
 			case "cluster_id":
 				var clusterString = v.(string)
 				params.ClusterID = &clusterString
+			case "device_type_id":
+				var deviceTypeIDString = v.(string)
+				params.DeviceTypeID = &deviceTypeIDString
 			case "name":
 				var nameString = v.(string)
 				params.Name = &nameString


### PR DESCRIPTION
This change introduces the device_type_id parameter to the Netbox devices data source. It allows users to filter devices based on their type, providing more granular control over the data retrieved.

```hcl
data "netbox_devices" "VSS" {
  filter {
    name  = "cluster_id"
    value = data.netbox_cluster.vm_cluster.cluster_id
  }
  filter {
    name  = "device_type_id"
    value = data.netbox_device_type.VSS.id
  }
  filter {
    name  = "tags"
    value = "managed_by_terraform"
  }
  filter {
    name  = "status"
    value = "active"
  }
}
```

Now it is possible to filter Netbox devices based on `device_id_type`. This could be usefully to create other resources with terraform.
