### PR TITLE
fix: guard nil DeviceType in netbox_devices data source

### DIFF
--- a/netbox/data_source_netbox_devices.go
+++ b/netbox/data_source_netbox_devices.go
@@ -296,12 +296,12 @@ func dataSourceNetboxDevicesRead(d *schema.ResourceData, m interface{}) error {
 		mapping["device_id"] = device.ID
 		if device.DeviceType != nil {
 			mapping["device_type_id"] = device.DeviceType.ID
-		}
-		if device.DeviceType.Manufacturer != nil {
-			mapping["manufacturer_id"] = device.DeviceType.Manufacturer.ID
-		}
-		if device.DeviceType.Model != nil {
-			mapping["model"] = *device.DeviceType.Model
+			if device.DeviceType.Manufacturer != nil {
+				mapping["manufacturer_id"] = device.DeviceType.Manufacturer.ID
+			}
+			if device.DeviceType.Model != nil {
+				mapping["model"] = *device.DeviceType.Model
+			}
 		}
 		if device.Name != nil {
 			mapping["name"] = *device.Name

--- a/netbox/data_source_netbox_devices_nil_device_type_test.go
+++ b/netbox/data_source_netbox_devices_nil_device_type_test.go
@@ -1,0 +1,55 @@
+package netbox
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestDataSourceNetboxDevicesReadNilDeviceType verifies that reading a device
+// whose device_type is null does not panic. NetBox can return devices without a
+// device type, and the data source must skip the device_type-derived attributes
+// instead of dereferencing a nil pointer.
+func TestDataSourceNetboxDevicesReadNilDeviceType(t *testing.T) {
+	device := minimalDeviceJSON(1, "device-without-type")
+	device["device_type"] = nil
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/dcim/devices/" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"count":    1,
+			"next":     nil,
+			"previous": nil,
+			"results":  []map[string]interface{}{device},
+		})
+	}))
+	defer ts.Close()
+
+	cfg := Config{APIToken: "test-token", ServerURL: ts.URL}
+	client, err := cfg.Client()
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+
+	state := &providerState{NetBoxAPI: client}
+	d := schema.TestResourceDataRaw(t, dataSourceNetboxDevices().Schema, map[string]interface{}{})
+
+	if err := dataSourceNetboxDevicesRead(d, state); err != nil {
+		t.Fatalf("dataSourceNetboxDevicesRead returned error: %v", err)
+	}
+
+	devices := d.Get("devices").([]interface{})
+	if len(devices) != 1 {
+		t.Fatalf("got %d devices, want 1", len(devices))
+	}
+	if mapping := devices[0].(map[string]interface{}); mapping["device_type_id"] != 0 {
+		t.Errorf("expected no device_type_id for device without device type, got %v", mapping["device_type_id"])
+	}
+}


### PR DESCRIPTION
The `netbox_devices` data source already checks `device.DeviceType != nil` before reading `device_type_id`, but the following `Manufacturer` and `Model` reads happen outside that guard, so a device without a device type panics with a nil pointer dereference. NetBox can return such devices, which makes the whole `data.netbox_devices` lookup fail. This moves the manufacturer/model reads inside the nil check and adds a regression test. Fixes #890.