### PR TITLE
Devices data-source: read OobIp

### DIFF
--- a/docs/data-sources/devices.md
+++ b/docs/data-sources/devices.md
@@ -53,6 +53,7 @@ Read-Only:
 - `manufacturer_id` (Number)
 - `model` (String)
 - `name` (String)
+- `oob_ip` (String)
 - `platform_id` (Number)
 - `primary_ipv4` (String)
 - `primary_ipv6` (String)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.24.4
 
 require (
-	github.com/fbreckle/go-netbox v0.0.0-20250611144412-652fde552952
+	github.com/fbreckle/go-netbox v0.0.0-20250613135753-f000a89e4006
 	github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3
 	github.com/go-openapi/runtime v0.28.0
 	github.com/go-openapi/strfmt v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
-github.com/fbreckle/go-netbox v0.0.0-20250611144412-652fde552952 h1:exDSbUzVBXbw9HsIbP6sNYzFa+KgIKNC39AWjoAAR3g=
-github.com/fbreckle/go-netbox v0.0.0-20250611144412-652fde552952/go.mod h1:3U3/m/hna9Ntd3sbHBYwZ1IqbP2+coRzoXw3mCfu3kM=
+github.com/fbreckle/go-netbox v0.0.0-20250613135753-f000a89e4006 h1:YYqqX6AEm8aGso90lOuXRSYuArLtPvSGBdlv3lMEcpk=
+github.com/fbreckle/go-netbox v0.0.0-20250613135753-f000a89e4006/go.mod h1:3U3/m/hna9Ntd3sbHBYwZ1IqbP2+coRzoXw3mCfu3kM=
 github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3 h1:DMSpM0btVedE2Tt1vfDHWQhf2obzjAe1F0/j8/CyfW4=
 github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3/go.mod h1:j3HmJySEjx6hOAOPDjGzmzpVNDQq9SNnnF+Vm22d2rs=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=

--- a/netbox/data_source_netbox_devices.go
+++ b/netbox/data_source_netbox_devices.go
@@ -148,6 +148,10 @@ func dataSourceNetboxDevices() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"oob_ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"tags": tagsSchemaRead,
 					},
 				},
@@ -317,6 +321,13 @@ func dataSourceNetboxDevicesRead(d *schema.ResourceData, m interface{}) error {
 			if err == nil {
 				primaryIPv6 := ip.String()
 				mapping["primary_ipv6"] = &primaryIPv6
+			}
+		}
+		if device.OobIP != nil {
+			ip, _, err := net.ParseCIDR(*device.OobIP.Address)
+			if err == nil {
+				OobIP := ip.String()
+				mapping["oob_ip"] = &OobIP
 			}
 		}
 		s = append(s, mapping)


### PR DESCRIPTION
Depends on https://github.com/fbreckle/go-netbox/pull/47
Data source parity for #538, `go-netbox` PR might address predicate requirement for that too.

Testing:
  See notes in other PR - "seems to work fine"