### PR TITLE
provider: apply request_timeout to per-operation timeout

### DIFF
--- a/netbox/client.go
+++ b/netbox/client.go
@@ -81,6 +81,12 @@ func (cfg *Config) Client() (*netboxclient.NetBoxAPI, error) {
 		Timeout:   time.Second * time.Duration(cfg.RequestTimeout),
 	}
 
+	// Also apply request_timeout to the per-operation timeout, which otherwise
+	// defaults to 30s independently of http.Client.Timeout.
+	if cfg.RequestTimeout > 0 {
+		httptransport.DefaultTimeout = time.Second * time.Duration(cfg.RequestTimeout)
+	}
+
 	transport := httptransport.NewWithClient(parsedURL.Host, parsedURL.Path+netboxclient.DefaultBasePath, desiredRuntimeClientSchemes, httpClient)
 	authScheme := "Token"
 	if strings.HasPrefix(cfg.APIToken, "nbt_") {

--- a/netbox/client_test.go
+++ b/netbox/client_test.go
@@ -4,8 +4,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/fbreckle/go-netbox/netbox/client/status"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -124,6 +126,21 @@ func TestV2TokenUsesBearerScheme(t *testing.T) {
 
 	req := status.NewStatusListParams()
 	client.Status.StatusList(req, nil)
+}
+
+func TestRequestTimeoutAppliesToOperationTimeout(t *testing.T) {
+	original := httptransport.DefaultTimeout
+	defer func() { httptransport.DefaultTimeout = original }()
+
+	config := Config{
+		APIToken:       "07b12b765127747e4afd56cb531b7bf9c61f3c30",
+		ServerURL:      "http://localhost",
+		RequestTimeout: 90,
+	}
+
+	_, err := config.Client()
+	assert.NoError(t, err)
+	assert.Equal(t, 90*time.Second, httptransport.DefaultTimeout)
 }
 
 /* TODO


### PR DESCRIPTION
The generated go-openapi client gives every operation a per-request timeout from httptransport.DefaultTimeout (30s), independent of http.Client.Timeout. As a result request_timeout had no effect on slow operations and backends slower than 30s (e.g. scale-to-zero cold starts in GCP CloudRun) failed with "context deadline exceeded" regardless of request_timeout.

Set DefaultTimeout from request_timeout during client construction so the setting governs both the HTTP client and per-operation timeouts.