### PR TITLE
feat(data-source): expose lag_device_interface_id and lag_id filter on netbox_device_interfaces

### DIFF
--- a/docs/data-sources/device_interfaces.md
+++ b/docs/data-sources/device_interfaces.md
@@ -44,6 +44,7 @@ Read-Only:
 - `device_id` (Number)
 - `enabled` (Boolean)
 - `id` (Number)
+- `lag_device_interface_id` (Number)
 - `mac_address` (String)
 - `mac_addresses` (Set of Object) (see [below for nested schema](#nestedobjatt--interfaces--mac_addresses))
 - `mode` (Map of String)

--- a/netbox/data_source_netbox_device_interfaces.go
+++ b/netbox/data_source_netbox_device_interfaces.go
@@ -154,6 +154,11 @@ func dataSourceNetboxDeviceInterfaces() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"lag_device_interface_id": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The ID of the LAG interface this interface is a member of, if any.",
+						},
 						"type": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -191,6 +196,8 @@ func dataSourceNetboxDeviceInterfaceRead(d *schema.ResourceData, m interface{}) 
 				params.Tag = []string{vString} // TODO: switch schema to list?
 			case "device_id":
 				params.DeviceID = &vString
+			case "lag_id":
+				params.LagID = &vString
 			default:
 				return fmt.Errorf("'%s' is not a supported filter parameter", k)
 			}
@@ -303,6 +310,10 @@ func dataSourceNetboxDeviceInterfaceRead(d *schema.ResourceData, m interface{}) 
 		}
 
 		mapping["device_id"] = v.Device.ID
+
+		if v.Lag != nil {
+			mapping["lag_device_interface_id"] = v.Lag.ID
+		}
 
 		s = append(s, mapping)
 	}

--- a/netbox/data_source_netbox_device_interfaces_test.go
+++ b/netbox/data_source_netbox_device_interfaces_test.go
@@ -65,6 +65,81 @@ data "netbox_device_interfaces" "by_tag" {
 	})
 }
 
+func TestAccNetboxDeviceInterfacesDataSource_lag(t *testing.T) {
+	testSlug := "dev_ifaces_ds_lag"
+	testName := testAccGetTestName(testSlug)
+	dependencies := testAccNetboxDeviceInterfacesDataSourceLAGDependencies(testName)
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: dependencies,
+			},
+			{
+				Config: dependencies + `
+data "netbox_device_interfaces" "by_lag_id" {
+  filter {
+    name  = "device_id"
+    value = netbox_device.test.id
+  }
+  filter {
+    name  = "lag_id"
+    value = netbox_device_interface.lag.id
+  }
+}
+`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_device_interfaces.by_lag_id", "interfaces.#", "1"),
+					resource.TestCheckResourceAttrPair("data.netbox_device_interfaces.by_lag_id", "interfaces.0.lag_device_interface_id", "netbox_device_interface.lag", "id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetboxDeviceInterfacesDataSourceLAGDependencies(testName string) string {
+	return fmt.Sprintf(`
+resource "netbox_site" "test" {
+  name   = "%[1]s"
+  status = "active"
+}
+
+resource "netbox_device_role" "test" {
+  name      = "%[1]s"
+  color_hex = "123456"
+}
+
+resource "netbox_manufacturer" "test" {
+  name = "%[1]s"
+}
+
+resource "netbox_device_type" "test" {
+  model           = "%[1]s"
+  manufacturer_id = netbox_manufacturer.test.id
+}
+
+resource "netbox_device" "test" {
+  name           = "%[1]s"
+  device_type_id = netbox_device_type.test.id
+  role_id        = netbox_device_role.test.id
+  site_id        = netbox_site.test.id
+}
+
+resource "netbox_device_interface" "lag" {
+  name      = "%[1]s_lag"
+  device_id = netbox_device.test.id
+  type      = "lag"
+}
+
+resource "netbox_device_interface" "member" {
+  name                    = "%[1]s_member"
+  device_id               = netbox_device.test.id
+  type                    = "1000base-t"
+  lag_device_interface_id = netbox_device_interface.lag.id
+}
+`, testName)
+}
+
 func testAccNetboxDeviceInterfacesDataSourceDependencies(testName string) string {
 	return fmt.Sprintf(`
 resource "netbox_tag" "test" {


### PR DESCRIPTION
## Summary

- Add `lag_device_interface_id` attribute to the `interfaces` list in the `netbox_device_interfaces` data source
- Add `lag_id` as a supported filter parameter (maps to the Netbox API `lag_id` query parameter)
- Add acceptance test `TestAccNetboxDeviceInterfacesDataSource_lag`

The `Interface` model already carries a `Lag` field (used by the `netbox_device_interface` resource), but the data source never mapped it and did not support filtering by LAG membership. This forces callers to select LAG member interfaces by hard-coding hardware-specific type strings (e.g. `"25gbase-x-sfp28"`), which breaks on mixed hardware or future port types.

With this change, you can filter at the API level:

```hcl
data "netbox_device_interfaces" "lag_members" {
  filter { name = "device_id", value = tostring(data.netbox_devices.this.devices[0].device_id) }
  filter { name = "lag_id",    value = tostring(netbox_device_interface.lag.id) }
}
```

Or post-filter in HCL using the new attribute:

```hcl
locals {
  lag_member_ifaces = {
    for iface in data.netbox_device_interfaces.all.interfaces :
    iface.name => iface
    if iface.lag_device_interface_id == tonumber(netbox_device_interface.lag.id)
  }
}
```

## Test plan

- [x] `go build ./...` passes
- [x] `make docs` regenerates `docs/data-sources/device_interfaces.md` with `lag_device_interface_id`
- [x] Acceptance test `TestAccNetboxDeviceInterfacesDataSource_lag`: creates a LAG + member interface via the resource, filters by `lag_id`, and verifies `lag_device_interface_id` is populated on the member

🤖 Generated with [Claude Code](https://claude.com/claude-code)