### PR TITLE
Add description filter to data netbox_prefixes

### DIFF
--- a/docs/data-sources/prefixes.md
+++ b/docs/data-sources/prefixes.md
@@ -30,7 +30,7 @@ description: |-
 
 Required:
 
-- `name` (String) The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `tenant_id`, `site_id`, & `tag`.
+- `name` (String) The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `tenant_id`, `site_id`, `description` & `tag`.
 - `value` (String) The value to pass to the specified filter.
 
 

--- a/netbox/data_source_netbox_prefixes.go
+++ b/netbox/data_source_netbox_prefixes.go
@@ -24,7 +24,7 @@ func dataSourceNetboxPrefixes() *schema.Resource {
 						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `tenant_id`, `site_id`, & `tag`.",
+							Description: "The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `tenant_id`, `site_id`, `description` & `tag`.",
 						},
 						"value": {
 							Type:        schema.TypeString,
@@ -138,6 +138,8 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 				params.TenantID = &vString
 			case "site_id":
 				params.SiteID = &vString
+			case "description":
+				params.Description = &vString
 			case "tag":
 				params.Tag = []string{vString}
 			default:

--- a/netbox/data_source_netbox_prefixes_test.go
+++ b/netbox/data_source_netbox_prefixes_test.go
@@ -164,6 +164,15 @@ data "netbox_prefixes" "find_prefix_with_contains" {
   }
 }
 
+data "netbox_prefixes" "find_prefix_with_description" {
+  depends_on = [netbox_prefix.test_prefix1]
+  filter {
+    name  = "description"
+    value = netbox_prefix.test_prefix1.description
+  }
+}
+
+
 `, testName, testPrefixes[0], testPrefixes[1], testPrefixes[2], testPrefixes[3], testPrefixes[4], testVlanVids[0], testVlanVids[1], testPrefixes[5]),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_prefixes.by_vrf", "prefixes.#", "2"),
@@ -181,6 +190,7 @@ data "netbox_prefixes" "find_prefix_with_contains" {
 					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_contains", "prefixes.#", "1"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_contains", "prefixes.0.prefix", "10.0.9.0/24"),
 					resource.TestCheckResourceAttrSet("data.netbox_prefixes.find_prefix_with_contains", "prefixes.0.site_id"),
+					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_description", "prefixes.0.description", "my-description"),
 				),
 			},
 		},


### PR DESCRIPTION
The provider is missing the ability to filter by description from the `netbox_prefixes` `data` so this just does that. 