### PR TITLE
provider: surface a clear error when the Netbox version check gets a non-JSON response

### DIFF
--- a/netbox/provider.go
+++ b/netbox/provider.go
@@ -353,7 +353,20 @@ func providerConfigure(ctx context.Context, data *schema.ResourceData) (interfac
 		req := status.NewStatusListParams()
 		res, err := netboxClient.Status.StatusList(req, nil)
 		if err != nil {
-			return nil, diag.FromErr(err)
+			return nil, diag.Diagnostics{{
+				Severity: diag.Error,
+				Summary:  "Failed to determine Netbox version",
+				Detail: fmt.Sprintf(
+					"The provider could not get a valid JSON response from a GET request to `%s/api/status/`.\n\n"+
+						"This usually means one of the following:\n"+
+						"  - `server_url` is misconfigured (wrong scheme, host or port, or it already includes a path such as `/api`)\n"+
+						"  - Netbox (or a reverse proxy/ingress in front of it) returned a non-JSON response, such as an HTML error page, or a response missing a `Content-Type: application/json` header\n"+
+						"  - the Netbox API is temporarily unreachable or returned a server error\n\n"+
+						"You can set `skip_version_check = true` on the provider to bypass this check while troubleshooting.\n\n"+
+						"Original error: %s",
+					serverURL, err,
+				),
+			}}
 		}
 
 		netboxVersionStringFromAPI := res.GetPayload().(map[string]interface{})["netbox-version"].(string)

--- a/netbox/provider_test.go
+++ b/netbox/provider_test.go
@@ -3,6 +3,8 @@ package netbox
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"regexp"
 	"strings"
@@ -13,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/assert"
 )
 
 var testAccProviders map[string]*schema.Provider
@@ -102,6 +105,46 @@ func TestAccNetboxProviderConfigure_failure(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestProviderConfigure_nonJSONStatusResponse verifies that when the Netbox
+// version check (GET /api/status/) gets a non-JSON response - for example
+// from a misconfigured server_url or a proxy/ingress returning an HTML error
+// page - providerConfigure returns a clear, actionable diagnostic instead of
+// the raw go-openapi "is not supported by the TextConsumer" error. See
+// https://github.com/e-breuninger/terraform-provider-netbox/issues/263,
+// https://github.com/e-breuninger/terraform-provider-netbox/issues/606, and
+// others reporting this same unhelpful error message.
+func TestProviderConfigure_nonJSONStatusResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html><body>not json</body></html>"))
+	}))
+	defer ts.Close()
+
+	raw := map[string]interface{}{
+		"server_url": ts.URL,
+		"api_token":  "0123456789abcdef0123456789abcdef01234567",
+	}
+	d := schema.TestResourceDataRaw(t, Provider().Schema, raw)
+
+	_, diags := providerConfigure(context.Background(), d)
+
+	if assert.True(t, diags.HasError(), "expected providerConfigure to return an error") {
+		found := false
+		for _, diagnostic := range diags {
+			if diagnostic.Severity != diag.Error {
+				continue
+			}
+			found = true
+			assert.Equal(t, "Failed to determine Netbox version", diagnostic.Summary)
+			assert.Contains(t, diagnostic.Detail, "skip_version_check")
+			assert.Contains(t, diagnostic.Detail, ts.URL+"/api/status/")
+			assert.True(t, strings.Contains(diagnostic.Detail, "Original error:"),
+				"expected the original go-openapi error to still be included for debugging, prefixed by an explanation")
+		}
+		assert.True(t, found, "expected an error diagnostic")
+	}
 }
 
 func TestAccNetboxProviderDefaultTags(t *testing.T) {


### PR DESCRIPTION
## Summary

The provider's version check (`GET /api/status/`, run in `providerConfigure` unless `skip_version_check = true`) let the raw go-openapi error leak straight through whenever Netbox — or a proxy/ingress in front of it — returned a non-JSON response:

<img width="1083" height="216" alt="image" src="https://github.com/user-attachments/assets/f422a49a-39a1-4f4c-983f-aaf95fe36183" />

This has been a recurring source of confusion with no indication of what actually went wrong: #263, #606, #750, #834, #840 are all the same underlying issue (a non-JSON response from `/api/status/`, usually caused by a misconfigured `server_url`, a reverse proxy/ingress returning an HTML error page, or a `Content-Type` that isn't `application/json`).

This PR wraps that error in a clear `diag.Diagnostic` that names the endpoint being called, lists the likely causes, and points at `skip_version_check` as a workaround — while still preserving the original error at the end of the message for debugging. It doesn't change any behavior when the status check succeeds or returns a normal error (e.g. connection refused).

Issue came after we configured the terraform cloud workspace to use the provider but forgot to allow the terraform cloud IPs in the WAF, so it was getting a 403 error.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./netbox/...` (0 issues)
- [x] Added `TestProviderConfigure_nonJSONStatusResponse`, a fast unit test (no `TF_ACC`/Docker needed) using `httptest.Server` to return a non-JSON body from `/api/status/`, asserting `providerConfigure` now returns the new clear diagnostic instead of the raw `TextConsumer` error
- [x] Existing unit tests in `netbox/client_test.go` and `netbox/provider_test.go` still pass