### PR TITLE
Fixes #635: added missing Default

### DIFF
--- a/netbox/resource_netbox_custom_field.go
+++ b/netbox/resource_netbox_custom_field.go
@@ -108,6 +108,7 @@ func resourceNetboxCustomFieldUpdate(d *schema.ResourceData, m interface{}) erro
 	data := &models.WritableCustomField{
 		Name:            strToPtr(d.Get("name").(string)),
 		Type:            d.Get("type").(string),
+		Default:         d.Get("default").(string),
 		Description:     d.Get("description").(string),
 		GroupName:       d.Get("group_name").(string),
 		Label:           d.Get("label").(string),
@@ -157,6 +158,7 @@ func resourceNetboxCustomFieldCreate(d *schema.ResourceData, m interface{}) erro
 	data := &models.WritableCustomField{
 		Name:            strToPtr(d.Get("name").(string)),
 		Type:            d.Get("type").(string),
+		Default:         d.Get("default").(string),
 		Description:     d.Get("description").(string),
 		GroupName:       d.Get("group_name").(string),
 		Label:           d.Get("label").(string),

--- a/netbox/resource_netbox_custom_field_test.go
+++ b/netbox/resource_netbox_custom_field_test.go
@@ -22,6 +22,7 @@ resource "netbox_custom_field" "test" {
   type = "text"
   content_types = ["virtualization.vminterface"]
   weight = 100
+  default = "red"
   validation_regex = "^.*$"
 }`, testName),
 				Check: resource.ComposeTestCheckFunc(
@@ -29,6 +30,7 @@ resource "netbox_custom_field" "test" {
 					resource.TestCheckResourceAttr("netbox_custom_field.test", "type", "text"),
 					resource.TestCheckTypeSetElemAttr("netbox_custom_field.test", "content_types.*", "virtualization.vminterface"),
 					resource.TestCheckResourceAttr("netbox_custom_field.test", "weight", "100"),
+					resource.TestCheckResourceAttr("netbox_custom_field.test", "default", "red"),
 					resource.TestCheckResourceAttr("netbox_custom_field.test", "validation_regex", "^.*$"),
 				),
 			},


### PR DESCRIPTION
Fixes #635: Added missing Default to data in resourceNetboxCustomField and resourceNetboxCustomFieldCreate

default value is now created correctly:
```
{
      ...
      "id": 1,
      "url": "http://localhost:8001/api/extras/custom-fields/1/",
      "display": "test",
      ...
      "data_type": "string",
      "name": "test",
      "label": "test",
      ...
      "default": "\"default value ignored\"",
      "weight": 100,
      ...
    }
  ]
}
```

UI screenshot:
![image](https://github.com/user-attachments/assets/95a451f7-f5a3-4e83-865e-239553ce1e73)
