### PR TITLE
fix: add decommissioning status for devices

### DIFF
--- a/docs/resources/device.md
+++ b/docs/resources/device.md
@@ -71,7 +71,7 @@ resource "netbox_device" "test" {
 - `rack_id` (Number)
 - `rack_position` (Number)
 - `serial` (String)
-- `status` (String) Valid values are `offline`, `active`, `planned`, `staged`, `failed` and `inventory`. Defaults to `active`.
+- `status` (String) Valid values are `offline`, `active`, `planned`, `staged`, `failed`, `inventory` and `decommissioning`. Defaults to `active`.
 - `tags` (Set of String)
 - `tenant_id` (Number)
 - `virtual_chassis_id` (Number) Required when `virtual_chassis_master` and `virtual_chassis_id` is set.

--- a/netbox/resource_netbox_device.go
+++ b/netbox/resource_netbox_device.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-var resourceNetboxDeviceStatusOptions = []string{"offline", "active", "planned", "staged", "failed", "inventory"}
+var resourceNetboxDeviceStatusOptions = []string{"offline", "active", "planned", "staged", "failed", "inventory", "decommissioning"}
 var resourceNetboxDeviceRackFaceOptions = []string{"front", "rear"}
 
 func resourceNetboxDevice() *schema.Resource {


### PR DESCRIPTION
Add the missing 'decommissioning' status to the `netbox_device` resource, so we can keep track in NetBox of devices in the process of being removed from the racks. Once the device is really physically removed from the rack we can remove it from terraform, which will cleanup NetBox in response.

`api/schema/swagger-ui/#/dcim/dcim_devices_create`:
<img width="495" alt="image" src="https://github.com/user-attachments/assets/b4b697c8-b03f-4458-80ff-2da9c55f3c05" />

Seems to have been added a while ago in NetBox 2.5.11 ([changelog](https://github.com/netbox-community/netbox/blob/e75d327f384d0b22ffb17f7e790d953ac81530ca/docs/release-notes/version-2.5.md?plain=1#L48C11-L48C65) / [issue](https://github.com/netbox-community/netbox/issues/3070))

