### PR TITLE
fix(datasources): convert boolean custom fields to strings

### DIFF
--- a/netbox/data_source_netbox_cluster.go
+++ b/netbox/data_source_netbox_cluster.go
@@ -148,7 +148,7 @@ func dataSourceNetboxClusterRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if result.CustomFields != nil {
-		d.Set("custom_fields", result.CustomFields)
+		d.Set("custom_fields", flattenCustomFields(result.CustomFields))
 	}
 
 	d.Set(tagsKey, getTagListFromNestedTagList(result.Tags))

--- a/netbox/data_source_netbox_devices.go
+++ b/netbox/data_source_netbox_devices.go
@@ -295,7 +295,7 @@ func dataSourceNetboxDevicesRead(d *schema.ResourceData, m interface{}) error {
 			mapping["status"] = *device.Status.Value
 		}
 		if device.CustomFields != nil {
-			mapping["custom_fields"] = device.CustomFields
+			mapping["custom_fields"] = flattenCustomFields(device.CustomFields)
 		}
 		if device.Rack != nil {
 			mapping["rack_id"] = device.Rack.ID

--- a/netbox/data_source_netbox_ip_address.go
+++ b/netbox/data_source_netbox_ip_address.go
@@ -1,10 +1,11 @@
 package netbox
 
 import (
+	"strconv"
+
 	"github.com/fbreckle/go-netbox/netbox/client/ipam"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"strconv"
 )
 
 func dataSourceNetboxIPAddress() *schema.Resource {
@@ -124,7 +125,7 @@ func dataSourceNetboxIPAddressRead(d *schema.ResourceData, m interface{}) error 
 	d.Set("description", result.Description)
 	d.Set("created", result.Created.String())
 	d.Set("last_updated", result.LastUpdated.String())
-	d.Set("custom_fields", result.CustomFields)
+	d.Set("custom_fields", flattenCustomFields(result.CustomFields))
 	d.Set("address_family", result.Family.Label)
 	d.Set("status", result.Status.Value)
 	d.Set("dns_name", result.DNSName)

--- a/netbox/data_source_netbox_ip_addresses.go
+++ b/netbox/data_source_netbox_ip_addresses.go
@@ -202,7 +202,7 @@ func dataSourceNetboxIPAddressesRead(d *schema.ResourceData, m interface{}) erro
 		mapping["description"] = v.Description
 		mapping["created"] = v.Created.String()
 		mapping["last_updated"] = v.LastUpdated.String()
-		mapping["custom_fields"] = v.CustomFields
+		mapping["custom_fields"] = flattenCustomFields(v.CustomFields)
 
 		mapping["ip_address"] = v.Address
 		mapping["address_family"] = v.Family.Label

--- a/netbox/data_source_netbox_ip_ranges.go
+++ b/netbox/data_source_netbox_ip_ranges.go
@@ -193,7 +193,7 @@ func dataSourceNetboxIPRangesRead(d *schema.ResourceData, m interface{}) error {
 		mapping["description"] = v.Description
 		mapping["created"] = v.Created.String()
 		mapping["last_updated"] = v.LastUpdated.String()
-		mapping["custom_fields"] = v.CustomFields
+		mapping["custom_fields"] = flattenCustomFields(v.CustomFields)
 
 		mapping["start_address"] = v.StartAddress
 		mapping["end_address"] = v.EndAddress

--- a/netbox/data_source_netbox_tenants.go
+++ b/netbox/data_source_netbox_tenants.go
@@ -195,7 +195,7 @@ func dataSourceNetboxTenantsRead(d *schema.ResourceData, m interface{}) error {
 		mapping["created"] = v.Created.String()
 		mapping["last_updated"] = v.LastUpdated.String()
 		mapping["comments"] = v.Comments
-		mapping["custom_fields"] = v.CustomFields
+		mapping["custom_fields"] = flattenCustomFields(v.CustomFields)
 
 		mapping["site_count"] = v.SiteCount
 		mapping["rack_count"] = v.RackCount

--- a/netbox/data_source_netbox_virtual_disk.go
+++ b/netbox/data_source_netbox_virtual_disk.go
@@ -147,7 +147,7 @@ func dataSourceNetboxVirtualDiskRead(d *schema.ResourceData, m interface{}) erro
 			mapping["virtual_machine_id"] = v.VirtualMachine.ID
 		}
 		if v.CustomFields != nil {
-			mapping["custom_fields"] = v.CustomFields
+			mapping["custom_fields"] = flattenCustomFields(v.CustomFields)
 		}
 		if v.Tags != nil {
 			tags := []string{}

--- a/netbox/data_source_netbox_virtual_machines.go
+++ b/netbox/data_source_netbox_virtual_machines.go
@@ -240,7 +240,7 @@ func dataSourceNetboxVirtualMachineRead(d *schema.ResourceData, m interface{}) e
 			}
 		}
 		if v.CustomFields != nil {
-			mapping["custom_fields"] = v.CustomFields
+			mapping["custom_fields"] = flattenCustomFields(v.CustomFields)
 		}
 		if v.Disk != nil {
 			mapping["disk_size_mb"] = *v.Disk


### PR DESCRIPTION
Apply flattenCustomFields() to convert boolean and numeric custom field values from the Netbox API to strings for Terraform state storage.

This fixes the error when reading resources with boolean custom fields: 'expected type string, got unconvertible type bool'

Modified data sources:
- data_source_netbox_cluster
- data_source_netbox_devices
- data_source_netbox_ip_address
- data_source_netbox_ip_addresses
- data_source_netbox_ip_ranges
- data_source_netbox_tenants
- data_source_netbox_virtual_disk
- data_source_netbox_virtual_machines