### PR TITLE
feat: add platform filter to virtual machine datasource

### DIFF
--- a/netbox/data_source_netbox_virtual_machines.go
+++ b/netbox/data_source_netbox_virtual_machines.go
@@ -198,6 +198,10 @@ func dataSourceNetboxVirtualMachineRead(d *schema.ResourceData, m interface{}) e
 				params.Tag = tags
 			case "status":
 				params.Status = &vString
+			case "platform":
+				params.Platform = &vString
+			case "platform_id":
+				params.PlatformID = &vString
 			default:
 				return fmt.Errorf("'%s' is not a supported filter parameter", k)
 			}

--- a/netbox/data_source_netbox_virtual_machines_test.go
+++ b/netbox/data_source_netbox_virtual_machines_test.go
@@ -291,6 +291,58 @@ data "netbox_virtual_machines" "test_decommissioning" {
   }
 }`
 
+func TestAccNetboxVirtualMachinesDataSource_platform(t *testing.T) {
+	testSlug := "vm_ds_platform"
+	testName := testAccGetTestName(testSlug)
+	dependencies := testAccNetboxVirtualMachineDataSourceDependenciesWithPlatform(testName)
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dependencies,
+			},
+			{
+				Config: dependencies + testAccNetboxVirtualMachineDataSourceFilterPlatform,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_virtual_machines.test", "vms.#", "1"),
+					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.0.name", "netbox_virtual_machine.test0", "name"),
+					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.0.platform_id", "netbox_platform.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetboxVirtualMachineDataSourceDependenciesWithPlatform(testName string) string {
+	return testAccNetboxVirtualMachineFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_platform" "test2" {
+  name = "%[1]s_2"
+}
+
+resource "netbox_virtual_machine" "test0" {
+  name        = "%[1]s_0"
+  cluster_id  = netbox_cluster.test.id
+  site_id     = netbox_site.test.id
+  platform_id = netbox_platform.test.id
+}
+
+resource "netbox_virtual_machine" "test1" {
+  name        = "%[1]s_1"
+  cluster_id  = netbox_cluster.test.id
+  site_id     = netbox_site.test.id
+  platform_id = netbox_platform.test2.id
+}
+`, testName)
+}
+
+const testAccNetboxVirtualMachineDataSourceFilterPlatform = `
+data "netbox_virtual_machines" "test" {
+  filter {
+    name  = "platform"
+    value = netbox_platform.test.slug
+  }
+}`
+
 func testAccNetboxVirtualMachineDataSourceDependenciesWithStatus(testName string) string {
 	return testAccNetboxVirtualMachineFullDependencies(testName) + fmt.Sprintf(`
 resource "netbox_tag" "servicea" {


### PR DESCRIPTION
Add support for filtering on platform when using the `netbox_virtual_machines` datasource to fetch VMs