### PR TITLE
Custom field defaults, options, alpha order

### DIFF
--- a/netbox/resource_netbox_custom_field.go
+++ b/netbox/resource_netbox_custom_field.go
@@ -1,6 +1,7 @@
 package netbox
 
 import (
+	"encoding/json"
 	"strconv"
 
 	"github.com/fbreckle/go-netbox/netbox/client/extras"
@@ -8,6 +9,35 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
+
+// customFieldDefaultToAPI - converts the tf attribute to the json netbox expects
+func customFieldDefaultToAPI(d *schema.ResourceData) interface{} {
+	v, ok := d.GetOk("default")
+	if !ok {
+		return nil
+	}
+	s := v.(string)
+	var parsed interface{}
+	if err := json.Unmarshal([]byte(s), &parsed); err != nil {
+		return s
+	}
+	return parsed
+}
+
+// normalizeCustomFieldDefault - state/config always compare as equal,
+// strings left the same
+func normalizeCustomFieldDefault(v interface{}) string {
+	s := v.(string)
+	var parsed interface{}
+	if json.Unmarshal([]byte(s), &parsed) != nil {
+		return s
+	}
+	b, err := json.Marshal(parsed)
+	if err != nil {
+		return s
+	}
+	return string(b)
+}
 
 func resourceCustomField() *schema.Resource {
 	return &schema.Resource{
@@ -59,8 +89,9 @@ func resourceCustomField() *schema.Resource {
 				},
 			},
 			"default": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				StateFunc: normalizeCustomFieldDefault,
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -113,7 +144,7 @@ func resourceNetboxCustomFieldUpdate(d *schema.ResourceData, m interface{}) erro
 	data := &models.WritableCustomField{
 		Name:              strToPtr(d.Get("name").(string)),
 		Type:              d.Get("type").(string),
-		Default:           d.Get("default").(string),
+		Default:           customFieldDefaultToAPI(d),
 		Description:       d.Get("description").(string),
 		GroupName:         d.Get("group_name").(string),
 		Label:             d.Get("label").(string),
@@ -164,7 +195,7 @@ func resourceNetboxCustomFieldCreate(d *schema.ResourceData, m interface{}) erro
 	data := &models.WritableCustomField{
 		Name:              strToPtr(d.Get("name").(string)),
 		Type:              d.Get("type").(string),
-		Default:           d.Get("default").(string),
+		Default:           customFieldDefaultToAPI(d),
 		Description:       d.Get("description").(string),
 		GroupName:         d.Get("group_name").(string),
 		Label:             d.Get("label").(string),
@@ -241,8 +272,15 @@ func resourceNetboxCustomFieldRead(d *schema.ResourceData, m interface{}) error 
 	}
 
 	d.Set("weight", customField.Weight)
+	// JSON value (number, bool, list) is re-encoded to its JSON text.
 	if customField.Default != nil {
-		d.Set("default", customField.Default)
+		if s, isStr := customField.Default.(string); isStr {
+			d.Set("default", s)
+		} else if b, err := json.Marshal(customField.Default); err == nil {
+			d.Set("default", string(b))
+		}
+	} else {
+		d.Set("default", "")
 	}
 
 	d.Set("description", customField.Description)

--- a/netbox/resource_netbox_custom_field_choice_set.go
+++ b/netbox/resource_netbox_custom_field_choice_set.go
@@ -89,7 +89,8 @@ func resourceNetboxCustomFieldChoiceSetCreate(d *schema.ResourceData, m interfac
 	name := d.Get("name").(string)
 
 	data := models.CustomFieldChoiceSet{
-		Name: &name,
+		Name:                &name,
+		OrderAlphabetically: d.Get("order_alphabetically").(bool),
 	}
 
 	data.Description = getOptionalStr(d, "description", false)
@@ -149,6 +150,20 @@ func resourceNetboxCustomFieldChoiceSetRead(d *schema.ResourceData, m interface{
 		d.Set("description", nil)
 	}
 
+	if choiceSet.ExtraChoices != nil {
+		d.Set("extra_choices", choiceSet.ExtraChoices)
+	} else {
+		d.Set("extra_choices", nil)
+	}
+
+	d.Set("order_alphabetically", choiceSet.OrderAlphabetically)
+
+	if choiceSet.BaseChoices != nil {
+		d.Set("base_choices", choiceSet.BaseChoices.Value)
+	} else {
+		d.Set("base_choices", nil)
+	}
+
 	return nil
 }
 
@@ -160,7 +175,8 @@ func resourceNetboxCustomFieldChoiceSetUpdate(d *schema.ResourceData, m interfac
 	name := d.Get("name").(string)
 
 	data := models.CustomFieldChoiceSet{
-		Name: &name,
+		Name:                &name,
+		OrderAlphabetically: d.Get("order_alphabetically").(bool),
 	}
 
 	data.Description = getOptionalStr(d, "description", true)

--- a/netbox/resource_netbox_custom_field_choice_set_test.go
+++ b/netbox/resource_netbox_custom_field_choice_set_test.go
@@ -71,3 +71,41 @@ resource "netbox_custom_field_choice_set" "test" {
 		},
 	})
 }
+
+func TestAccNetboxCustomFieldChoiceSet_orderAlphabeticallyAndImport(t *testing.T) {
+	testSlug := "cfields_choiceset_order"
+	testName := strings.ReplaceAll(testAccGetTestName(testSlug), "-", "_")
+	config := fmt.Sprintf(`
+resource "netbox_custom_field_choice_set" "test" {
+  name                 = "%s"
+  order_alphabetically = true
+  extra_choices = [
+    ["choice1", "label1"],
+    ["choice2", "label2"]
+  ]
+}`, testName)
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_custom_field_choice_set.test", "order_alphabetically", "true"),
+					resource.TestCheckResourceAttr("netbox_custom_field_choice_set.test", "extra_choices.0.0", "choice1"),
+					resource.TestCheckResourceAttr("netbox_custom_field_choice_set.test", "extra_choices.1.0", "choice2"),
+				),
+			},
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				ResourceName:      "netbox_custom_field_choice_set.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/netbox/resource_netbox_custom_field_test.go
+++ b/netbox/resource_netbox_custom_field_test.go
@@ -263,3 +263,143 @@ resource "netbox_custom_field" "test" {
 		},
 	})
 }
