### PR TITLE
fix: use tenant_id for filtering multiple VRFs with same name

### DIFF
--- a/netbox/data_source_netbox_vrf.go
+++ b/netbox/data_source_netbox_vrf.go
@@ -35,6 +35,11 @@ func dataSourceNetboxVrfRead(d *schema.ResourceData, m interface{}) error {
 	limit := int64(2) // Limit of 2 is enough
 	params.Limit = &limit
 
+	if tenant_id, ok := d.Get("tenant_id").(int); ok && tenant_id != 0 {
+		tenant_id := strconv.Itoa(tenant_id)
+		params.TenantID = &tenant_id
+	}
+
 	res, err := api.Ipam.IpamVrfsList(params, nil)
 	if err != nil {
 		return err

--- a/netbox/data_source_netbox_vrf_test.go
+++ b/netbox/data_source_netbox_vrf_test.go
@@ -2,6 +2,7 @@ package netbox
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -10,23 +11,90 @@ import (
 func TestAccNetboxVrfDataSource_basic(t *testing.T) {
 	testSlug := "vrf_ds_basic"
 	testName := testAccGetTestName(testSlug)
+	simpleSetup := testAccNetboxVrfSetUp(testName)
+	advancedSetup := testAccNetboxVrfAdvancedSetUp(testName)
 	resource.ParallelTest(t, resource.TestCase{
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(`
-resource"netbox_vrf" "test" {
-  name = "%[1]s"
-}
-
-data "netbox_vrf" "test" {
-  depends_on = [netbox_vrf.test]
-  name = "%[1]s"
-}`, testName),
+				Config: simpleSetup + testAccNetboxVrfData(testName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("data.netbox_vrf.test", "id", "netbox_vrf.test", "id"),
 				),
 			},
+			{
+				Config:      simpleSetup + advancedSetup + testAccNetboxVrfData(testName),
+				ExpectError: regexp.MustCompile("more than one vrf returned, specify a more narrow filter"),
+			},
+			{
+				Config:      advancedSetup + testAccNetboxVrfDataWithoutTenant(testName),
+				ExpectError: regexp.MustCompile("more than one vrf returned, specify a more narrow filter"),
+			},
+			{
+				Config: simpleSetup + advancedSetup + testAccNetboxVrfDataWithTenantId(testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("data.netbox_vrf.vrf_a", "id", "netbox_vrf.vrf_a", "id"),
+					resource.TestCheckResourceAttrPair("data.netbox_vrf.vrf_b", "id", "netbox_vrf.vrf_b", "id"),
+				),
+			},
 		},
 	})
+}
+
+func testAccNetboxVrfSetUp(testName string) string {
+	return fmt.Sprintf(`
+resource"netbox_vrf" "test" {
+  name = "%[1]s"
+}`, testName)
+}
+
+func testAccNetboxVrfData(testName string) string {
+	return fmt.Sprintf(`
+data "netbox_vrf" "test" {
+  depends_on = [netbox_vrf.test]
+  name = "%[1]s"
+}`, testName)
+}
+
+func testAccNetboxVrfAdvancedSetUp(testName string) string {
+	return fmt.Sprintf(`
+resource "netbox_tenant" "tenant_a" {
+	name = "%[1]s-a"
+}
+
+resource "netbox_tenant" "tenant_b" {
+	name = "%[1]s-b"
+}
+
+resource "netbox_vrf" "vrf_a" {
+	name      = "%[1]s"
+	tenant_id = netbox_tenant.tenant_a.id
+}
+
+resource "netbox_vrf" "vrf_b" {
+	name      = "%[1]s"
+	tenant_id = netbox_tenant.tenant_b.id
+}
+`, testName)
+}
+
+func testAccNetboxVrfDataWithoutTenant(testName string) string {
+	return fmt.Sprintf(`
+data "netbox_vrf" "vrf_a" {
+	name       = "%[1]s"
+}
+`, testName)
+}
+
+func testAccNetboxVrfDataWithTenantId(testName string) string {
+	return fmt.Sprintf(`
+data "netbox_vrf" "vrf_a" {
+	name       = "%[1]s"
+	tenant_id  = netbox_tenant.tenant_a.id
+}
+data "netbox_vrf" "vrf_b" {
+	name       = "%[1]s"
+	tenant_id  = netbox_tenant.tenant_b.id
+}
+`, testName)
 }


### PR DESCRIPTION
Fixes #640 