### PR TITLE
Add custom fields support for VLANs

### DIFF
--- a/docs/data-sources/vlan.md
+++ b/docs/data-sources/vlan.md
@@ -36,6 +36,7 @@ data "netbox_vlan" "vlan3" {
 
 ### Optional
 
+- `custom_fields` (Map of String)
 - `group_id` (Number)
 - `name` (String)
 - `role` (Number)

--- a/docs/data-sources/vlans.md
+++ b/docs/data-sources/vlans.md
@@ -17,6 +17,7 @@ description: |-
 
 ### Optional
 
+- `custom_fields` (Map of String)
 - `filter` (Block Set) (see [below for nested schema](#nestedblock--filter))
 - `limit` (Number) Defaults to `0`.
 
@@ -39,6 +40,7 @@ Required:
 
 Read-Only:
 
+- `custom_fields` (Map of String)
 - `description` (String)
 - `group_id` (Number)
 - `id` (Number)

--- a/docs/resources/vlan.md
+++ b/docs/resources/vlan.md
@@ -45,6 +45,7 @@ resource "netbox_vlan" "example2" {
 
 ### Optional
 
+- `custom_fields` (Map of String)
 - `description` (String) Defaults to `""`.
 - `group_id` (Number)
 - `role_id` (Number)

--- a/netbox/data_source_netbox_vlan.go
+++ b/netbox/data_source_netbox_vlan.go
@@ -10,6 +10,7 @@ import (
 )
 
 func dataSourceNetboxVlan() *schema.Resource {
+	customFieldsFilterSchema := *customFieldsSchema
 	return &schema.Resource{
 		Read:        dataSourceNetboxVlanRead,
 		Description: `:meta:subcategory:IP Address Management (IPAM):`,
@@ -50,6 +51,7 @@ func dataSourceNetboxVlan() *schema.Resource {
 				Computed: true,
 				Optional: true,
 			},
+			customFieldsKey: &customFieldsFilterSchema,
 		},
 	}
 }
@@ -57,6 +59,7 @@ func dataSourceNetboxVlan() *schema.Resource {
 func dataSourceNetboxVlanRead(d *schema.ResourceData, m interface{}) error {
 	api := m.(*providerState)
 	params := ipam.NewIpamVlansListParams()
+	var opts []ipam.ClientOption
 
 	params.Limit = int64ToPtr(2)
 	if name, ok := d.Get("name").(string); ok && name != "" {
@@ -74,8 +77,11 @@ func dataSourceNetboxVlanRead(d *schema.ResourceData, m interface{}) error {
 	if tenantID, ok := d.Get("tenant").(int); ok && tenantID != 0 {
 		params.TenantID = strToPtr(strconv.Itoa(tenantID))
 	}
+	if cfm, ok := d.Get(customFieldsKey).(map[string]interface{}); ok {
+		opts = append(opts, WithCustomFieldParamsOption(cfm))
+	}
 
-	res, err := api.Ipam.IpamVlansList(params, nil)
+	res, err := api.Ipam.IpamVlansList(params, nil, opts...)
 	if err != nil {
 		return err
 	}
@@ -105,6 +111,10 @@ func dataSourceNetboxVlanRead(d *schema.ResourceData, m interface{}) error {
 	}
 	if vlan.Tenant != nil {
 		d.Set("tenant", vlan.Tenant.ID)
+	}
+	cf := getCustomFields(vlan.CustomFields)
+	if cf != nil {
+		d.Set(customFieldsKey, cf)
 	}
 
 	return nil

--- a/netbox/data_source_netbox_vlan_test.go
+++ b/netbox/data_source_netbox_vlan_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -64,6 +65,61 @@ func TestAccNetboxVlanDataSource_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccNetboxVlanDataSource_customFields(t *testing.T) {
+	testName := testAccGetTestName("vlan_ds_custom_fields")
+	testField := fmt.Sprintf("vlan_ds_cf_%s", acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz"))
+	testVid := acctest.RandIntRange(1000, 4000)
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxVlanDataSourceWithCustomFields(testName, testField, testVid),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("data.netbox_vlan.by_vid", "id", "netbox_vlan.test_custom_fields", "id"),
+					resource.TestCheckResourceAttr("data.netbox_vlan.by_vid", fmt.Sprintf("custom_fields.%s", testField), "match"),
+					resource.TestCheckResourceAttrPair("data.netbox_vlan.by_custom_fields", "id", "netbox_vlan.test_custom_fields", "id"),
+					resource.TestCheckResourceAttr("data.netbox_vlan.by_custom_fields", fmt.Sprintf("custom_fields.%s", testField), "match"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetboxVlanDataSourceWithCustomFields(testName string, testField string, testVid int) string {
+	return fmt.Sprintf(`
+resource "netbox_custom_field" "test" {
+	name          = "%[2]s"
+	type          = "text"
+	content_types = ["ipam.vlan"]
+}
+
+resource "netbox_vlan" "test_custom_fields" {
+	name = "%[1]s"
+	vid  = %[3]d
+	tags = []
+
+	custom_fields = {
+		(netbox_custom_field.test.name) = "match"
+	}
+}
+
+data "netbox_vlan" "by_vid" {
+	depends_on = [netbox_vlan.test_custom_fields]
+	vid        = netbox_vlan.test_custom_fields.vid
+}
+
+data "netbox_vlan" "by_custom_fields" {
+	depends_on = [netbox_vlan.test_custom_fields]
+
+	custom_fields = {
+		(netbox_custom_field.test.name) = "match"
+	}
+}
+`, testName, testField, testVid)
 }
 
 func testAccNetboxVlanSetUp(testVid int, testName string) string {

--- a/netbox/data_source_netbox_vlans.go
+++ b/netbox/data_source_netbox_vlans.go
@@ -12,6 +12,7 @@ import (
 )
 
 func dataSourceNetboxVlans() *schema.Resource {
+	customFieldsFilterSchema := *customFieldsSchema
 	return &schema.Resource{
 		Read:        dataSourceNetboxVlansRead,
 		Description: `:meta:subcategory:IP Address Management (IPAM):`,
@@ -38,6 +39,7 @@ func dataSourceNetboxVlans() *schema.Resource {
 				ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
 				Default:          0,
 			},
+			customFieldsKey: &customFieldsFilterSchema,
 			"vlans": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -86,6 +88,13 @@ func dataSourceNetboxVlans() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						customFieldsKey: {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
 					},
 				},
 			},
@@ -97,6 +106,7 @@ func dataSourceNetboxVlansRead(d *schema.ResourceData, m interface{}) error {
 	api := m.(*providerState)
 
 	params := ipam.NewIpamVlansListParams()
+	var opts []ipam.ClientOption
 
 	// Get user limit
 	var userLimit int64 = 0
@@ -162,6 +172,9 @@ func dataSourceNetboxVlansRead(d *schema.ResourceData, m interface{}) error {
 			}
 		}
 	}
+	if cfm, ok := d.Get(customFieldsKey).(map[string]interface{}); ok {
+		opts = append(opts, WithCustomFieldParamsOption(cfm))
+	}
 
 	// Fetch all pages with pagination
 	paginationHelper := NewPaginationHelper(userLimit)
@@ -173,7 +186,7 @@ func dataSourceNetboxVlansRead(d *schema.ResourceData, m interface{}) error {
 		params.Limit = &pageSize
 		params.Offset = &currentOffset
 
-		res, err := api.Ipam.IpamVlansList(params, nil)
+		res, err := api.Ipam.IpamVlansList(params, nil, opts...)
 		if err != nil {
 			return fmt.Errorf("failed to fetch VLANs at offset %d: %w", currentOffset, err)
 		}
@@ -221,6 +234,10 @@ func dataSourceNetboxVlansRead(d *schema.ResourceData, m interface{}) error {
 		mapping["status"] = v.Status.Value
 		if v.Tenant != nil {
 			mapping["tenant"] = v.Tenant.ID
+		}
+		cf := flattenCustomFields(v.CustomFields)
+		if cf != nil {
+			mapping[customFieldsKey] = cf
 		}
 		if v.Tags != nil {
 			var tagIDs []int64

--- a/netbox/data_source_netbox_vlans_test.go
+++ b/netbox/data_source_netbox_vlans_test.go
@@ -1,8 +1,10 @@
 package netbox
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -103,4 +105,76 @@ func TestAccNetboxVlansDataSource_basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccNetboxVlansDataSource_customFields(t *testing.T) {
+	testName := testAccGetTestName("vlans_ds_custom_fields")
+	testField := fmt.Sprintf("vlans_ds_cf_%s", acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz"))
+	testVidMatch := acctest.RandIntRange(1000, 2000)
+	testVidSkip := acctest.RandIntRange(2001, 4000)
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxVlansWithCustomFields(testName, testField, testVidMatch, testVidSkip),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_vlans.by_vid", "vlans.#", "1"),
+					resource.TestCheckResourceAttrPair("data.netbox_vlans.by_vid", "vlans.0.id", "netbox_vlan.test_match", "id"),
+					resource.TestCheckResourceAttr("data.netbox_vlans.by_vid", fmt.Sprintf("vlans.0.custom_fields.%s", testField), "match"),
+					resource.TestCheckResourceAttr("data.netbox_vlans.by_custom_fields", "vlans.#", "1"),
+					resource.TestCheckResourceAttrPair("data.netbox_vlans.by_custom_fields", "vlans.0.id", "netbox_vlan.test_match", "id"),
+					resource.TestCheckResourceAttr("data.netbox_vlans.by_custom_fields", fmt.Sprintf("vlans.0.custom_fields.%s", testField), "match"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetboxVlansWithCustomFields(testName string, testField string, testVidMatch int, testVidSkip int) string {
+	return fmt.Sprintf(`
+resource "netbox_custom_field" "test" {
+	name          = "%[2]s"
+	type          = "text"
+	content_types = ["ipam.vlan"]
+}
+
+resource "netbox_vlan" "test_match" {
+	name = "%[1]s-match"
+	vid  = %[3]d
+	tags = []
+
+	custom_fields = {
+		(netbox_custom_field.test.name) = "match"
+	}
+}
+
+resource "netbox_vlan" "test_skip" {
+	name = "%[1]s-skip"
+	vid  = %[4]d
+	tags = []
+
+	custom_fields = {
+		(netbox_custom_field.test.name) = "skip"
+	}
+}
+
+data "netbox_vlans" "by_vid" {
+	depends_on = [netbox_vlan.test_match, netbox_vlan.test_skip]
+
+	filter {
+		name  = "vid"
+		value = netbox_vlan.test_match.vid
+	}
+}
+
+data "netbox_vlans" "by_custom_fields" {
+	depends_on = [netbox_vlan.test_match, netbox_vlan.test_skip]
+
+	custom_fields = {
+		(netbox_custom_field.test.name) = "match"
+	}
+}
+`, testName, testField, testVidMatch, testVidSkip)
 }

--- a/netbox/resource_netbox_vlan.go
+++ b/netbox/resource_netbox_vlan.go
@@ -61,7 +61,8 @@ func resourceNetboxVlan() *schema.Resource {
 				Optional: true,
 				Default:  "",
 			},
-			tagsKey: tagsSchema,
+			customFieldsKey: customFieldsSchema,
+			tagsKey:         tagsSchema,
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -97,6 +98,9 @@ func resourceNetboxVlanCreate(d *schema.ResourceData, m interface{}) error {
 
 	if roleID, ok := d.GetOk("role_id"); ok {
 		data.Role = int64ToPtr(int64(roleID.(int)))
+	}
+	if cf, ok := d.GetOk(customFieldsKey); ok {
+		data.CustomFields = getCustomFields(cf)
 	}
 
 	var err error
@@ -139,6 +143,10 @@ func resourceNetboxVlanRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("vid", vlan.Vid)
 	d.Set("description", vlan.Description)
 	api.readTags(d, vlan.Tags)
+	cf := getCustomFields(vlan.CustomFields)
+	if cf != nil {
+		d.Set(customFieldsKey, cf)
+	}
 
 	if vlan.Status != nil {
 		d.Set("status", vlan.Status.Value)
@@ -187,6 +195,9 @@ func resourceNetboxVlanUpdate(d *schema.ResourceData, m interface{}) error {
 
 	if roleID, ok := d.GetOk("role_id"); ok {
 		data.Role = int64ToPtr(int64(roleID.(int)))
+	}
+	if cf, ok := d.GetOk(customFieldsKey); ok {
+		data.CustomFields = getCustomFields(cf)
 	}
 
 	var err error

--- a/netbox/resource_netbox_vlan_test.go
+++ b/netbox/resource_netbox_vlan_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/fbreckle/go-netbox/netbox/client/ipam"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -106,6 +107,58 @@ resource "netbox_vlan" "test_with_dependencies" {
 			},
 		},
 	})
+}
+
+func TestAccNetboxVlan_customFields(t *testing.T) {
+	testName := testAccGetTestName("vlan_custom_fields")
+	testField := fmt.Sprintf("vlan_cf_%s", acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz"))
+	testVid := acctest.RandIntRange(1000, 4000)
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxVlanWithCustomFields(testName, testField, testVid, "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_vlan.test_custom_fields", "name", testName),
+					resource.TestCheckResourceAttr("netbox_vlan.test_custom_fields", "vid", fmt.Sprintf("%d", testVid)),
+					resource.TestCheckResourceAttr("netbox_vlan.test_custom_fields", fmt.Sprintf("custom_fields.%s", testField), "value1"),
+				),
+			},
+			{
+				Config: testAccNetboxVlanWithCustomFields(testName, testField, testVid, "value2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_vlan.test_custom_fields", fmt.Sprintf("custom_fields.%s", testField), "value2"),
+				),
+			},
+			{
+				ResourceName:      "netbox_vlan.test_custom_fields",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccNetboxVlanWithCustomFields(testName string, testField string, testVid int, testValue string) string {
+	return fmt.Sprintf(`
+resource "netbox_custom_field" "test" {
+	name          = "%[2]s"
+	type          = "text"
+	content_types = ["ipam.vlan"]
+}
+
+resource "netbox_vlan" "test_custom_fields" {
+	name = "%[1]s"
+	vid  = %[3]d
+	tags = []
+
+	custom_fields = {
+		(netbox_custom_field.test.name) = "%[4]s"
+	}
+}
+`, testName, testField, testVid, testValue)
 }
 
 func init() {


### PR DESCRIPTION
Adds `custom_fields` support for VLANs.

- Replaces #395.
- Changes inspired by the merged PR that added `custom_fields` support to another resource/data type: #679
