### PR TITLE
fix: suppress DNS name case drift caused by NetBox lowercasing

### DIFF
--- a/netbox/resource_netbox_available_ip_address.go
+++ b/netbox/resource_netbox_available_ip_address.go
@@ -3,6 +3,7 @@ package netbox
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/fbreckle/go-netbox/netbox/client/ipam"
 	"github.com/fbreckle/go-netbox/netbox/models"
@@ -86,6 +87,10 @@ This resource will retrieve the next available IP address from a given prefix or
 			"dns_name": {
 				Type:     schema.TypeString,
 				Optional: true,
+				// NetBox always converts DNS names to lowercase
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/netbox/resource_netbox_ip_address.go
+++ b/netbox/resource_netbox_ip_address.go
@@ -2,6 +2,7 @@ package netbox
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/fbreckle/go-netbox/netbox/client/ipam"
 	"github.com/fbreckle/go-netbox/netbox/models"
@@ -71,6 +72,10 @@ func resourceNetboxIPAddress() *schema.Resource {
 			"dns_name": {
 				Type:     schema.TypeString,
 				Optional: true,
+				// NetBox always converts DNS names to lowercase
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.EqualFold(old, new)
+				},
 			},
 			tagsKey: tagsSchema,
 			"description": {

--- a/netbox/resource_netbox_ip_address_test.go
+++ b/netbox/resource_netbox_ip_address_test.go
@@ -551,3 +551,28 @@ func init() {
 		},
 	})
 }
+
+func TestAccNetboxIPAddress_dnsNameCase(t *testing.T) {
+	testIP := "1.1.1.253/32"
+	testSlug := "ipaddr_dns_case"
+	testName := testAccGetTestName(testSlug)
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Mixed-case dns_name: NetBox stores it as lowercase.
+				// Without DiffSuppressFunc the post-apply plan check detects
+				// drift and fails with "the plan was not empty" (#828).
+				Config: testAccNetboxIPAddressFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_ip_address" "test" {
+  ip_address = "%s"
+  status     = "active"
+  dns_name   = "Mytest.Example.Com"
+}`, testIP),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_ip_address.test", "dns_name", "mytest.example.com"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Problem
NetBox automatically converts DNS names to lowercase (see NetBox IP models). When users specify a mixed-case `dns_name` (e.g. `Host.Example.Com`), the provider sees a difference between the config value and the stored lowercase value, causing false configuration drift on every subsequent plan.

## Solution
Add a `DiffSuppressFunc` using `strings.EqualFold` to the `dns_name` field in both `netbox_ip_address` and `netbox_available_ip_address`, suppressing diffs that differ only in case. This mirrors the fix applied to `mac_address` in #446.

**Fixes:** #828.