### PR TITLE
[Available-VLAN] Fixed group ID in update 

### DIFF
--- a/netbox/resource_netbox_available_vlan.go
+++ b/netbox/resource_netbox_available_vlan.go
@@ -172,6 +172,7 @@ func resourceNetboxAvailableVLANUpdate(d *schema.ResourceData, m interface{}) er
 		Description: getOptionalStr(d, "description", false),
 		Tenant:      getOptionalInt(d, "tenant_id"),
 		Site:        getOptionalInt(d, "site_id"),
+		Group:       getOptionalInt(d, "group_id"),
 		Role:        getOptionalInt(d, "role_id"),
 		Status:      d.Get("status").(string),
 		Vid:         int64ToPtr(int64(d.Get("vid").(int))),


### PR DESCRIPTION
Thanks to @alxgarder's comment in #717 a small error was in the update method. This has now be fixed