### PR TITLE
Fix typographical error in example data-sources/interfaces

### DIFF
--- a/docs/data-sources/interfaces.md
+++ b/docs/data-sources/interfaces.md
@@ -13,7 +13,7 @@ description: |-
 ## Example Usage
 
 ```terraform
-data "netbox_interface" "myvm_eth0" {
+data "netbox_interfaces" "myvm_eth0" {
   name_regex = "eth0"
   filter {
     name  = "name"

--- a/examples/data-sources/netbox_interfaces/data-source.tf
+++ b/examples/data-sources/netbox_interfaces/data-source.tf
@@ -1,4 +1,4 @@
-data "netbox_interface" "myvm_eth0" {
+data "netbox_interfaces" "myvm_eth0" {
   name_regex = "eth0"
   filter {
     name  = "name"


### PR DESCRIPTION
Corrected a typo in the documentation example for data-sources/interfaces.