### PR TITLE
fix: don't destroy an imported netbox_available_ip_address

### DIFF
--- a/netbox/resource_netbox_available_ip_address.go
+++ b/netbox/resource_netbox_available_ip_address.go
@@ -1,6 +1,7 @@
 package netbox
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -11,12 +12,39 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+// forceNewOnAllocationSourceMove replaces the address only when its allocation
+// source really moves from one prefix or range to another.
+//
+// prefix_id / ip_range_id are write-only: Netbox does not report which prefix or
+// range an address came from, so Read cannot populate them and an imported
+// address keeps 0. An old value of 0 therefore means "source unknown", not
+// "moved" - as does a new value that is not known until apply, such as a prefix
+// id from a data source whose read is deferred. Replacing on either destroys a
+// live address, and Netbox hands out a different one on the re-allocation.
+//
+// customdiff.ForceNewIfChange cannot express this: its predicate only receives
+// the values, and GetChange reports an unknown as 0.
+func forceNewOnAllocationSourceMove(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	for _, key := range []string{"prefix_id", "ip_range_id"} {
+		oldValue, newValue := d.GetChange(key)
+		if !d.NewValueKnown(key) || oldValue.(int) == 0 || oldValue.(int) == newValue.(int) {
+			continue
+		}
+		if err := d.ForceNew(key); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func resourceNetboxAvailableIPAddress() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceNetboxAvailableIPAddressCreate,
 		Read:   resourceNetboxAvailableIPAddressRead,
 		Update: resourceNetboxAvailableIPAddressUpdate,
 		Delete: resourceNetboxAvailableIPAddressDelete,
+
+		CustomizeDiff: forceNewOnAllocationSourceMove,
 
 		Description: `:meta:subcategory:IP Address Management (IPAM):Per [the docs](https://netbox.readthedocs.io/en/stable/models/ipam/ipaddress/):
 
@@ -33,16 +61,15 @@ func resourceNetboxAvailableIPAddress() *schema.Resource {
 This resource will retrieve the next available IP address from a given prefix or IP range (specified by ID)`,
 
 		Schema: map[string]*schema.Schema{
+			// Not ForceNew: see forceNewOnAllocationSourceMove.
 			"prefix_id": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ForceNew:     true,
 				ExactlyOneOf: []string{"prefix_id", "ip_range_id"},
 			},
 			"ip_range_id": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				ForceNew:     true,
 				ExactlyOneOf: []string{"prefix_id", "ip_range_id"},
 			},
 			"ip_address": {

--- a/netbox/resource_netbox_available_ip_address_diff_test.go
+++ b/netbox/resource_netbox_available_ip_address_diff_test.go
@@ -1,0 +1,55 @@
+package netbox
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// unknownConfigValue mirrors hcl2shim.UnknownVariableValue, which lives in an
+// internal package: the placeholder for a config value that is not known until
+// apply.
+const unknownConfigValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
+
+func TestAvailableIPAddressAllocationSourceForceNew(t *testing.T) {
+	tests := []struct {
+		name           string
+		statePrefixID  string
+		configPrefixID interface{}
+		wantForceNew   bool
+	}{
+		{"moved to another prefix", "3758", 3146, true},
+		{"unchanged", "3758", 3758, false},
+		{"imported, source unknown to state", "0", 3758, false},
+		// A prefix id read from a data source whose read defers to apply.
+		// Replacing on it would re-allocate the address on every plan.
+		{"config value unknown at plan", "3758", unknownConfigValue, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &terraform.InstanceState{
+				ID: "23",
+				Attributes: map[string]string{
+					"id":         "23",
+					"prefix_id":  tt.statePrefixID,
+					"ip_address": "10.0.0.1/24",
+				},
+			}
+			config := terraform.NewResourceConfigRaw(map[string]interface{}{
+				"prefix_id": tt.configPrefixID,
+			})
+
+			diff, err := resourceNetboxAvailableIPAddress().Diff(context.Background(), state, config, nil)
+			if err != nil {
+				t.Fatalf("Diff: %s", err)
+			}
+
+			forceNew := diff != nil && diff.RequiresNew()
+			if forceNew != tt.wantForceNew {
+				t.Errorf("RequiresNew() = %t, want %t", forceNew, tt.wantForceNew)
+			}
+		})
+	}
+}

--- a/netbox/resource_netbox_available_ip_address_test.go
+++ b/netbox/resource_netbox_available_ip_address_test.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/fbreckle/go-netbox/netbox/client/ipam"
 	"github.com/fbreckle/go-netbox/netbox/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccNetboxAvailableIPAddress_basic(t *testing.T) {
@@ -329,6 +331,274 @@ resource "netbox_available_ip_address" "test" {
 			},
 		},
 	})
