### PR TITLE
fix: don't clobber interface fields a partial update does not manage

### DIFF
--- a/netbox/resource_netbox_device_interface.go
+++ b/netbox/resource_netbox_device_interface.go
@@ -300,18 +300,16 @@ func resourceNetboxDeviceInterfaceUpdate(ctx context.Context, d *schema.Resource
 	deviceID := int64(d.Get("device_id").(int))
 
 	data := models.WritableInterface{
-		Name:         &name,
-		Description:  description,
-		Label:        label,
-		Type:         &interfaceType,
-		Enabled:      enabled,
-		MgmtOnly:     mgmtonly,
-		Mode:         mode,
-		Tags:         tags,
-		TaggedVlans:  taggedVlans,
-		Device:       &deviceID,
-		WirelessLans: []int64{},
-		Vdcs:         []int64{},
+		Name:        &name,
+		Description: description,
+		Label:       label,
+		Type:        &interfaceType,
+		Enabled:     enabled,
+		MgmtOnly:    mgmtonly,
+		Mode:        mode,
+		Tags:        tags,
+		TaggedVlans: taggedVlans,
+		Device:      &deviceID,
 	}
 	data.Module = getOptionalInt(d, "module_id")
 
@@ -335,16 +333,15 @@ func resourceNetboxDeviceInterfaceUpdate(ctx context.Context, d *schema.Resource
 		untaggedvlan := int64(d.Get("untagged_vlan").(int))
 		data.UntaggedVlan = &untaggedvlan
 	}
-	if d.HasChange("primary_mac_address_id") {
-		primaryMac := int64(d.Get("primary_mac_address_id").(int))
-		data.PrimaryMacAddress = &primaryMac
-	}
 	if d.HasChange("vrf_id") {
 		data.Vrf = getOptionalInt(d, "vrf_id")
 	}
 
+	// primary_mac_address, vdcs and wireless_lans are not managed here, so they
+	// must not appear in the body at all, see hackOmitFields.
 	params := dcim.NewDcimInterfacesPartialUpdateParams().WithID(id).WithData(&data)
-	_, err = api.Dcim.DcimInterfacesPartialUpdate(params, nil)
+	_, err = api.Dcim.DcimInterfacesPartialUpdate(params, nil,
+		dcim.ClientOption(hackOmitFields("primary_mac_address", "vdcs", "wireless_lans")))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/netbox/resource_netbox_device_interface_primary_mac_address_test.go
+++ b/netbox/resource_netbox_device_interface_primary_mac_address_test.go
@@ -2,9 +2,12 @@ package netbox
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
+	"github.com/fbreckle/go-netbox/netbox/client/dcim"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func testAccNetboxDeviceInterfacePrimaryMACAddressFullDependencies(testName string) string {
@@ -80,6 +83,176 @@ resource "netbox_device_interface_primary_mac_address" "test" {
   mac_address_id      = netbox_mac_address.test.id
 }
 `, testName)
+}
+
+func testAccNetboxDeviceInterfacePrimaryMACAddressUpdatableInterface(testName, description string) string {
+	return fmt.Sprintf(`
+resource "netbox_site" "test" {
+  name   = "%[1]s"
+  status = "active"
+}
+
+resource "netbox_device_role" "test" {
+  name      = "%[1]s"
+  color_hex = "123456"
+}
+
+resource "netbox_manufacturer" "test" {
+  name = "%[1]s-manufacturer"
+}
+
+resource "netbox_device_type" "test" {
+  model           = "%[1]s-model"
+  manufacturer_id = netbox_manufacturer.test.id
+}
+
+resource "netbox_device" "test" {
+  name           = "%[1]s"
+  device_type_id = netbox_device_type.test.id
+  role_id        = netbox_device_role.test.id
+  site_id        = netbox_site.test.id
+}
+
+resource "netbox_device_interface" "test" {
+  name        = "%[1]s-if0"
+  device_id   = netbox_device.test.id
+  type        = "1000base-t"
+  description = "%[2]s"
+}
+
+resource "netbox_mac_address" "test" {
+  mac_address         = "00:1A:2B:3C:4D:5E"
+  device_interface_id = netbox_device_interface.test.id
+}
+
+resource "netbox_device_interface_primary_mac_address" "test" {
+  interface_id   = netbox_device_interface.test.id
+  mac_address_id = netbox_mac_address.test.id
+}
+`, testName, description)
+}
+
+// testAccCheckDeviceInterfacePrimaryMACAddressSet asserts NetBox itself still
+// reports the expected primary MAC on the interface. It deliberately does not
+// go through Terraform state: netbox_device_interface's Update does not re-read
+// after PATCHing, so a primary MAC cleared as a side effect of that PATCH stays
+// in state until the next refresh.
+func testAccCheckDeviceInterfacePrimaryMACAddressSet(interfaceResourceName, macResourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		api := testAccProvider.Meta().(*providerState)
+
+		interfaceState, ok := s.RootModule().Resources[interfaceResourceName]
+		if !ok {
+			return fmt.Errorf("%s not found in state", interfaceResourceName)
+		}
+		macState, ok := s.RootModule().Resources[macResourceName]
+		if !ok {
+			return fmt.Errorf("%s not found in state", macResourceName)
+		}
+
+		interfaceID, err := strconv.ParseInt(interfaceState.Primary.ID, 10, 64)
+		if err != nil {
+			return err
+		}
+
+		res, err := api.Dcim.DcimInterfacesRead(dcim.NewDcimInterfacesReadParams().WithID(interfaceID), nil)
+		if err != nil {
+			return err
+		}
+
+		primaryMAC := res.GetPayload().PrimaryMacAddress
+		if primaryMAC == nil {
+			return fmt.Errorf("interface %d has no primary MAC address in Netbox, expected MAC address %s", interfaceID, macState.Primary.ID)
+		}
+		if got, want := strconv.FormatInt(primaryMAC.ID, 10), macState.Primary.ID; got != want {
+			return fmt.Errorf("interface %d has primary MAC address %s in Netbox, expected %s", interfaceID, got, want)
+		}
+		return nil
+	}
+}
+
+// TestAccNetboxDeviceInterfacePrimaryMACAddress_survivesInterfaceUpdate covers
+// the primary MAC surviving an unrelated in-place update of the interface it is
+// attached to. WritableInterface.PrimaryMacAddress has no `omitempty`, so any
+// PATCH that leaves it nil sends `"primary_mac_address": null` and Netbox drops
+// the primary MAC as collateral damage.
+func TestAccNetboxDeviceInterfacePrimaryMACAddress_survivesInterfaceUpdate(t *testing.T) {
+	testSlug := "pr_device_mac_upd"
+	testName := testAccGetTestName(testSlug)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxDeviceInterfacePrimaryMACAddressUpdatableInterface(testName, "before update"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_device_interface_primary_mac_address.test", "mac_address_id", "netbox_mac_address.test", "id"),
+					testAccCheckDeviceInterfacePrimaryMACAddressSet("netbox_device_interface.test", "netbox_mac_address.test"),
+				),
+			},
+			{
+				// Only the interface's description changes; nothing about the
+				// primary MAC does. Besides the explicit check, the test
+				// framework's own post-apply plan must stay empty: once Netbox
+				// has dropped the primary MAC, the binding resource's Read
+				// clears its id and the next plan wants to re-create it.
+				Config: testAccNetboxDeviceInterfacePrimaryMACAddressUpdatableInterface(testName, "after update"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_device_interface.test", "description", "after update"),
+					testAccCheckDeviceInterfacePrimaryMACAddressSet("netbox_device_interface.test", "netbox_mac_address.test"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccNetboxDeviceInterfacePrimaryMACAddress_survivesDeletedMAC is the other
+// half of carrying the primary MAC through an update: the value comes from
+// state, so a MAC address deleted out of band must not be sent back. Netbox
+// rejects the dangling id with "Related object not found", which would fail the
+// update of an interface that has nothing to do with MAC addresses.
+func TestAccNetboxDeviceInterfacePrimaryMACAddress_survivesDeletedMAC(t *testing.T) {
+	testSlug := "pr_device_mac_gone"
+	testName := testAccGetTestName(testSlug)
+
+	var macID int64
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxDeviceInterfacePrimaryMACAddressUpdatableInterface(testName, "before update"),
+				Check: func(s *terraform.State) (err error) {
+					rs, ok := s.RootModule().Resources["netbox_mac_address.test"]
+					if !ok {
+						return fmt.Errorf("netbox_mac_address.test not found in state")
+					}
+					macID, err = strconv.ParseInt(rs.Primary.ID, 10, 64)
+					return err
+				},
+			},
+			{
+				// Delete the MAC address behind Terraform's back: its id stays in
+				// state, and the interface loses its primary MAC.
+				PreConfig: func() {
+					api := testAccProvider.Meta().(*providerState)
+					_, err := api.Dcim.DcimMacAddressesDelete(dcim.NewDcimMacAddressesDeleteParams().WithID(macID), nil)
+					if err != nil {
+						t.Fatalf("deleting MAC address %d: %s", macID, err)
+					}
+				},
+				// The description change forces an interface update in the same
+				// apply that re-creates the MAC and the binding.
+				Config: testAccNetboxDeviceInterfacePrimaryMACAddressUpdatableInterface(testName, "after update"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_device_interface.test", "description", "after update"),
+					testAccCheckDeviceInterfacePrimaryMACAddressSet("netbox_device_interface.test", "netbox_mac_address.test"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccNetboxDeviceInterfacePrimaryMACAddress_basic(t *testing.T) {

--- a/netbox/resource_netbox_device_interface_test.go
+++ b/netbox/resource_netbox_device_interface_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/fbreckle/go-netbox/netbox/client/dcim"
+	"github.com/fbreckle/go-netbox/netbox/models"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	log "github.com/sirupsen/logrus"
@@ -371,6 +372,109 @@ func TestAccNetboxDeviceInterface_vrf(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccNetboxDeviceInterfaceWirelessLans(testName, description string) string {
+	return fmt.Sprintf(`
+resource "netbox_wireless_lan" "test" {
+  ssid = "%[1]s"
+}
+
+resource "netbox_device_interface" "test" {
+  name        = "%[1]s"
+  device_id   = netbox_device.test.id
+  type        = "ieee802.11ac"
+  description = "%[2]s"
+}`, testName, description)
+}
+
+// TestAccNetboxDeviceInterface_preservesWirelessLans covers wireless LAN
+// assignments surviving an unrelated in-place update of the interface.
+//
+// Neither `wireless_lans` nor `vdcs` is modelled by this resource, so the only
+// way either can hold a value is out of band - another tool, the UI, or an
+// import. Netbox treats both as full-replacement lists and WritableInterface
+// declares them without `omitempty`, so sending an empty slice on every update
+// wipes them.
+func TestAccNetboxDeviceInterface_preservesWirelessLans(t *testing.T) {
+	testSlug := "iface_wlans"
+	testName := testAccGetTestName(testSlug)
+
+	var deviceID, interfaceID, wirelessLanID int64
+
+	resource.ParallelTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckDeviceInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxDeviceInterfaceFullDependencies(testName) + testAccNetboxDeviceInterfaceWirelessLans(testName, "before update"),
+				Check: func(s *terraform.State) (err error) {
+					if deviceID, err = testAccStateResourceID(s, "netbox_device.test"); err != nil {
+						return err
+					}
+					if interfaceID, err = testAccStateResourceID(s, "netbox_device_interface.test"); err != nil {
+						return err
+					}
+					wirelessLanID, err = testAccStateResourceID(s, "netbox_wireless_lan.test")
+					return err
+				},
+			},
+			{
+				PreConfig: func() {
+					api := testAccProvider.Meta().(*providerState)
+
+					// Assign the wireless LAN to the interface behind
+					// Terraform's back. The unrelated fields have to be filled
+					// in by hand because WritableInterface declares
+					// device/name/type/enabled without `omitempty` too, so
+					// leaving them nil would clear them.
+					interfaceName := testName
+					interfaceType := "ieee802.11ac"
+					_, err := api.Dcim.DcimInterfacesPartialUpdate(
+						dcim.NewDcimInterfacesPartialUpdateParams().WithID(interfaceID).WithData(&models.WritableInterface{
+							Device:       &deviceID,
+							Name:         &interfaceName,
+							Type:         &interfaceType,
+							Enabled:      true,
+							Tags:         []*models.NestedTag{},
+							TaggedVlans:  []int64{},
+							Vdcs:         []int64{},
+							WirelessLans: []int64{wirelessLanID},
+						}), nil)
+					if err != nil {
+						t.Fatalf("assigning interface %d to wireless LAN %d: %s", interfaceID, wirelessLanID, err)
+					}
+				},
+				// Only the interface's description changes.
+				Config: testAccNetboxDeviceInterfaceFullDependencies(testName) + testAccNetboxDeviceInterfaceWirelessLans(testName, "after update"),
+				Check: func(s *terraform.State) error {
+					api := testAccProvider.Meta().(*providerState)
+
+					res, err := api.Dcim.DcimInterfacesRead(dcim.NewDcimInterfacesReadParams().WithID(interfaceID), nil)
+					if err != nil {
+						return err
+					}
+
+					for _, wirelessLan := range res.GetPayload().WirelessLans {
+						if wirelessLan.ID == wirelessLanID {
+							return nil
+						}
+					}
+					return fmt.Errorf("interface %d is no longer assigned to wireless LAN %d after the update", interfaceID, wirelessLanID)
+				},
+			},
+		},
+	})
+}
+
+// testAccStateResourceID returns the Netbox numeric id of a resource in state.
+func testAccStateResourceID(s *terraform.State, address string) (int64, error) {
+	rs, ok := s.RootModule().Resources[address]
+	if !ok {
+		return 0, fmt.Errorf("%s not found in state", address)
+	}
+	return strconv.ParseInt(rs.Primary.ID, 10, 64)
 }
 
 func testAccCheckDeviceInterfaceDestroy(s *terraform.State) error {

--- a/netbox/resource_netbox_interface.go
+++ b/netbox/resource_netbox_interface.go
@@ -227,10 +227,9 @@ func resourceNetboxInterfaceUpdate(ctx context.Context, d *schema.ResourceData, 
 		untaggedvlan := int64(d.Get("untagged_vlan").(int))
 		data.UntaggedVlan = &untaggedvlan
 	}
-	if d.HasChange("primary_mac_address_id") {
-		primaryMac := int64(d.Get("primary_mac_address_id").(int))
-		data.PrimaryMacAddress = &primaryMac
-	}
+	// primary_mac_address is deliberately absent: it is managed by
+	// netbox_virtual_machine_interface_primary_mac_address and dropped from the
+	// body below, see hackOmitFields.
 
 	// About the `nullFields` hack
 	//
@@ -273,7 +272,9 @@ func resourceNetboxInterfaceUpdate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	params := virtualization.NewVirtualizationInterfacesPartialUpdateParams().WithID(id).WithData(&data)
-	_, err = api.Virtualization.VirtualizationInterfacesPartialUpdate(params, nil, hackSerializeAsNull(nullFields...))
+	_, err = api.Virtualization.VirtualizationInterfacesPartialUpdate(params, nil,
+		hackSerializeAsNull(nullFields...),
+		virtualization.ClientOption(hackOmitFields("primary_mac_address")))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -311,6 +312,7 @@ func getIDsFromNestedVLAN(nestedvlans []*models.NestedVLAN) []int64 {
 type interceptWriter struct {
 	runtime.ClientRequest
 	fields []string
+	omit   []string
 }
 
 func (iw interceptWriter) SetBodyParam(p any) error {
@@ -331,18 +333,41 @@ func (iw interceptWriter) SetBodyParam(p any) error {
 			out[fieldName] = nil
 		}
 	}
+	for _, fieldName := range iw.omit {
+		delete(out, fieldName)
+	}
 	return iw.ClientRequest.SetBodyParam(out)
 }
 
 type interceptParams struct {
 	inner  runtime.ClientRequestWriter
 	fields []string
+	omit   []string
 }
 
 // WriteToRequest implements [runtime.ClientRequestWriter].
 func (ip interceptParams) WriteToRequest(req runtime.ClientRequest, reg strfmt.Registry) error {
-	writer := interceptWriter{ClientRequest: req, fields: ip.fields}
+	writer := interceptWriter{ClientRequest: req, fields: ip.fields, omit: ip.omit}
 	return ip.inner.WriteToRequest(writer, reg)
+}
+
+// hackOmitFields is the counterpart of hackSerializeAsNull: it drops the given
+// fields from the request body entirely, so a partial update leaves them
+// untouched.
+//
+// It is needed for fields the generated models declare *without* `omitempty`,
+// which a resource does not manage: a nil pointer there serializes as
+// `"field": null` and an empty slice as `"field": []`, and Netbox reads both as
+// "clear this". Whatever such a field holds was set out of band, so a PATCH that
+// is not about it must not mention it.
+//
+// The result is a plain func so that it converts to any of the generated
+// per-package ClientOption types, e.g.
+// dcim.ClientOption(hackOmitFields("tags")).
+func hackOmitFields(fields ...string) func(*runtime.ClientOperation) {
+	return func(co *runtime.ClientOperation) {
+		co.Params = interceptParams{inner: co.Params, omit: fields}
+	}
 }
 
 // hackSerializeAsNull is a serialization middleware of sorts that will

--- a/netbox/resource_netbox_virtual_machine_interface_primary_mac_address_test.go
+++ b/netbox/resource_netbox_virtual_machine_interface_primary_mac_address_test.go
@@ -2,9 +2,12 @@ package netbox
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
+	"github.com/fbreckle/go-netbox/netbox/client/virtualization"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func testAccNetboxVirtualMachineInterfacePrimaryMACAddressFullDependencies(testName string) string {
@@ -74,6 +77,117 @@ resource "netbox_virtual_machine_interface_primary_mac_address" "test" {
   mac_address_id = netbox_mac_address.test.id
 }
 `, testName)
+}
+
+func testAccNetboxVirtualMachineInterfacePrimaryMACAddressUpdatableInterface(testName, description string) string {
+	return fmt.Sprintf(`
+resource "netbox_site" "test" {
+  name   = "%[1]s"
+  status = "active"
+}
+
+resource "netbox_cluster_type" "test" {
+  name = "%[1]s"
+}
+
+resource "netbox_cluster" "test" {
+  name            = "%[1]s"
+  cluster_type_id = netbox_cluster_type.test.id
+  site_id         = netbox_site.test.id
+}
+
+resource "netbox_virtual_machine" "test" {
+  name       = "%[1]s"
+  cluster_id = netbox_cluster.test.id
+  site_id    = netbox_site.test.id
+}
+
+resource "netbox_interface" "test" {
+  virtual_machine_id = netbox_virtual_machine.test.id
+  name               = "%[1]s"
+  description        = "%[2]s"
+}
+
+resource "netbox_mac_address" "test" {
+  mac_address                  = "00:1A:2B:3C:4D:5E"
+  virtual_machine_interface_id = netbox_interface.test.id
+}
+
+resource "netbox_virtual_machine_interface_primary_mac_address" "test" {
+  interface_id   = netbox_interface.test.id
+  mac_address_id = netbox_mac_address.test.id
+}
+`, testName, description)
+}
+
+// testAccCheckVirtualMachineInterfacePrimaryMACAddressSet asserts Netbox itself
+// still reports the expected primary MAC on the VM interface. See the device
+// interface twin of this helper for why it does not read Terraform state.
+func testAccCheckVirtualMachineInterfacePrimaryMACAddressSet(interfaceResourceName, macResourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		api := testAccProvider.Meta().(*providerState)
+
+		interfaceState, ok := s.RootModule().Resources[interfaceResourceName]
+		if !ok {
+			return fmt.Errorf("%s not found in state", interfaceResourceName)
+		}
+		macState, ok := s.RootModule().Resources[macResourceName]
+		if !ok {
+			return fmt.Errorf("%s not found in state", macResourceName)
+		}
+
+		interfaceID, err := strconv.ParseInt(interfaceState.Primary.ID, 10, 64)
+		if err != nil {
+			return err
+		}
+
+		res, err := api.Virtualization.VirtualizationInterfacesRead(virtualization.NewVirtualizationInterfacesReadParams().WithID(interfaceID), nil)
+		if err != nil {
+			return err
+		}
+
+		primaryMAC := res.GetPayload().PrimaryMacAddress
+		if primaryMAC == nil {
+			return fmt.Errorf("VM interface %d has no primary MAC address in Netbox, expected MAC address %s", interfaceID, macState.Primary.ID)
+		}
+		if got, want := strconv.FormatInt(primaryMAC.ID, 10), macState.Primary.ID; got != want {
+			return fmt.Errorf("VM interface %d has primary MAC address %s in Netbox, expected %s", interfaceID, got, want)
+		}
+		return nil
+	}
+}
+
+// TestAccNetboxVirtualMachineInterfacePrimaryMACAddress_survivesInterfaceUpdate
+// is the netbox_interface twin of
+// TestAccNetboxDeviceInterfacePrimaryMACAddress_survivesInterfaceUpdate:
+// WritableVMInterface.PrimaryMacAddress has no `omitempty` either, so any PATCH
+// that leaves it nil drops the VM interface's primary MAC.
+func TestAccNetboxVirtualMachineInterfacePrimaryMACAddress_survivesInterfaceUpdate(t *testing.T) {
+	testSlug := "pr_vm_mac_upd"
+	testName := testAccGetTestName(testSlug)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxVirtualMachineInterfacePrimaryMACAddressUpdatableInterface(testName, "before update"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("netbox_virtual_machine_interface_primary_mac_address.test", "mac_address_id", "netbox_mac_address.test", "id"),
+					testAccCheckVirtualMachineInterfacePrimaryMACAddressSet("netbox_interface.test", "netbox_mac_address.test"),
+				),
+			},
+			{
+				// Only the interface's description changes; nothing about the
+				// primary MAC does.
+				Config: testAccNetboxVirtualMachineInterfacePrimaryMACAddressUpdatableInterface(testName, "after update"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_interface.test", "description", "after update"),
+					testAccCheckVirtualMachineInterfacePrimaryMACAddressSet("netbox_interface.test", "netbox_mac_address.test"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccNetboxVirtualMachineInterfacePrimaryMACAddress_basic(t *testing.T) {


### PR DESCRIPTION
## Problem

Two interface `Update` paths send fields the resource cannot set, and Netbox reads the value as "clear this":

- **`primary_mac_address`**, on `netbox_device_interface` and `netbox_interface`. `primary_mac_address_id` is computed-only — the primary MAC is managed through the dedicated `netbox_*_primary_mac_address` resources — so the `d.HasChange` guard around it was never true and the field went out as `null` on every update.
- **`vdcs` and `wireless_lans`** on `netbox_device_interface`, hardcoded to empty slices and backed by no schema attribute at all.

`WritableInterface` and `WritableVMInterface` declare these without `omitempty`, so a nil pointer serializes as `"primary_mac_address": null` and an empty slice as `"vdcs": []`.

The effect is that renaming a LAG, bumping an MTU or editing a description silently drops the interface's primary MAC, VDCs and wireless LANs. The dedicated primary-MAC resource has no diff in such a plan, so nothing re-asserts the pointer in the same apply; consumers have to work around it with `lifecycle.replace_triggered_by`.

On master the new tests report:

```
interface 110 has no primary MAC address in Netbox, expected MAC address 46
VM interface 45 has no primary MAC address in Netbox, expected MAC address 47
interface 111 is no longer assigned to wireless LAN 6 after the update
```

## Fix

`hackOmitFields`, the counterpart of the existing `hackSerializeAsNull` from #856: it drops the given fields from the request body entirely, so a partial update leaves them untouched. Omitting is what keeps it cheap — nothing has to be read back from Netbox or carried through Terraform state first.

This is the mirror image of #857: there, `omitempty` prevents sending an explicit `null` when you *do* want to unset a field; here, its absence forces a `null` when you want to touch nothing.

## Tests

- a description-only change keeps the primary MAC, on device and VM interfaces;
- a MAC address deleted out of band does not break the next interface update;
- a wireless LAN assignment survives an unrelated update.

Verified against Netbox v4.4.10: each fails on master and passes with the fix.

## Not in scope, same class

- `netbox_platform` sends an empty `tags` list on every update and has no `tags` attribute, so every update wipes a platform's tags. One line with this helper, happy to follow up.
- `netbox_interface` still has a dead `if d.HasChange("mac_address")` block on a computed-only attribute that Netbox ignores on write.
