### PR TITLE
feat: add optional module_id to netbox_device_interface (fixes #922)

### DIFF
--- a/docs/resources/device_interface.md
+++ b/docs/resources/device_interface.md
@@ -41,6 +41,7 @@ resource "netbox_device_interface" "test" {
 - `lag_device_interface_id` (Number) If this device is a member of a LAG group, you can reference the LAG interface here.
 - `mgmtonly` (Boolean)
 - `mode` (String) Valid values are `access`, `tagged`, `tagged-all` and `q-in-q`.
+- `module_id` (Number)
 - `mtu` (Number)
 - `parent_device_interface_id` (Number) The netbox_device_interface id of the parent interface. Useful if this interface is a logical interface.
 - `speed` (Number)

--- a/netbox/resource_netbox_device_interface.go
+++ b/netbox/resource_netbox_device_interface.go
@@ -32,6 +32,10 @@ func resourceNetboxDeviceInterface() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: true,
 			},
+			"module_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -180,6 +184,7 @@ func resourceNetboxDeviceInterfaceCreate(ctx context.Context, d *schema.Resource
 		data.UntaggedVlan = int64ToPtr(int64(untaggedVlan))
 	}
 	data.Vrf = getOptionalInt(d, "vrf_id")
+	data.Module = getOptionalInt(d, "module_id")
 
 	params := dcim.NewDcimInterfacesCreateParams().WithData(&data)
 
@@ -227,6 +232,12 @@ func resourceNetboxDeviceInterfaceRead(ctx context.Context, d *schema.ResourceDa
 	api.readTags(d, iface.Tags)
 	d.Set("tagged_vlans", getIDsFromNestedVLANDevice(iface.TaggedVlans))
 	d.Set("device_id", iface.Device.ID)
+
+	if iface.Module != nil {
+		d.Set("module_id", iface.Module.ID)
+	} else {
+		d.Set("module_id", nil)
+	}
 
 	if iface.Lag != nil {
 		d.Set("lag_device_interface_id", iface.Lag.ID)
@@ -302,6 +313,7 @@ func resourceNetboxDeviceInterfaceUpdate(ctx context.Context, d *schema.Resource
 		WirelessLans: []int64{},
 		Vdcs:         []int64{},
 	}
+	data.Module = getOptionalInt(d, "module_id")
 
 	if d.HasChange("lag_device_interface_id") {
 		lag := int64(d.Get("lag_device_interface_id").(int))

--- a/netbox/resource_netbox_device_interface_test.go
+++ b/netbox/resource_netbox_device_interface_test.go
@@ -60,11 +60,29 @@ resource "netbox_vlan" "test2" {
 
 func testAccNetboxDeviceInterfaceBasic(testName string) string {
 	return fmt.Sprintf(`
-resource "netbox_device_interface" "test" {
-  name = "%s"
+resource "netbox_device_module_bay" "test" {
   device_id = netbox_device.test.id
-  tags = [netbox_tag.test.name]
-  type = "1000base-t"
+  name      = "%[1]s"
+}
+
+resource "netbox_module_type" "test" {
+  manufacturer_id = netbox_manufacturer.test.id
+  model           = "%[1]s"
+}
+
+resource "netbox_module" "test" {
+  device_id      = netbox_device.test.id
+  module_bay_id  = netbox_device_module_bay.test.id
+  module_type_id = netbox_module_type.test.id
+  status         = "active"
+}
+
+resource "netbox_device_interface" "test" {
+  name      = "%[1]s"
+  device_id = netbox_device.test.id
+  module_id = netbox_module.test.id
+  tags      = [netbox_tag.test.name]
+  type      = "1000base-t"
 }`, testName)
 }
 
@@ -157,6 +175,7 @@ func TestAccNetboxDeviceInterface_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("netbox_device_interface.test", "name", testName),
 					resource.TestCheckResourceAttr("netbox_device_interface.test", "type", "1000base-t"),
 					resource.TestCheckResourceAttrPair("netbox_device_interface.test", "device_id", "netbox_device.test", "id"),
+					resource.TestCheckResourceAttrPair("netbox_device_interface.test", "module_id", "netbox_module.test", "id"),
 					resource.TestCheckResourceAttr("netbox_device_interface.test", "tags.#", "1"),
 					resource.TestCheckResourceAttr("netbox_device_interface.test", "tags.0", testName),
 				),
@@ -322,7 +341,6 @@ resource "netbox_device_interface" "test" {
   vrf_id    = netbox_vrf.test2.id
 }`, testName)
 }
-
 
 func TestAccNetboxDeviceInterface_vrf(t *testing.T) {
 	testSlug := "iface_vrf"


### PR DESCRIPTION
## Description

Adds an optional `module_id` to `netbox_device_interface`, so an interface can be assigned to a module of its device (NetBox's `interface.module`). Resolves #922.

```hcl
resource "netbox_device_interface" "eth0" {
  name      = "eth0"
  device_id = netbox_device.pdu.id
  module_id = netbox_module.linecard.id
  type      = "1000base-t"
}
```

## Implementation

- No go-netbox change needed — `WritableInterface.Module` (`*int64`) already exists.
- Wired through create/read/update exactly like `module_id` on `netbox_device_power_outlet` (`getOptionalInt` on write, nil-guarded `d.Set` on read).
- Docs regenerated.

## Tests

Per the maintainer note on the issue, `module_id` is covered in `TestAccNetboxDeviceInterface_basic`: it creates a module (module bay + module type + module) and asserts the interface's `module_id` round-trips. Passes locally against NetBox 4.4.10, including import verify.