### PR TITLE
Fix vm_role attribute drift in netbox_device_role resource

### DIFF
--- a/docs/resources/device_role.md
+++ b/docs/resources/device_role.md
@@ -16,9 +16,19 @@ From the [official documentation](https://docs.netbox.dev/en/stable/features/dev
 ## Example Usage
 
 ```terraform
+# Device role for physical devices only
 resource "netbox_device_role" "core_sw" {
   color_hex = "FF00FF"
   name      = "core-sw"
+  vm_role   = false
+}
+
+# Device role that can be used for both devices and VMs
+resource "netbox_device_role" "web_server" {
+  color_hex   = "00FF00"
+  name        = "web-server"
+  description = "Web server role"
+  vm_role     = true
 }
 ```
 
@@ -35,7 +45,7 @@ resource "netbox_device_role" "core_sw" {
 - `description` (String)
 - `slug` (String)
 - `tags` (Set of String)
-- `vm_role` (Boolean) Defaults to `true`.
+- `vm_role` (Boolean) Virtual machines may be assigned to this role. Defaults to `false`.
 
 ### Read-Only
 

--- a/netbox/resource_netbox_device_role.go
+++ b/netbox/resource_netbox_device_role.go
@@ -34,7 +34,7 @@ func resourceNetboxDeviceRole() *schema.Resource {
 			"vm_role": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Default:  false,
 			},
 			"color_hex": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
**Description:**
Fixes #820 - Removes the incorrect `Default: true` from the `vm_role` attribute in the `netbox_device_role` resource, which was causing persistent drift with NetBox 3.0+.

**Changes Made**
- Removed `Default: true` from the `vm_role` schema definition in `resource_netbox_device_role.go`

**Referenced Issue:** #820 