### PR TITLE
Add custom fields support in IPAM IP address.

### DIFF
--- a/docs/resources/ip_address.md
+++ b/docs/resources/ip_address.md
@@ -112,6 +112,7 @@ resource "netbox_ip_address" "this" {
 
 ### Optional
 
+- `custom_fields` (Map of String)
 - `description` (String)
 - `device_interface_id` (Number) Conflicts with `interface_id` and `virtual_machine_interface_id`.
 - `dns_name` (String)

--- a/netbox/resource_netbox_ip_address.go
+++ b/netbox/resource_netbox_ip_address.go
@@ -108,6 +108,7 @@ func resourceNetboxIPAddress() *schema.Resource {
 					},
 				},
 			},
+			customFieldsKey: customFieldsSchema,
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -152,6 +153,11 @@ func resourceNetboxIPAddressCreate(d *schema.ResourceData, m interface{}) error 
 	}
 
 	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+
+	cf, ok := d.GetOk(customFieldsKey)
+	if ok {
+		data.CustomFields = cf
+	}
 
 	params := ipam.NewIpamIPAddressesCreateParams().WithData(&data)
 
@@ -255,6 +261,10 @@ func resourceNetboxIPAddressRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("description", ipAddress.Description)
 	d.Set("status", ipAddress.Status.Value)
 	d.Set(tagsKey, getTagListFromNestedTagList(ipAddress.Tags))
+	cf := getCustomFields(res.GetPayload().CustomFields)
+	if cf != nil {
+		d.Set(customFieldsKey, cf)
+	}
 	return nil
 }
 
@@ -296,6 +306,10 @@ func resourceNetboxIPAddressUpdate(d *schema.ResourceData, m interface{}) error 
 	}
 
 	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
+
+	if cf, ok := d.GetOk(customFieldsKey); ok {
+		data.CustomFields = cf
+	}
 
 	params := ipam.NewIpamIPAddressesUpdateParams().WithID(id).WithData(&data)
 


### PR DESCRIPTION
Adds custom fields support to IPAM IP address. Highly based on #553
 
```
TF_ACC=1 go test -timeout 20m -v -cover netbox/*.go -run TestAccNetboxIPAddress_basic
=== RUN   TestAccNetboxIPAddress_basic
=== PAUSE TestAccNetboxIPAddress_basic
=== CONT  TestAccNetboxIPAddress_basic
--- PASS: TestAccNetboxIPAddress_basic (11.46s)
PASS
coverage: 8.9% of statements
ok      command-line-arguments  12.088s coverage: 8.9% of statements
```