+
+func TestAccNetboxCustomField_integerDefault(t *testing.T) {
+	testSlug := "custom_fields_int_default"
+	testName := strings.ReplaceAll(testAccGetTestName(testSlug), "-", "_")
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_custom_field" "test" {
+  name          = "%s"
+  type          = "integer"
+  content_types = ["dcim.device"]
+  weight        = 100
+  default       = "42"
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_custom_field.test", "type", "integer"),
+					resource.TestCheckResourceAttr("netbox_custom_field.test", "default", "42"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetboxCustomField_booleanDefault(t *testing.T) {
+	testSlug := "custom_fields_bool_default"
+	testName := strings.ReplaceAll(testAccGetTestName(testSlug), "-", "_")
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_custom_field" "test" {
+  name          = "%s"
+  type          = "boolean"
+  content_types = ["dcim.device"]
+  weight        = 100
+  default       = "true"
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_custom_field.test", "type", "boolean"),
+					resource.TestCheckResourceAttr("netbox_custom_field.test", "default", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetboxCustomField_noDefault(t *testing.T) {
+	testSlug := "custom_fields_no_default"
+	testName := strings.ReplaceAll(testAccGetTestName(testSlug), "-", "_")
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_custom_field" "test" {
+  name          = "%s"
+  type          = "text"
+  content_types = ["dcim.device"]
+  weight        = 100
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_custom_field.test", "default", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetboxCustomField_jsonDefault(t *testing.T) {
+	testSlug := "custom_fields_json_default"
+	testName := strings.ReplaceAll(testAccGetTestName(testSlug), "-", "_")
+	config := fmt.Sprintf(`
+resource "netbox_custom_field" "test" {
+  name          = "%s"
+  type          = "json"
+  content_types = ["dcim.device"]
+  weight        = 100
+  default       = "{\"b\": 2, \"a\": 1}"
+}`, testName)
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.TestCheckResourceAttr(
+					"netbox_custom_field.test", "default", `{"a":1,"b":2}`),
+			},
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccNetboxCustomField_multiselectDefault(t *testing.T) {
+	testSlug := "custom_fields_multiselect_default"
+	testName := strings.ReplaceAll(testAccGetTestName(testSlug), "-", "_")
+	config := fmt.Sprintf(`
+resource "netbox_custom_field_choice_set" "test" {
+  name = "%[1]s"
+  extra_choices = [
+    ["red", "red"],
+    ["blue", "blue"]
+  ]
+}
+
+resource "netbox_custom_field" "test" {
+  name          = "%[1]s"
+  type          = "multiselect"
+  content_types = ["dcim.device"]
+  weight        = 100
+  choice_set_id = netbox_custom_field_choice_set.test.id
+  default       = "[\"red\", \"blue\"]"
+}`, testName)
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.TestCheckResourceAttr(
+					"netbox_custom_field.test", "default", `["red","blue"]`),
+			},
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}


### PR DESCRIPTION
Hi there! I was using terraform to manage our custom-field sprawl in netbox (we got up to 60 fields) - and I noticed a few issues. Hope this is OK!

* default was being sent as a raw string, coercing null values and ints to strings. for custom fields, modifying a default of `None` to `''` had catastrophic consequences 
* order_alphabetically wasn't being persisted
* read only restored name and description, include extra_choices, order_alphabetically, and base_choices in state - import and drift detection were false-positives