### PR TITLE
Fix custom fields state drift

### DIFF
--- a/netbox/custom_fields_test.go
+++ b/netbox/custom_fields_test.go
@@ -76,7 +76,7 @@ func TestFlattenCustomFields(t *testing.T) {
 				},
 			},
 			expected: map[string]interface{}{
-				"gateway": `{"address":"10.21.10.254/24","display":"10.21.10.254/24","family":{"label":"IPv4","value":4},"id":9,"url":"https://netbox.example.com/api/ipam/ip-addresses/9/"}`,
+				"gateway": "9",
 			},
 		},
 		{
@@ -191,21 +191,15 @@ func TestFlattenCustomFields_ComplexRealWorldExample(t *testing.T) {
 		t.Fatal("expected non-nil result")
 	}
 
-	// Check that gateway is a JSON string
+	// Check that gateway is extracted to just the ID string
 	gateway, ok := result["gateway"].(string)
 	if !ok {
 		t.Errorf("expected gateway to be a string, got %T", result["gateway"])
 	}
 
-	// Verify we can parse the gateway JSON
-	var gatewayObj map[string]interface{}
-	if err := json.Unmarshal([]byte(gateway), &gatewayObj); err != nil {
-		t.Errorf("failed to parse gateway JSON: %v", err)
-	}
-
-	// Verify the gateway object has expected fields
-	if gatewayObj["address"] != "10.21.10.254/24" {
-		t.Errorf("expected address 10.21.10.254/24, got %v", gatewayObj["address"])
+	// Verify the gateway is just the ID
+	if gateway != "9" {
+		t.Errorf("expected gateway=9, got %v", gateway)
 	}
 
 	// Check simple fields

--- a/netbox/resource_netbox_cable.go
+++ b/netbox/resource_netbox_cable.go
@@ -181,7 +181,7 @@ func resourceNetboxCableRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("description", cable.Description)
 	d.Set("comments", cable.Comments)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_circuit_termination.go
+++ b/netbox/resource_netbox_circuit_termination.go
@@ -221,7 +221,7 @@ func resourceNetboxCircuitTerminationRead(d *schema.ResourceData, m interface{})
 
 	api.readTags(d, term.Tags)
 
-	cf := getCustomFields(term.CustomFields)
+	cf := flattenCustomFields(term.CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_device.go
+++ b/netbox/resource_netbox_device.go
@@ -353,7 +353,7 @@ func resourceNetboxDeviceRead(ctx context.Context, d *schema.ResourceData, m int
 		d.Set("config_template_id", nil)
 	}
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_device_bay.go
+++ b/netbox/resource_netbox_device_bay.go
@@ -115,7 +115,7 @@ func resourceNetboxDeviceBayRead(d *schema.ResourceData, m interface{}) error {
 	}
 	d.Set("description", deviceBay.Description)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_device_console_port.go
+++ b/netbox/resource_netbox_device_console_port.go
@@ -150,7 +150,7 @@ func resourceNetboxDeviceConsolePortRead(d *schema.ResourceData, m interface{}) 
 	d.Set("description", consolePort.Description)
 	d.Set("mark_connected", consolePort.MarkConnected)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_device_console_server_port.go
+++ b/netbox/resource_netbox_device_console_server_port.go
@@ -150,7 +150,7 @@ func resourceNetboxDeviceConsoleServerPortRead(d *schema.ResourceData, m interfa
 	d.Set("description", consoleServerPort.Description)
 	d.Set("mark_connected", consoleServerPort.MarkConnected)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_device_front_port.go
+++ b/netbox/resource_netbox_device_front_port.go
@@ -162,7 +162,7 @@ func resourceNetboxDeviceFrontPortRead(d *schema.ResourceData, m interface{}) er
 	d.Set("description", frontPort.Description)
 	d.Set("mark_connected", frontPort.MarkConnected)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_device_module_bay.go
+++ b/netbox/resource_netbox_device_module_bay.go
@@ -115,7 +115,7 @@ func resourceNetboxDeviceModuleBayRead(d *schema.ResourceData, m interface{}) er
 	d.Set("position", moduleBay.Position)
 	d.Set("description", moduleBay.Description)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_device_power_feed.go
+++ b/netbox/resource_netbox_device_power_feed.go
@@ -199,7 +199,7 @@ func resourceNetboxPowerFeedRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("description", powerFeed.Description)
 	d.Set("comments", powerFeed.Comments)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_device_power_outlet.go
+++ b/netbox/resource_netbox_device_power_outlet.go
@@ -166,7 +166,7 @@ func resourceNetboxDevicePowerOutletRead(d *schema.ResourceData, m interface{}) 
 	d.Set("description", powerOutlet.Description)
 	d.Set("mark_connected", powerOutlet.MarkConnected)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_device_power_port.go
+++ b/netbox/resource_netbox_device_power_port.go
@@ -152,7 +152,7 @@ func resourceNetboxDevicePowerPortRead(d *schema.ResourceData, m interface{}) er
 	d.Set("description", powerPort.Description)
 	d.Set("mark_connected", powerPort.MarkConnected)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_device_rear_port.go
+++ b/netbox/resource_netbox_device_rear_port.go
@@ -151,7 +151,7 @@ func resourceNetboxDeviceRearPortRead(d *schema.ResourceData, m interface{}) err
 	d.Set("description", rearPort.Description)
 	d.Set("mark_connected", rearPort.MarkConnected)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_inventory_item.go
+++ b/netbox/resource_netbox_inventory_item.go
@@ -191,7 +191,7 @@ func resourceNetboxInventoryItemRead(d *schema.ResourceData, m interface{}) erro
 	d.Set("component_type", item.ComponentType)
 	d.Set("component_id", item.ComponentID)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_inventory_item_role.go
+++ b/netbox/resource_netbox_inventory_item_role.go
@@ -102,7 +102,7 @@ func resourceNetboxInventoryItemRoleRead(d *schema.ResourceData, m interface{}) 
 	d.Set("color_hex", role.Color)
 	d.Set("description", role.Description)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_ip_address.go
+++ b/netbox/resource_netbox_ip_address.go
@@ -274,7 +274,7 @@ func resourceNetboxIPAddressRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("description", ipAddress.Description)
 	d.Set("status", ipAddress.Status.Value)
 	api.readTags(d, ipAddress.Tags)
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_location.go
+++ b/netbox/resource_netbox_location.go
@@ -164,7 +164,7 @@ func resourceNetboxLocationRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("tenant_id", nil)
 	}
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_mac_address.go
+++ b/netbox/resource_netbox_mac_address.go
@@ -171,7 +171,7 @@ func resourceNetboxMACAddressRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("comments", macAddress.Comments)
 	api.readTags(d, macAddress.Tags)
 
-	cf := getCustomFields(macAddress.CustomFields)
+	cf := flattenCustomFields(macAddress.CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_module.go
+++ b/netbox/resource_netbox_module.go
@@ -154,7 +154,7 @@ func resourceNetboxModuleRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("description", module.Description)
 	d.Set("comments", module.Comments)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_module_type.go
+++ b/netbox/resource_netbox_module_type.go
@@ -135,7 +135,7 @@ func resourceNetboxModuleTypeRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("description", moduleType.Description)
 	d.Set("comments", moduleType.Comments)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_power_panel.go
+++ b/netbox/resource_netbox_power_panel.go
@@ -119,7 +119,7 @@ func resourceNetboxPowerPanelRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("description", powerPanel.Description)
 	d.Set("comments", powerPanel.Comments)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_prefix.go
+++ b/netbox/resource_netbox_prefix.go
@@ -241,7 +241,7 @@ func resourceNetboxPrefixRead(d *schema.ResourceData, m interface{}) error {
 			d.Set("region_id", scopeID)
 		}
 	}
-	cf := getCustomFields(prefix.CustomFields)
+	cf := flattenCustomFields(prefix.CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_rack.go
+++ b/netbox/resource_netbox_rack.go
@@ -313,7 +313,7 @@ func resourceNetboxRackRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("form_factor", nil)
 	}
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_service.go
+++ b/netbox/resource_netbox_service.go
@@ -178,7 +178,7 @@ func resourceNetboxServiceRead(d *schema.ResourceData, m interface{}) error {
 		api.readTags(d, tags)
 	}
 
-	cf := getCustomFields(service.CustomFields)
+	cf := flattenCustomFields(service.CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_site.go
+++ b/netbox/resource_netbox_site.go
@@ -255,7 +255,7 @@ func resourceNetboxSiteRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("tenant_id", nil)
 	}
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_virtual_chassis.go
+++ b/netbox/resource_netbox_virtual_chassis.go
@@ -122,7 +122,7 @@ func resourceNetboxVirtualChassisRead(ctx context.Context, d *schema.ResourceDat
 	d.Set("description", virtualChassis.Description)
 	d.Set("comments", virtualChassis.Comments)
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_virtual_disk.go
+++ b/netbox/resource_netbox_virtual_disk.go
@@ -127,7 +127,7 @@ func resourceNetboxVirtualDisksRead(ctx context.Context, d *schema.ResourceData,
 		d.Set("virtual_machine_id", VirtualDisks.VirtualMachine.ID)
 	}
 
-	cf := getCustomFields(res.GetPayload().CustomFields)
+	cf := flattenCustomFields(res.GetPayload().CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}

--- a/netbox/resource_netbox_virtual_machine.go
+++ b/netbox/resource_netbox_virtual_machine.go
@@ -324,7 +324,7 @@ func resourceNetboxVirtualMachineRead(ctx context.Context, d *schema.ResourceDat
 	}
 	api.readTags(d, vm.Tags)
 
-	cf := getCustomFields(vm.CustomFields)
+	cf := flattenCustomFields(vm.CustomFields)
 	if cf != nil {
 		d.Set(customFieldsKey, cf)
 	}


### PR DESCRIPTION
**Description**
- Running `terraform plan` repeatedly shows the same custom fields needing to be added
- Permanent state drift that never resolves
- Specifically affects object reference custom fields like `cloud_account `on `netbox_prefix` resources

**Changes Made**
1. Fixed `flattenCustomFields` function
2. Changed from `getCustomFields()` to `flattenCustomFields()` and ensures consistent handling across all resources with custom fields
3. Added `DiffSuppressFunc` which suppresses false positives between `{}` (empty map) and `""` (empty string) and prevents spurious drift on empty custom fields
4. Updated client configuration which configures JSON consumer to handle numeric values properly
 and `uses json.Number` to prevent type conversion issues

**Referenced Issue:** #712 