### PR TITLE
feat: Add Description & Comments Field To ASN Resource

### DIFF
--- a/docs/resources/asn.md
+++ b/docs/resources/asn.md
@@ -24,8 +24,10 @@ resource "netbox_rir" "test" {
 }
 
 resource "netbox_asn" "test" {
-  asn    = 1337
-  rir_id = netbox_rir.test.id
+  asn         = 1337
+  rir_id      = netbox_rir.test.id
+  description = "test"
+  comments    = "test"
 }
 ```
 
@@ -34,11 +36,13 @@ resource "netbox_asn" "test" {
 
 ### Required
 
-- `asn` (Number)
-- `rir_id` (Number)
+- `asn` (Number) Value for the AS Number record.
+- `rir_id` (Number) ID for the RIR for the AS Number record.
 
 ### Optional
 
+- `comments` (String) Comments field for the AS Number record.
+- `description` (String) Description field for the AS Number record.
 - `tags` (Set of String)
 
 ### Read-Only

--- a/docs/resources/config_context.md
+++ b/docs/resources/config_context.md
@@ -18,7 +18,7 @@ From the [official documentation](https://docs.netbox.dev/en/stable/models/extra
 ```terraform
 resource "netbox_config_context" "test" {
   name = "%s"
-  data = jsonencode({"testkey" = "testval"})
+  data = jsonencode({ "testkey" = "testval" })
 }
 ```
 

--- a/docs/resources/interface_template.md
+++ b/docs/resources/interface_template.md
@@ -17,23 +17,23 @@ From the [official documentation](https://docs.netbox.dev/en/stable/models/dcim/
 
 ```terraform
 resource "netbox_manufacturer" "test" {
-	name = "my-manufacturer"
+  name = "my-manufacturer"
 }
 
 resource "netbox_device_type" "test" {
-	model = "test-model"
-	slug = "test-model"
-	part_number = "test-part-number"
-	manufacturer_id = netbox_manufacturer.test.id
+  model           = "test-model"
+  slug            = "test-model"
+  part_number     = "test-part-number"
+  manufacturer_id = netbox_manufacturer.test.id
 }
 
 resource "netbox_interface_template" "test" {
-	name = "eth0"
-	description = "eth0 description"
-	label = "eth0 label"
-	device_type_id = netbox_device_type.test.id
-	type = "100base-tx"
-	mgmt_only = true
+  name           = "eth0"
+  description    = "eth0 description"
+  label          = "eth0 label"
+  device_type_id = netbox_device_type.test.id
+  type           = "100base-tx"
+  mgmt_only      = true
 }
 ```
 

--- a/examples/resources/netbox_asn/resource.tf
+++ b/examples/resources/netbox_asn/resource.tf
@@ -3,6 +3,8 @@ resource "netbox_rir" "test" {
 }
 
 resource "netbox_asn" "test" {
-  asn    = 1337
-  rir_id = netbox_rir.test.id
+  asn         = 1337
+  rir_id      = netbox_rir.test.id
+  description = "test"
+  comments    = "test"
 }

--- a/examples/resources/netbox_config_context/resource.tf
+++ b/examples/resources/netbox_config_context/resource.tf
@@ -1,4 +1,4 @@
 resource "netbox_config_context" "test" {
   name = "%s"
-  data = jsonencode({"testkey" = "testval"})
+  data = jsonencode({ "testkey" = "testval" })
 }

--- a/examples/resources/netbox_interface_template/resource.tf
+++ b/examples/resources/netbox_interface_template/resource.tf
@@ -1,19 +1,19 @@
 resource "netbox_manufacturer" "test" {
-	name = "my-manufacturer"
+  name = "my-manufacturer"
 }
 
 resource "netbox_device_type" "test" {
-	model = "test-model"
-	slug = "test-model"
-	part_number = "test-part-number"
-	manufacturer_id = netbox_manufacturer.test.id
+  model           = "test-model"
+  slug            = "test-model"
+  part_number     = "test-part-number"
+  manufacturer_id = netbox_manufacturer.test.id
 }
 
 resource "netbox_interface_template" "test" {
-	name = "eth0"
-	description = "eth0 description"
-	label = "eth0 label"
-	device_type_id = netbox_device_type.test.id
-	type = "100base-tx"
-	mgmt_only = true
+  name           = "eth0"
+  description    = "eth0 description"
+  label          = "eth0 label"
+  device_type_id = netbox_device_type.test.id
+  type           = "100base-tx"
+  mgmt_only      = true
 }

--- a/netbox/resource_netbox_asn.go
+++ b/netbox/resource_netbox_asn.go
@@ -23,12 +23,24 @@ func resourceNetboxAsn() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"asn": {
-				Type:     schema.TypeInt,
-				Required: true,
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "Value for the AS Number record",
 			},
 			"rir_id": {
-				Type:     schema.TypeInt,
-				Required: true,
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "ID for the RIR for the AS Number record",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Description field for the AS Number record",
+			},
+			"comments": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Comments field for the AS Number record",
 			},
 			tagsKey: tagsSchema,
 		},
@@ -49,6 +61,8 @@ func resourceNetboxAsnCreate(d *schema.ResourceData, m interface{}) error {
 	rir := int64(d.Get("rir_id").(int))
 	data.Rir = &rir
 
+	data.Description = d.Get("description").(string)
+	data.Comments = d.Get("comments").(string)
 	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := ipam.NewIpamAsnsCreateParams().WithData(&data)
@@ -85,7 +99,8 @@ func resourceNetboxAsnRead(d *schema.ResourceData, m interface{}) error {
 	asn := res.GetPayload()
 	d.Set("asn", asn.Asn)
 	d.Set("rir_id", asn.Rir.ID)
-
+	d.Set("description", asn.Description)
+	d.Set("comments", asn.Comments)
 	d.Set(tagsKey, getTagListFromNestedTagList(asn.Tags))
 
 	return nil
@@ -103,6 +118,8 @@ func resourceNetboxAsnUpdate(d *schema.ResourceData, m interface{}) error {
 	rir := int64(d.Get("rir_id").(int))
 	data.Rir = &rir
 
+	data.Description = d.Get("description").(string)
+	data.Comments = d.Get("comments").(string)
 	data.Tags, _ = getNestedTagListFromResourceDataSet(api, d.Get(tagsKey))
 
 	params := ipam.NewIpamAsnsUpdateParams().WithID(id).WithData(&data)

--- a/netbox/resource_netbox_asn_test.go
+++ b/netbox/resource_netbox_asn_test.go
@@ -31,10 +31,15 @@ resource "netbox_asn" "test" {
   asn    = 1337
   rir_id = netbox_rir.test.id
 
+  description = "test"
+  comments = "test"
+
   tags = ["%[1]sa"]
 }`, testName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_asn.test", "asn", "1337"),
+					resource.TestCheckResourceAttr("netbox_asn.test", "description", "test"),
+					resource.TestCheckResourceAttr("netbox_asn.test", "comments", "test"),
 					resource.TestCheckResourceAttr("netbox_asn.test", "tags.#", "1"),
 					resource.TestCheckResourceAttr("netbox_asn.test", "tags.0", testName+"a"),
 				),


### PR DESCRIPTION
This PR adds the `description` and `comments` fields to the `netbox_asn` resource as optional attributes.

This also includes some changes to unrelated docs and examples which occurred as the results of running a `terraform fmt --recursive` on the example directory.
