### PR TITLE
Add limit to device_interfaces data source

### DIFF
--- a/netbox/data_source_netbox_device_interfaces.go
+++ b/netbox/data_source_netbox_device_interfaces.go
@@ -39,6 +39,10 @@ func dataSourceNetboxDeviceInterfaces() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringIsValidRegExp,
 			},
+			"limit": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"interfaces": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -139,6 +143,12 @@ func dataSourceNetboxDeviceInterfaceRead(d *schema.ResourceData, m interface{}) 
 	api := m.(*client.NetBoxAPI)
 
 	params := dcim.NewDcimInterfacesListParams()
+
+	if limit, ok := d.GetOk("limit"); ok {
+		limitInt := int64(limit.(int))
+		params.Limit = &limitInt
+	}
+
 
 	if filter, ok := d.GetOk("filter"); ok {
 		var filterParams = filter.(*schema.Set)


### PR DESCRIPTION
Add limit as implemented in devices data source.

Testing:
  Local - appears to ignore all outputs after first 1k despite
setting to 10k, otherwise works