### PR TITLE
fix: read power outlets whose power port is cabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
-	github.com/fbreckle/go-netbox v0.0.0-20260615100513-e55bea5bec39
+	github.com/fbreckle/go-netbox v0.0.0-20260714120540-5bc14f351d09
 	github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3
 	github.com/go-openapi/runtime v0.32.4
 	github.com/go-openapi/strfmt v0.26.4

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
-github.com/fbreckle/go-netbox v0.0.0-20260615100513-e55bea5bec39 h1:9hATmWLiSu2ipyjr8Nk8MUZZAFSYMfer2vP5EyanKHo=
-github.com/fbreckle/go-netbox v0.0.0-20260615100513-e55bea5bec39/go.mod h1:3U3/m/hna9Ntd3sbHBYwZ1IqbP2+coRzoXw3mCfu3kM=
+github.com/fbreckle/go-netbox v0.0.0-20260714120540-5bc14f351d09 h1:BqxmoX9CUXvfUkQ1PsBZKYIjOqRoWKACHOua+EEXKq8=
+github.com/fbreckle/go-netbox v0.0.0-20260714120540-5bc14f351d09/go.mod h1:3U3/m/hna9Ntd3sbHBYwZ1IqbP2+coRzoXw3mCfu3kM=
 github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3 h1:DMSpM0btVedE2Tt1vfDHWQhf2obzjAe1F0/j8/CyfW4=
 github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3/go.mod h1:j3HmJySEjx6hOAOPDjGzmzpVNDQq9SNnnF+Vm22d2rs=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=

--- a/netbox/resource_netbox_device_power_outlet_test.go
+++ b/netbox/resource_netbox_device_power_outlet_test.go
@@ -140,6 +140,79 @@ resource "netbox_device_power_outlet" "test" {
 	})
 }
 
+// TestAccNetboxDevicePowerOutlet_cabledPowerPort is a regression test for the
+// NestedPowerPort.cable unmarshal bug: reading a power outlet whose parent
+// power port is cabled used to fail with
+//
+//	json: cannot unmarshal object into Go struct field
+//	NestedPowerPort.power_port.cable of type int64
+//
+// because NetBox 4.x returns the nested power_port's `cable` as an object. The
+// second step re-reads (refreshes) the outlet while the cable exists, which is
+// exactly the read path that previously errored.
+func TestAccNetboxDevicePowerOutlet_cabledPowerPort(t *testing.T) {
+	testSlug := "power_outlet_cabled_port"
+	testName := testAccGetTestName(testSlug)
+
+	cabledConfig := testAccNetboxDevicePowerOutletFullDependencies(testName) + fmt.Sprintf(`
+resource "netbox_power_panel" "test" {
+  name    = "%[1]s"
+  site_id = netbox_site.test.id
+}
+
+resource "netbox_power_feed" "test" {
+  power_panel_id          = netbox_power_panel.test.id
+  name                    = "%[1]s"
+  status                  = "active"
+  type                    = "primary"
+  supply                  = "ac"
+  phase                   = "single-phase"
+  voltage                 = 230
+  amperage                = 16
+  max_percent_utilization = 80
+}
+
+resource "netbox_device_power_outlet" "test" {
+  device_id     = netbox_device.test.id
+  name          = "%[1]s"
+  power_port_id = netbox_device_power_port.test.id
+}
+
+resource "netbox_cable" "test" {
+  a_termination {
+    object_type = "dcim.powerfeed"
+    object_id   = netbox_power_feed.test.id
+  }
+  b_termination {
+    object_type = "dcim.powerport"
+    object_id   = netbox_device_power_port.test.id
+  }
+  status = "connected"
+}`, testName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckDevicePowerOutletDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: cabledConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_power_outlet.test", "power_port_id", "netbox_device_power_port.test", "id"),
+				),
+			},
+			{
+				// Re-reading the outlet while its power port is cabled is what
+				// used to trip the unmarshal error.
+				Config: cabledConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_power_outlet.test", "power_port_id", "netbox_device_power_port.test", "id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDevicePowerOutletDestroy(s *terraform.State) error {
 	// retrieve the connection established in Provider configuration
 	conn := testAccProvider.Meta().(*providerState)


### PR DESCRIPTION
## Problem

Reading a `netbox_device_power_outlet` fails once its parent power port has a cable:

```
json: cannot unmarshal object into Go struct field NestedPowerPort.power_port.cable of type int64
```

NetBox 4.x returns the nested power port's `cable` as an object, but the generated `NestedPowerPort.cable` was typed as a bare integer. The failure is on **read**, so it breaks `terraform plan`/`apply` for every affected power outlet until the cable is removed.

## Fix

The root cause is in the swagger-generated client. The fix is **fbreckle/go-netbox#70** (retype `NestedPowerPort.cable` as `NestedCable`). No provider source change is required.

This PR:
- Points the module at the go-netbox fix via a temporary `replace` (fork commit) so CI proves the fix end to end.
- Adds a regression acceptance test, `TestAccNetboxDevicePowerOutlet_cabledPowerPort`, that creates a power outlet on a power port cabled to a power feed and re-reads it.

## Verification

Run locally against NetBox 4.4.10:
- **Without** the go-netbox fix: the new test fails with the `NestedPowerPort.power_port.cable` unmarshal error above.
- **With** the fix: it passes.

## Follow-up

`replace github.com/fbreckle/go-netbox => github.com/FlxPeters/go-netbox <fork-commit>` is temporary. Once fbreckle/go-netbox#70 is merged and released, this will be swapped for a normal version bump and the `replace` removed. Marking as draft until then.

Depends on: fbreckle/go-netbox#70