+}
+
+// TestAccNetboxAvailableIPAddress_adoptExistingIP imports an address allocated
+// out of band - the only way to manage one - and asserts it survives: same
+// NetBox record, prefix recorded in state, empty plan afterwards. Moving it to
+// another prefix from there must still re-allocate.
+func TestAccNetboxAvailableIPAddress_adoptExistingIP(t *testing.T) {
+	prefixes := `
+resource "netbox_prefix" "test" {
+  prefix  = "1.1.9.0/24"
+  status  = "active"
+  is_pool = false
+}
+
+resource "netbox_prefix" "other" {
+  prefix  = "1.1.13.0/24"
+  status  = "active"
+  is_pool = false
+}`
+
+	withAdoptedIP := prefixes + `
+resource "netbox_available_ip_address" "test" {
+  prefix_id = netbox_prefix.test.id
+}`
+
+	movedToOtherPrefix := prefixes + `
+resource "netbox_available_ip_address" "test" {
+  prefix_id = netbox_prefix.other.id
+}`
+
+	var prefixID, adoptedIPID int64
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Prefixes only; remember the id to allocate from.
+			{
+				Config: prefixes,
+				Check: func(s *terraform.State) (err error) {
+					prefixID, err = testAccStateID(s, "netbox_prefix.test")
+					return err
+				},
+			},
+			// Allocate behind Terraform's back, the same way the resource
+			// does, then adopt it.
+			{
+				PreConfig: func() {
+					api := testAccProvider.Meta().(*providerState)
+					params := ipam.NewIpamPrefixesAvailableIpsCreateParams().WithID(prefixID).
+						WithData([]*models.AvailableIP{{}})
+					res, err := api.Ipam.IpamPrefixesAvailableIpsCreate(params, nil)
+					if err != nil {
+						t.Fatalf("allocating an out-of-band IP in prefix %d: %s", prefixID, err)
+					}
+					if len(res.Payload) == 0 {
+						t.Fatalf("no available IP addresses in prefix %d", prefixID)
+					}
+					adoptedIPID = res.Payload[0].ID
+				},
+				Config:             withAdoptedIP,
+				ResourceName:       "netbox_available_ip_address.test",
+				ImportState:        true,
+				ImportStatePersist: true,
+				ImportStateIdFunc: func(*terraform.State) (string, error) {
+					return strconv.FormatInt(adoptedIPID, 10), nil
+				},
+				ImportStateCheck: testAccCheckImportedAllocationSourceUnset("prefix_id"),
+			},
+			// Records the prefix in state, keeps the address. Unfixed, this
+			// destroys the imported address and allocates another.
+			{
+				Config: withAdoptedIP,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_available_ip_address.test", "prefix_id", "netbox_prefix.test", "id"),
+					func(s *terraform.State) error {
+						id, err := testAccStateID(s, "netbox_available_ip_address.test")
+						if err != nil {
+							return err
+						}
+						if id != adoptedIPID {
+							return fmt.Errorf("expected the adopted address (NetBox id %d) to be kept, got id %d", adoptedIPID, id)
+						}
+						return nil
+					},
+				),
+			},
+			// Converged.
+			{
+				Config:   withAdoptedIP,
+				PlanOnly: true,
+			},
+			// Source known now, so a change re-allocates as usual.
+			{
+				Config: movedToOtherPrefix,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_available_ip_address.test", "ip_address", "1.1.13.1/24"),
+					func(s *terraform.State) error {
+						id, err := testAccStateID(s, "netbox_available_ip_address.test")
+						if err != nil {
+							return err
+						}
+						if id == adoptedIPID {
+							return fmt.Errorf("expected the address to be replaced, but it is still NetBox id %d", adoptedIPID)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// TestAccNetboxAvailableIPAddress_adoptExistingIPFromRange is the ip_range_id
+// twin of TestAccNetboxAvailableIPAddress_adoptExistingIP.
+func TestAccNetboxAvailableIPAddress_adoptExistingIPFromRange(t *testing.T) {
+	rangeOnly := `
+resource "netbox_ip_range" "test" {
+  start_address = "1.1.12.1/24"
+  end_address   = "1.1.12.50/24"
+}`
+
+	withAdoptedIP := rangeOnly + `
+resource "netbox_available_ip_address" "test" {
+  ip_range_id = netbox_ip_range.test.id
+}`
+
+	var rangeID, adoptedIPID int64
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: rangeOnly,
+				Check: func(s *terraform.State) (err error) {
+					rangeID, err = testAccStateID(s, "netbox_ip_range.test")
+					return err
+				},
+			},
+			{
+				PreConfig: func() {
+					api := testAccProvider.Meta().(*providerState)
+					params := ipam.NewIpamIPRangesAvailableIpsCreateParams().WithID(rangeID).
+						WithData([]*models.AvailableIP{{}})
+					res, err := api.Ipam.IpamIPRangesAvailableIpsCreate(params, nil)
+					if err != nil {
+						t.Fatalf("allocating an out-of-band IP in range %d: %s", rangeID, err)
+					}
+					if len(res.Payload) == 0 {
+						t.Fatalf("no available IP addresses in range %d", rangeID)
+					}
+					adoptedIPID = res.Payload[0].ID
+				},
+				Config:             withAdoptedIP,
+				ResourceName:       "netbox_available_ip_address.test",
+				ImportState:        true,
+				ImportStatePersist: true,
+				ImportStateIdFunc: func(*terraform.State) (string, error) {
+					return strconv.FormatInt(adoptedIPID, 10), nil
+				},
+				ImportStateCheck: testAccCheckImportedAllocationSourceUnset("ip_range_id"),
+			},
+			{
+				Config: withAdoptedIP,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_available_ip_address.test", "ip_range_id", "netbox_ip_range.test", "id"),
+					func(s *terraform.State) error {
+						id, err := testAccStateID(s, "netbox_available_ip_address.test")
+						if err != nil {
+							return err
+						}
+						if id != adoptedIPID {
+							return fmt.Errorf("expected the adopted address (NetBox id %d) to be kept, got id %d", adoptedIPID, id)
+						}
+						return nil
+					},
+				),
+			},
+			{
+				Config:   withAdoptedIP,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccNetboxAvailableIPAddress_allocationSourceChangeReallocates guards the
+// other side: a real prefix change on a provider-created address re-allocates.
+func TestAccNetboxAvailableIPAddress_allocationSourceChangeReallocates(t *testing.T) {
+	prefixes := `
+resource "netbox_prefix" "first" {
+  prefix  = "1.1.10.0/24"
+  status  = "active"
+  is_pool = false
+}
+
+resource "netbox_prefix" "second" {
+  prefix  = "1.1.11.0/24"
+  status  = "active"
+  is_pool = false
+}`
+
+	fromFirst := prefixes + `
+resource "netbox_available_ip_address" "test" {
+  prefix_id = netbox_prefix.first.id
+}`
+
+	fromSecond := prefixes + `
+resource "netbox_available_ip_address" "test" {
+  prefix_id = netbox_prefix.second.id
+}`
+
+	var firstIPID int64
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fromFirst,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_available_ip_address.test", "ip_address", "1.1.10.1/24"),
+					func(s *terraform.State) (err error) {
+						firstIPID, err = testAccStateID(s, "netbox_available_ip_address.test")
+						return err
+					},
+				),
+			},
+			{
+				Config: fromSecond,
+				Check: resource.ComposeTestCheckFunc(
+					// New address and new record; an in-place update would
+					// have kept both.
+					resource.TestCheckResourceAttr("netbox_available_ip_address.test", "ip_address", "1.1.11.1/24"),
+					func(s *terraform.State) error {
+						secondIPID, err := testAccStateID(s, "netbox_available_ip_address.test")
+						if err != nil {
+							return err
+						}
+						if secondIPID == firstIPID {
+							return fmt.Errorf("expected the IP address to be replaced, but it is still NetBox id %d", firstIPID)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+// testAccCheckImportedAllocationSourceUnset asserts an import could not
+// populate the given allocation source, which is the root of the problem.
+func testAccCheckImportedAllocationSourceUnset(attribute string) resource.ImportStateCheckFunc {
+	return func(states []*terraform.InstanceState) error {
+		for _, is := range states {
+			if got := is.Attributes[attribute]; got != "" && got != "0" {
+				return fmt.Errorf("expected imported %s to be unset, got %q", attribute, got)
+			}
+		}
+		return nil
+	}
+}
+
+// testAccStateID returns a resource's NetBox id from state.
+func testAccStateID(s *terraform.State, address string) (int64, error) {
+	rs, ok := s.RootModule().Resources[address]
+	if !ok {
+		return 0, fmt.Errorf("%s not found in state", address)
+	}
+	return strconv.ParseInt(rs.Primary.ID, 10, 64)
 }
 
 func init() {


### PR DESCRIPTION
## Problem

`prefix_id` / `ip_range_id` are write-only allocation instructions: Netbox does not report which prefix or range an address was allocated from, so `Read` cannot populate them and an imported address keeps `0` in state. Both being `ForceNew`, that `0 -> id` difference plans a destroy+create of an already-existing address on every plan, and the re-allocation hands out a *different* address — silently renumbering a possibly-live host. Importing is the only way to manage an address that was allocated out of band.

Plan on master, after importing an existing address:

```
  # netbox_available_ip_address.test must be replaced
-/+ resource "netbox_available_ip_address" "test" {
      ~ ip_address = "1.1.9.1/24" -> (known after apply)
      + prefix_id  = 1 # forces replacement
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

`TestAccNetboxAvailableIPAddress_cf` already works around the gap with `ImportStateVerifyIgnore: ["prefix_id"]`.

## Fix

Drop `ForceNew` and decide replacement in `CustomizeDiff`: only a move between two ids state actually knows means "allocate from somewhere else". An old value of `0` means "source unknown", which also covers create. A new value that is not known until apply is not a move either - a `prefix_id` read from a data source whose read is deferred would otherwise re-allocate the address on every plan. (`customdiff.ForceNewIfChange` cannot express that: its predicate only receives the values, and `GetChange` reports an unknown as `0`.)

`0 -> id` is deliberately left in the diff as an ordinary in-place update — `Update` touches neither field, so nothing is sent to Netbox for it — and the apply records the configured source in state. An adopted address is therefore only special until its first apply; changing its source afterwards replaces like on any other address. A `DiffSuppressFunc` would be shorter but strictly worse: a suppressed diff never reaches state, so the `0` would be permanent and re-allocating an adopted address would need `-replace` forever.

## Tests

- Adopt an address allocated behind Terraform's back, from a prefix and from an IP range (same `available-ips` calls the resource itself makes): import it, assert the allocation source comes back unset, then that the apply keeps the same Netbox record and converges to an empty plan.
- A unit test drives `Resource.Diff` directly over the four cases - moved, unchanged, imported, unknown at plan - with no Netbox needed.
- A real allocation-source change still re-allocates — asserted on both an adopted and a provider-created address, on the new address *and* the new Netbox id. These fail if the predicate is ever weakened.

Verified against Netbox v4.4.10: the adoption tests fail on master (`expected the adopted address (NetBox id 66) to be kept, got id 67`), pass with the fix, and the re-allocation tests fail again if `allocationSourceMoved` is stubbed to return `false`. Switching `prefix_id` <-> `ip_range_id` still replaces correctly — checked by hand, not committed as a test.
