### PR TITLE
fix(netbox_user): resolve date_joined datetime out of range error

### DIFF
--- a/netbox/resource_netbox_user.go
+++ b/netbox/resource_netbox_user.go
@@ -2,6 +2,7 @@ package netbox
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/fbreckle/go-netbox/netbox/client/users"
 	"github.com/fbreckle/go-netbox/netbox/models"
@@ -87,6 +88,7 @@ func resourceNetboxUserCreate(d *schema.ResourceData, m interface{}) error {
 	data.IsActive = active
 	data.IsStaff = staff
 	data.Groups = groupIDs
+	data.DateJoined = strfmt.DateTime(time.Now())
 
 	params := users.NewUsersUsersCreateParams().WithData(&data)
 	res, err := api.Users.UsersUsersCreate(params, nil)
@@ -155,6 +157,7 @@ func resourceNetboxUserUpdate(d *schema.ResourceData, m interface{}) error {
 	data.IsActive = active
 	data.IsStaff = staff
 	data.Groups = groupIDs
+	data.DateJoined = strfmt.DateTime(time.Now())
 
 	params := users.NewUsersUsersUpdateParams().WithID(id).WithData(&data)
 	_, err := api.Users.UsersUsersUpdate(params, nil)


### PR DESCRIPTION
Fixes invalid datetime value being sent to NetBox API when creating user resources without explicit date_joined field. The provider now correctly handles the date_joined field to prevent validation errors.