### PR TITLE
fix: change contact to accept group array

### DIFF
--- a/docs/data-sources/contact.md
+++ b/docs/data-sources/contact.md
@@ -23,7 +23,7 @@ description: |-
 
 ### Read-Only
 
-- `group_id` (Number)
+- `group_ids` (List of Number)
 - `id` (String) The ID of this resource.
 
 

--- a/docs/resources/contact.md
+++ b/docs/resources/contact.md
@@ -37,7 +37,7 @@ resource "netbox_contact" "test" {
 
 - `description` (String)
 - `email` (String)
-- `group_id` (Number)
+- `group_ids` (List of Number)
 - `link` (String)
 - `phone` (String)
 - `tags` (Set of String)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/e-breuninger/terraform-provider-netbox
 go 1.25.8
 
 require (
-	github.com/fbreckle/go-netbox v0.0.0-20260529144755-0e7d8f1c0178
+	github.com/fbreckle/go-netbox v0.0.0-20260605085127-7ccc1c5de0b4
 	github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3
 	github.com/go-openapi/runtime v0.32.3
 	github.com/go-openapi/strfmt v0.26.3

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
-github.com/fbreckle/go-netbox v0.0.0-20260529144755-0e7d8f1c0178 h1:qNer+pL5nn1rRFfWNSaaynOuK/ywpYICEMt6TeUF0F8=
-github.com/fbreckle/go-netbox v0.0.0-20260529144755-0e7d8f1c0178/go.mod h1:3U3/m/hna9Ntd3sbHBYwZ1IqbP2+coRzoXw3mCfu3kM=
+github.com/fbreckle/go-netbox v0.0.0-20260605085127-7ccc1c5de0b4 h1:ATU72xtLo2KZ8wg0Kk9tU9Bp2ksxvHVNQ9CIr2cnjho=
+github.com/fbreckle/go-netbox v0.0.0-20260605085127-7ccc1c5de0b4/go.mod h1:3U3/m/hna9Ntd3sbHBYwZ1IqbP2+coRzoXw3mCfu3kM=
 github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3 h1:DMSpM0btVedE2Tt1vfDHWQhf2obzjAe1F0/j8/CyfW4=
 github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3/go.mod h1:j3HmJySEjx6hOAOPDjGzmzpVNDQq9SNnnF+Vm22d2rs=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=

--- a/netbox/data_source_netbox_contact.go
+++ b/netbox/data_source_netbox_contact.go
@@ -25,8 +25,11 @@ func dataSourceNetboxContact() *schema.Resource {
 				Computed:     true,
 				AtLeastOneOf: []string{"name", "slug"},
 			},
-			"group_id": {
-				Type:     schema.TypeInt,
+			"group_ids": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
 				Computed: true,
 			},
 			"description": {
@@ -62,8 +65,13 @@ func dataSourceNetboxContactRead(d *schema.ResourceData, m interface{}) error {
 	result := res.GetPayload().Results[0]
 	d.SetId(strconv.FormatInt(result.ID, 10))
 	d.Set("name", result.Name)
-	if result.Group != nil {
-		d.Set("group_id", result.Group.ID)
+	if result.Groups != nil {
+		groups := result.Groups
+		groupIDs := make([]int64, len(groups))
+		for i, group := range groups {
+			groupIDs[i] = group.ID
+		}
+		d.Set("group_ids", groupIDs)
 	}
 	return nil
 }

--- a/netbox/resource_netbox_contact.go
+++ b/netbox/resource_netbox_contact.go
@@ -28,8 +28,11 @@ func resourceNetboxContact() *schema.Resource {
 				Required: true,
 			},
 			tagsKey: tagsSchema,
-			"group_id": {
-				Type:     schema.TypeInt,
+			"group_ids": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
 				Optional: true,
 			},
 			"email": {
@@ -63,7 +66,7 @@ func resourceNetboxContactCreate(d *schema.ResourceData, m interface{}) error {
 	email := d.Get("email").(string)
 	link := d.Get("link").(string)
 	description := d.Get("description").(string)
-	groupID := int64(d.Get("group_id").(int))
+	groupIDs := d.Get("group_ids").([]interface{})
 
 	tags, _ := getNestedTagListFromResourceDataSet(api, d.Get(tagsAllKey))
 
@@ -75,8 +78,9 @@ func resourceNetboxContactCreate(d *schema.ResourceData, m interface{}) error {
 	data.Email = strfmt.Email(email)
 	data.Link = strfmt.URI(link)
 	data.Description = description
-	if groupID != 0 {
-		data.Group = &groupID
+	data.Groups = make([]int64, len(groupIDs))
+	for i, id := range groupIDs {
+		data.Groups[i] = int64(id.(int))
 	}
 
 	params := tenancy.NewTenancyContactsCreateParams().WithData(data)
@@ -114,8 +118,13 @@ func resourceNetboxContactRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("email", res.GetPayload().Email)
 	d.Set("link", res.GetPayload().Link)
 	d.Set("description", res.GetPayload().Description)
-	if res.GetPayload().Group != nil {
-		d.Set("group_id", res.GetPayload().Group.ID)
+	if res.GetPayload().Groups != nil {
+		groups := res.GetPayload().Groups
+		groupIDs := make([]int64, len(groups))
+		for i, group := range groups {
+			groupIDs[i] = group.ID
+		}
+		d.Set("group_ids", groupIDs)
 	}
 
 	return nil
@@ -132,7 +141,7 @@ func resourceNetboxContactUpdate(d *schema.ResourceData, m interface{}) error {
 	email := d.Get("email").(string)
 	link := d.Get("link").(string)
 	description := d.Get("description").(string)
-	groupID := int64(d.Get("group_id").(int))
+	groupIDs := d.Get("group_ids").([]interface{})
 
 	tags, _ := getNestedTagListFromResourceDataSet(api, d.Get(tagsAllKey))
 
@@ -142,8 +151,9 @@ func resourceNetboxContactUpdate(d *schema.ResourceData, m interface{}) error {
 	data.Email = strfmt.Email(email)
 	data.Link = strfmt.URI(link)
 	data.Description = description
-	if groupID != 0 {
-		data.Group = &groupID
+	data.Groups = make([]int64, len(groupIDs))
+	for i, id := range groupIDs {
+		data.Groups[i] = int64(id.(int))
 	}
 
 	params := tenancy.NewTenancyContactsPartialUpdateParams().WithID(id).WithData(&data)

--- a/netbox/resource_netbox_contact_test.go
+++ b/netbox/resource_netbox_contact_test.go
@@ -53,6 +53,7 @@ resource "netbox_contact" "test" {
 					resource.TestCheckResourceAttr("netbox_contact.test", "phone", "123-123123"),
 					resource.TestCheckResourceAttr("netbox_contact.test", "link", "https://example.com"),
 					resource.TestCheckResourceAttr("netbox_contact.test", "description", "desc"),
+					resource.TestCheckResourceAttr("netbox_contact.test", "group_ids.#", "0"),
 				),
 			},
 			{
@@ -102,6 +103,37 @@ resource "netbox_contact" "test_tags" {
 }`, testName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_contact.test_tags", "tags.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetboxContact_groupsAssignment(t *testing.T) {
+	testSlug := "contact_groupAssingment"
+	testName := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_contact_group" "test_group" {
+	name = "%[1]s"
+}
+
+resource "netbox_contact_group" "test_group2" {
+	name = "%[1]s-2"
+}
+
+resource "netbox_contact" "test_contact" {
+	name = "%[1]s"
+	group_ids = [netbox_contact_group.test_group.id, netbox_contact_group.test_group2.id]
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_contact.test_contact", "name", testName),
+					resource.TestCheckResourceAttrPair("netbox_contact.test_contact", "group_ids.0", "netbox_contact_group.test_group", "id"),
+					resource.TestCheckResourceAttrPair("netbox_contact.test_contact", "group_ids.1", "netbox_contact_group.test_group2", "id"),
 				),
 			},
 		},


### PR DESCRIPTION
Adjusts the schema to match the current Netbox API spec for the contact resource.
- Replaced single `group_id` attribute with list `group_ids` to allow for multiple contact group assignments

#closes: https://github.com/e-breuninger/terraform-provider-netbox/issues/880