### PR TITLE
feat: add custom_fields support to Tenant and TenantGroup

### DIFF
--- a/netbox/resource_netbox_tenant.go
+++ b/netbox/resource_netbox_tenant.go
@@ -33,7 +33,8 @@ func resourceNetboxTenant() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
-			tagsKey: tagsSchema,
+			tagsKey:         tagsSchema,
+			customFieldsKey: customFieldsSchema,
 			"group_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -78,6 +79,11 @@ func resourceNetboxTenantCreate(d *schema.ResourceData, m interface{}) error {
 		data.Group = &groupID
 	}
 
+	ct, ok := d.GetOk(customFieldsKey)
+	if ok {
+		data.CustomFields = ct
+	}
+
 	params := tenancy.NewTenancyTenantsCreateParams().WithData(data)
 
 	res, err := api.Tenancy.TenancyTenantsCreate(params, nil)
@@ -108,12 +114,18 @@ func resourceNetboxTenantRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.Set("name", res.GetPayload().Name)
-	d.Set("slug", res.GetPayload().Slug)
-	d.Set("description", res.GetPayload().Description)
-	if res.GetPayload().Group != nil {
-		d.Set("group_id", res.GetPayload().Group.ID)
+	tenant := res.GetPayload()
+	d.Set("name", tenant.Name)
+	d.Set("slug", tenant.Slug)
+	d.Set("description", tenant.Description)
+	if tenant.Group != nil {
+		d.Set("group_id", tenant.Group.ID)
 	}
+	cf := flattenCustomFields(tenant.CustomFields)
+	if cf != nil {
+		d.Set(customFieldsKey, cf)
+	}
+	api.readTags(d, tenant.Tags)
 
 	return nil
 }
@@ -144,6 +156,11 @@ func resourceNetboxTenantUpdate(d *schema.ResourceData, m interface{}) error {
 	data.Tags = tags
 	if groupID != 0 {
 		data.Group = &groupID
+	}
+
+	ct, ok := d.GetOk(customFieldsKey)
+	if ok {
+		data.CustomFields = ct
 	}
 
 	params := tenancy.NewTenancyTenantsPartialUpdateParams().WithID(id).WithData(&data)

--- a/netbox/resource_netbox_tenant_group.go
+++ b/netbox/resource_netbox_tenant_group.go
@@ -33,6 +33,7 @@ func resourceNetboxTenantGroup() *schema.Resource {
 				Computed:     true,
 				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
+			customFieldsKey: customFieldsSchema,
 			"parent_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -74,6 +75,11 @@ func resourceNetboxTenantGroupCreate(d *schema.ResourceData, m interface{}) erro
 		data.Parent = &parentID
 	}
 
+	ct, ok := d.GetOk(customFieldsKey)
+	if ok {
+		data.CustomFields = ct
+	}
+
 	params := tenancy.NewTenancyTenantGroupsCreateParams().WithData(data)
 
 	res, err := api.Tenancy.TenancyTenantGroupsCreate(params, nil)
@@ -105,12 +111,19 @@ func resourceNetboxTenantGroupRead(d *schema.ResourceData, m interface{}) error 
 		return err
 	}
 
-	d.Set("name", res.GetPayload().Name)
-	d.Set("slug", res.GetPayload().Slug)
-	d.Set("description", res.GetPayload().Description)
-	if res.GetPayload().Parent != nil {
-		d.Set("parent", res.GetPayload().Parent.ID)
+	group := res.GetPayload()
+	d.Set("name", group.Name)
+	d.Set("slug", group.Slug)
+	d.Set("description", group.Description)
+	if group.Parent != nil {
+		d.Set("parent_id", group.Parent.ID)
 	}
+
+	cf := flattenCustomFields(group.CustomFields)
+	if cf != nil {
+		d.Set(customFieldsKey, cf)
+	}
+
 	return nil
 }
 
@@ -141,6 +154,12 @@ func resourceNetboxTenantGroupUpdate(d *schema.ResourceData, m interface{}) erro
 	if parentID != 0 {
 		data.Parent = &parentID
 	}
+
+	ct, ok := d.GetOk(customFieldsKey)
+	if ok {
+		data.CustomFields = ct
+	}
+
 	params := tenancy.NewTenancyTenantGroupsPartialUpdateParams().WithID(id).WithData(&data)
 
 	_, err := api.Tenancy.TenancyTenantGroupsPartialUpdate(params, nil)

--- a/netbox/resource_netbox_tenant_group_test.go
+++ b/netbox/resource_netbox_tenant_group_test.go
@@ -59,6 +59,39 @@ resource "netbox_tenant_group" "test" {
 	})
 }
 
+func TestAccNetboxTenantGroup_customFields(t *testing.T) {
+	testSlug := "t_grp_cf"
+	testName := testAccGetTestName(testSlug)
+	testField := strings.ReplaceAll(testAccGetTestName(testSlug), "-", "_")
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_custom_field" "test" {
+  name          = "%[2]s"
+  type          = "text"
+  content_types = ["tenancy.tenantgroup"]
+}
+
+resource "netbox_tenant_group" "test" {
+  name          = "%[1]s"
+  custom_fields = {"${netbox_custom_field.test.name}" = "testvalue"}
+}`, testName, testField),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_tenant_group.test", "custom_fields."+testField, "testvalue"),
+				),
+			},
+			{
+				ResourceName:      "netbox_tenant_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func init() {
 	resource.AddTestSweepers("netbox_tenant_group", &resource.Sweeper{
 		Name:         "netbox_tenant_group",

--- a/netbox/resource_netbox_tenant_test.go
+++ b/netbox/resource_netbox_tenant_test.go
@@ -118,6 +118,39 @@ resource "netbox_tenant" "test_tags" {
 	})
 }
 
+func TestAccNetboxTenant_customFields(t *testing.T) {
+	testSlug := "tenant_cf"
+	testName := testAccGetTestName(testSlug)
+	testField := strings.ReplaceAll(testAccGetTestName(testSlug), "-", "_")
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_custom_field" "test" {
+  name          = "%[2]s"
+  type          = "text"
+  content_types = ["tenancy.tenant"]
+}
+
+resource "netbox_tenant" "test" {
+  name          = "%[1]s"
+  custom_fields = {"${netbox_custom_field.test.name}" = "testvalue"}
+}`, testName, testField),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_tenant.test", "custom_fields."+testField, "testvalue"),
+				),
+			},
+			{
+				ResourceName:      "netbox_tenant.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func init() {
 	resource.AddTestSweepers("netbox_tenant", &resource.Sweeper{
 		Name:         "netbox_tenant",


### PR DESCRIPTION
Add custom_fields support to Tenant and TenantGroup resources.
The NetBox API and the underlying models support it. 
This brings them in line with other resources such as netbox_device_type.

Also fixes:
- Tenant.Read not calling api.readTags, which caused tags to never be reflected back into state.
- TenantGroup.Read setting "parent" instead of "parent_id", which caused it to never be reflected back into state.