### PR TITLE
Update documentation for virtual_disk with correct schema

### DIFF
--- a/docs/resources/virtual_disk.md
+++ b/docs/resources/virtual_disk.md
@@ -29,7 +29,7 @@ resource "netbox_virtual_machine" "base_vm" {
 resource "netbox_virtual_disk" "example" {
   name               = "disk-01"
   description        = "Main disk"
-  size               = 50
+  size_gb            = 50
   virtual_machine_id = netbox_virtual_machine.base_vm.id
 }
 ```

--- a/examples/resources/netbox_virtual_disk/resource.tf
+++ b/examples/resources/netbox_virtual_disk/resource.tf
@@ -11,6 +11,6 @@ resource "netbox_virtual_machine" "base_vm" {
 resource "netbox_virtual_disk" "example" {
   name               = "disk-01"
   description        = "Main disk"
-  size               = 50
+  size_gb            = 50
   virtual_machine_id = netbox_virtual_machine.base_vm.id
 }


### PR DESCRIPTION
Hello just a little error on the documentation in https://registry.terraform.io/providers/e-breuninger/netbox/latest/docs/resources/virtual_disk

between the examples and the schema.

Have good day.