### PR TITLE
feat: add role_id and region_id filters to netbox_prefixes data source

### DIFF
--- a/docs/data-sources/prefixes.md
+++ b/docs/data-sources/prefixes.md
@@ -30,7 +30,7 @@ description: |-
 
 Required:
 
-- `name` (String) The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `tenant_id`, `site_id`, `description` & `tag`.
+- `name` (String) The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `tenant_id`, `site_id`, `role_id`, `region_id`, `description` & `tag`.
 - `value` (String) The value to pass to the specified filter.
 
 
@@ -45,6 +45,7 @@ Read-Only:
 - `location_id` (Number)
 - `prefix` (String)
 - `region_id` (Number)
+- `role_id` (Number)
 - `site_group_id` (Number)
 - `site_id` (Number)
 - `status` (String)

--- a/netbox/data_source_netbox_prefixes.go
+++ b/netbox/data_source_netbox_prefixes.go
@@ -25,7 +25,7 @@ func dataSourceNetboxPrefixes() *schema.Resource {
 						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `tenant_id`, `site_id`, `description` & `tag`.",
+							Description: "The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `tenant_id`, `site_id`, `role_id`, `region_id`, `description` & `tag`.",
 						},
 						"value": {
 							Type:        schema.TypeString,
@@ -76,6 +76,10 @@ func dataSourceNetboxPrefixes() *schema.Resource {
 							Computed: true,
 						},
 						"region_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"role_id": {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
@@ -148,6 +152,10 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 				params.TenantID = &vString
 			case "site_id":
 				params.SiteID = &vString
+			case "role_id":
+				params.RoleID = &vString
+			case "region_id":
+				params.RegionID = &vString
 			case "description":
 				params.Description = &vString
 			case "tag":
@@ -207,6 +215,9 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 		}
 		if v.Tenant != nil {
 			mapping["tenant_id"] = v.Tenant.ID
+		}
+		if v.Role != nil {
+			mapping["role_id"] = v.Role.ID
 		}
 		if v.ScopeType != nil && v.ScopeID != nil {
 			scopeID := v.ScopeID

--- a/netbox/data_source_netbox_prefixes_test.go
+++ b/netbox/data_source_netbox_prefixes_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccNetboxPrefixesDataSource_basic(t *testing.T) {
-	testPrefixes := []string{"10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24", "10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24"}
+	testPrefixes := []string{"10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24", "10.0.7.0/24", "10.0.8.0/24", "10.0.9.0/24", "10.0.10.0/24", "10.0.11.0/24"}
 	testSlug := "prefixes_ds_basic"
 	testVlanVids := []int{4093, 4094}
 	testName := testAccGetTestName(testSlug)
@@ -68,6 +68,26 @@ resource "netbox_prefix" "with_container" {
   prefix  = "%[9]s"
   status  = "container"
   site_id    = netbox_site.test2.id
+}
+
+resource "netbox_ipam_role" "test" {
+  name = "%[1]s_role"
+}
+
+resource "netbox_prefix" "with_role_id" {
+  prefix  = "%[10]s"
+  status  = "container"
+  role_id = netbox_ipam_role.test.id
+}
+
+resource "netbox_region" "test" {
+  name = "%[1]s_region"
+}
+
+resource "netbox_prefix" "with_region_id" {
+  prefix    = "%[11]s"
+  status    = "container"
+  region_id = netbox_region.test.id
 }
 
 resource "netbox_vrf" "test_vrf" {
@@ -160,6 +180,22 @@ data "netbox_prefixes" "find_prefix_with_site_id" {
   }
 }
 
+data "netbox_prefixes" "find_prefix_with_role_id" {
+  depends_on = [netbox_prefix.with_role_id]
+  filter {
+    name  = "role_id"
+    value = netbox_ipam_role.test.id
+  }
+}
+
+data "netbox_prefixes" "find_prefix_with_region_id" {
+  depends_on = [netbox_prefix.with_region_id]
+  filter {
+    name  = "region_id"
+    value = netbox_region.test.id
+  }
+}
+
 data "netbox_prefixes" "find_prefix_with_contains" {
   depends_on = [netbox_prefix.with_container]
   filter {
@@ -177,7 +213,7 @@ data "netbox_prefixes" "find_prefix_with_description" {
 }
 
 
-`, testName, testPrefixes[0], testPrefixes[1], testPrefixes[2], testPrefixes[3], testPrefixes[4], testVlanVids[0], testVlanVids[1], testPrefixes[5]),
+`, testName, testPrefixes[0], testPrefixes[1], testPrefixes[2], testPrefixes[3], testPrefixes[4], testVlanVids[0], testVlanVids[1], testPrefixes[5], testPrefixes[6], testPrefixes[7]),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_prefixes.by_vrf", "prefixes.#", "2"),
 					resource.TestCheckResourceAttrPair("data.netbox_prefixes.by_vrf", "prefixes.1.vlan_vid", "netbox_vlan.test_vlan2", "vid"),
@@ -195,6 +231,12 @@ data "netbox_prefixes" "find_prefix_with_description" {
 					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_contains", "prefixes.0.prefix", "10.0.9.0/24"),
 					resource.TestCheckResourceAttrSet("data.netbox_prefixes.find_prefix_with_contains", "prefixes.0.site_id"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_description", "prefixes.0.description", "my-description"),
+					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_role_id", "prefixes.#", "1"),
+					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_role_id", "prefixes.0.prefix", "10.0.10.0/24"),
+					resource.TestCheckResourceAttrPair("data.netbox_prefixes.find_prefix_with_role_id", "prefixes.0.role_id", "netbox_ipam_role.test", "id"),
+					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_region_id", "prefixes.#", "1"),
+					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_region_id", "prefixes.0.prefix", "10.0.11.0/24"),
+					resource.TestCheckResourceAttrPair("data.netbox_prefixes.find_prefix_with_region_id", "prefixes.0.region_id", "netbox_region.test", "id"),
 				),
 			},
 		},


### PR DESCRIPTION
Need

The `netbox_prefixes` data source already supported filtering by `vrf_id`, `tenant_id`, `site_id`, etc., but had no way to filter by a prefix's IPAM role or its region scope. Consumers needing to look up prefixes for a specific role (e.g. "Voice", "Data") or region had to fetch all prefixes and filter client-side in Terraform, which doesn't scale well and defeats the purpose of server-side filtering. Additionally, while `region_id` was already exposed as a computed output attribute on each returned prefix, `role_id` was missing entirely from the output, so even after filtering by role there was no way to confirm which role a returned prefix belonged to.

**Resolution**

- Added `role_id` and `region_id` as supported values for the `filter.name` field, mapping them to the existing `RoleID`/`RegionID` params on the underlying` IpamPrefixesListParams` API call — following the same pattern already used for `vrf_id`, `tenant_id`, and `site_id`.
- Added `role_id` as a new computed attribute on each entry in prefixes, populated from the prefix's `Role` field, for parity with the existing `region_id` computed attribute.
- Updated the data source's `filter.name `schema description and `docs/data-sources/prefixes.md`to document both new filters and the new `role_id` output attribute.
- Extended `TestAccNetboxPrefixesDataSource_basic` with a `netbox_ipam_role` and `netbox_region` resource, prefixes assigned to each, and two new data source blocks (`find_prefix_with_role_id`, `find_prefix_with_region_id`) asserting both the filter and the corresponding output attribute.

**How it solves the problem**

Users can now query `netbox_prefixes` directly by role or region:

```
data "netbox_prefixes" "by_role_and_region" {
  filter {
    name  = "role_id"
    value = netbox_ipam_role.example.id
  }
  filter {
    name  = "region_id"
    value = netbox_region.example.id
  }
}
```

This pushes the filtering to the NetBox API (consistent with all other supported filters) instead of requiring post-processing in Terraform, and the new `role_id` output lets callers verify/consume the role of each returned prefix.