### PR TITLE
fix: clear expires from state when token has no expiry

### DIFF
--- a/netbox/resource_netbox_token.go
+++ b/netbox/resource_netbox_token.go
@@ -135,6 +135,8 @@ func resourceNetboxTokenRead(ctx context.Context, d *schema.ResourceData, m inte
 	d.Set("last_used", token.LastUsed)
 	if token.Expires != nil {
 		d.Set("expires", token.Expires.String())
+	} else {
+		d.Set("expires", nil)
 	}
 	d.Set("allowed_ips", token.AllowedIps)
 	d.Set("write_enabled", token.WriteEnabled)

--- a/netbox/resource_netbox_token_test.go
+++ b/netbox/resource_netbox_token_test.go
@@ -73,6 +73,30 @@ resource "netbox_token" "test_without_expires" {
   allowed_ips   = ["2.4.8.16/32"]
   write_enabled = false
   description   = "Netbox Token Without Expires"
+  expires       = "2036-01-02T15:04:05.000Z"
+}`, testName, testToken),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "key", testToken),
+					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "allowed_ips.#", "1"),
+					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "allowed_ips.0", "2.4.8.16/32"),
+					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "write_enabled", "false"),
+					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "description", "Netbox Token Without Expires"),
+					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "expires", "2036-01-02T15:04:05.000Z"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_user" "test" {
+  username = "%s"
+  password = "Abcdefghijkl1"
+}
+
+resource "netbox_token" "test_without_expires" {
+  user_id       = netbox_user.test.id
+  key           = "%s"
+  allowed_ips   = ["2.4.8.16/32"]
+  write_enabled = false
+  description   = "Netbox Token Without Expires"
 }`, testName, testToken),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "key", testToken),

--- a/netbox/resource_netbox_token_test.go
+++ b/netbox/resource_netbox_token_test.go
@@ -81,6 +81,30 @@ resource "netbox_token" "test_without_expires" {
   allowed_ips   = ["2.4.8.16/32"]
   write_enabled = false
   description   = "Netbox Token Without Expires"
+  expires       = "2036-01-02T15:04:05.000Z"
+}`, testName, testToken),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "key", testToken),
+					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "allowed_ips.#", "1"),
+					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "allowed_ips.0", "2.4.8.16/32"),
+					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "write_enabled", "false"),
+					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "description", "Netbox Token Without Expires"),
+					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "expires", "2036-01-02T15:04:05.000Z"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_user" "test" {
+  username = "%s"
+  password = "Abcdefghijkl1"
+}
+
+resource "netbox_token" "test_without_expires" {
+  user_id       = netbox_user.test.id
+  key           = "%s"
+  allowed_ips   = ["2.4.8.16/32"]
+  write_enabled = false
+  description   = "Netbox Token Without Expires"
 }`, testName, testToken),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "key", testToken),

--- a/netbox/resource_netbox_token_test.go
+++ b/netbox/resource_netbox_token_test.go
@@ -112,7 +112,7 @@ resource "netbox_token" "test_without_expires" {
 					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "allowed_ips.0", "2.4.8.16/32"),
 					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "write_enabled", "false"),
 					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "description", "Netbox Token Without Expires"),
-					resource.TestCheckNoResourceAttr("netbox_token.test_without_expires", "expires"),
+					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "expires", ""),
 				),
 			},
 			{


### PR DESCRIPTION
## Problem
When NetBox returns a token with no expiration date, the Read function skips `d.Set("expires", ...)` entirely, leaving any previously stored value in state. This causes perpetual drift if a token is imported or its expiry is cleared out-of-band.

## Fix
Explicitly set `expires` to `nil` in Read when the API returns no expiration, ensuring state always accurately reflects the token's actual state in NetBox.

## Notes
The companion fix for write (guarding Create/Update with `GetOk` so a null `expires` doesn't get sent as epoch `1970-01-01`) was already addressed in #97fc307 and related to https://github.com/e-breuninger/terraform-provider-netbox/issues/772