### PR TITLE
fix: stop vm_role drift on netbox_device_role (fixes #820)

### DIFF
--- a/docs/resources/device_role.md
+++ b/docs/resources/device_role.md
@@ -16,9 +16,19 @@ From the [official documentation](https://docs.netbox.dev/en/stable/features/dev
 ## Example Usage
 
 ```terraform
+# Device role for physical devices only
 resource "netbox_device_role" "core_sw" {
   color_hex = "ff00ff"
   name      = "core-sw"
+  vm_role   = false
+}
+
+# Device role that can be used for both devices and virtual machines
+resource "netbox_device_role" "web_server" {
+  color_hex   = "00ff00"
+  name        = "web-server"
+  description = "Web server role"
+  vm_role     = true
 }
 ```
 
@@ -35,7 +45,7 @@ resource "netbox_device_role" "core_sw" {
 - `description` (String)
 - `slug` (String)
 - `tags` (Set of String)
-- `vm_role` (Boolean) Defaults to `true`.
+- `vm_role` (Boolean) Virtual machines may be assigned to this role. Defaults to `false`.
 
 ### Read-Only
 

--- a/examples/resources/netbox_device_role/resource.tf
+++ b/examples/resources/netbox_device_role/resource.tf
@@ -1,4 +1,14 @@
+# Device role for physical devices only
 resource "netbox_device_role" "core_sw" {
   color_hex = "ff00ff"
   name      = "core-sw"
+  vm_role   = false
+}
+
+# Device role that can be used for both devices and virtual machines
+resource "netbox_device_role" "web_server" {
+  color_hex   = "00ff00"
+  name        = "web-server"
+  description = "Web server role"
+  vm_role     = true
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
-	github.com/fbreckle/go-netbox v0.0.0-20260714120540-5bc14f351d09
+	github.com/fbreckle/go-netbox v0.0.0-20260715070837-bf00e79b42dc
 	github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3
 	github.com/go-openapi/runtime v0.32.4
 	github.com/go-openapi/strfmt v0.26.4

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
-github.com/fbreckle/go-netbox v0.0.0-20260714120540-5bc14f351d09 h1:BqxmoX9CUXvfUkQ1PsBZKYIjOqRoWKACHOua+EEXKq8=
-github.com/fbreckle/go-netbox v0.0.0-20260714120540-5bc14f351d09/go.mod h1:3U3/m/hna9Ntd3sbHBYwZ1IqbP2+coRzoXw3mCfu3kM=
+github.com/fbreckle/go-netbox v0.0.0-20260715070837-bf00e79b42dc h1:MU3iECnreMsdpc2U172DhCH14UwXXmA+pytMf2xB9tk=
+github.com/fbreckle/go-netbox v0.0.0-20260715070837-bf00e79b42dc/go.mod h1:3U3/m/hna9Ntd3sbHBYwZ1IqbP2+coRzoXw3mCfu3kM=
 github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3 h1:DMSpM0btVedE2Tt1vfDHWQhf2obzjAe1F0/j8/CyfW4=
 github.com/fbreckle/terraform-plugin-docs v0.0.0-20220812121758-a828466500d3/go.mod h1:j3HmJySEjx6hOAOPDjGzmzpVNDQq9SNnnF+Vm22d2rs=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=

--- a/netbox/resource_netbox_device_role.go
+++ b/netbox/resource_netbox_device_role.go
@@ -32,9 +32,10 @@ func resourceNetboxDeviceRole() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
 			"vm_role": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Virtual machines may be assigned to this role.",
 			},
 			"color_hex": {
 				Type:     schema.TypeString,
@@ -78,7 +79,7 @@ func resourceNetboxDeviceRoleCreate(d *schema.ResourceData, m interface{}) error
 			Slug:        &slug,
 			Color:       color,
 			Description: description,
-			VMRole:      vmRole,
+			VMRole:      &vmRole,
 			Tags:        tags,
 		},
 	)
@@ -144,7 +145,7 @@ func resourceNetboxDeviceRoleUpdate(d *schema.ResourceData, m interface{}) error
 
 	data.Slug = &slug
 	data.Name = &name
-	data.VMRole = vmRole
+	data.VMRole = &vmRole
 	data.Color = color
 	data.Description = description
 

--- a/netbox/resource_netbox_device_role_test.go
+++ b/netbox/resource_netbox_device_role_test.go
@@ -31,12 +31,45 @@ resource "netbox_device_role" "test" {
 					resource.TestCheckResourceAttr("netbox_device_role.test", "slug", randomSlug),
 					resource.TestCheckResourceAttr("netbox_device_role.test", "color_hex", "111111"),
 					resource.TestCheckResourceAttr("netbox_device_role.test", "description", "Some fancy device role"),
+					// vm_role is not set, so it must settle at the default (false)
+					// without a perpetual diff back to Netbox's server default.
+					resource.TestCheckResourceAttr("netbox_device_role.test", "vm_role", "false"),
 				),
 			},
 			{
 				ResourceName:      "netbox_device_role.test",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccNetboxDeviceRole_vmRole is a regression test for the vm_role drift
+// (#820): an explicit vm_role must round-trip in both directions without a
+// perpetual plan. This only works when the client can send an explicit
+// `false` (VMRole *bool), not a bool dropped by omitempty.
+func TestAccNetboxDeviceRole_vmRole(t *testing.T) {
+	testName := testAccGetTestName("dvcrl_vmrole")
+	role := func(vmRole bool) string {
+		return fmt.Sprintf(`
+resource "netbox_device_role" "test" {
+  name      = "%s"
+  color_hex = "112233"
+  vm_role   = %t
+}`, testName, vmRole)
+	}
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: role(true),
+				Check:  resource.TestCheckResourceAttr("netbox_device_role.test", "vm_role", "true"),
+			},
+			{
+				Config: role(false),
+				Check:  resource.TestCheckResourceAttr("netbox_device_role.test", "vm_role", "false"),
 			},
 		},
 	})


### PR DESCRIPTION
## Problem

`netbox_device_role.vm_role` had `Default: true`. A role that is `vm_role = false` in NetBox shows a **perpetual plan** wanting to flip it back to `true` (#820, #342).

## Why just changing the default isn't enough

#824 changed the schema default `true → false`, but its acceptance tests fail with a **new** perpetual diff (`vm_role = true -> false`). Root cause: the go-netbox model typed the field as:

```go
VMRole bool `json:"vm_role,omitempty"`
```

`omitempty` **drops a `false`** from the request, so NetBox re-applies its own server-side default (`true`) — a `false` can never actually be stored.

## Fix (two parts)

1. **go-netbox** (fbreckle/go-netbox#75, merged): `vm_role` is now nullable → generates `VMRole *bool`, so an explicit `false` is sent.
2. **This PR**: bump go-netbox to the merged version, send `VMRole` as a pointer, default the attribute to `false`, add a `Description`, and regenerate the docs from an updated example.

## Tests

- Existing `TestAccNetboxDeviceRole_basic` now asserts `vm_role = false` with no drift.
- New `TestAccNetboxDeviceRole_vmRole` round-trips `vm_role` through `true` and `false`, asserting no perpetual plan in either direction.

Verified locally against NetBox 4.4.10 — all device-role tests pass (they fail without the go-netbox `*bool` change).

Fixes #820. Supersedes #824.