### PR TITLE
resource/netbox_device_type: add description and comments

### DIFF
--- a/docs/resources/device_type.md
+++ b/docs/resources/device_type.md
@@ -37,7 +37,9 @@ resource "netbox_device_type" "test" {
 
 ### Optional
 
+- `comments` (String)
 - `custom_fields` (Map of String)
+- `description` (String)
 - `is_full_depth` (Boolean)
 - `part_number` (String)
 - `slug` (String)

--- a/netbox/resource_netbox_device_type.go
+++ b/netbox/resource_netbox_device_type.go
@@ -52,6 +52,14 @@ func resourceNetboxDeviceType() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"comments": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			tagsKey:         tagsSchema,
 			customFieldsKey: customFieldsSchema,
 		},
@@ -97,6 +105,10 @@ func resourceNetboxDeviceTypeCreate(d *schema.ResourceData, m interface{}) error
 	if subdeviceRoleValue, ok := d.GetOk("subdevice_role"); ok {
 		data.SubdeviceRole = subdeviceRoleValue.(string)
 	}
+
+	data.Description = d.Get("description").(string)
+
+	data.Comments = d.Get("comments").(string)
 
 	var err error
 	data.Tags, err = getNestedTagListFromResourceDataSet(api, d.Get(tagsAllKey))
@@ -152,6 +164,8 @@ func resourceNetboxDeviceTypeRead(d *schema.ResourceData, m interface{}) error {
 	} else {
 		d.Set("subdevice_role", "")
 	}
+	d.Set("description", deviceType.Description)
+	d.Set("comments", deviceType.Comments)
 	api.readTags(d, deviceType.Tags)
 
 	cf := getCustomFields(deviceType.CustomFields)
@@ -198,6 +212,10 @@ func resourceNetboxDeviceTypeUpdate(d *schema.ResourceData, m interface{}) error
 	if subdeviceRoleValue, ok := d.GetOk("subdevice_role"); ok {
 		data.SubdeviceRole = subdeviceRoleValue.(string)
 	}
+
+	data.Description = d.Get("description").(string)
+
+	data.Comments = d.Get("comments").(string)
 
 	var err error
 	data.Tags, err = getNestedTagListFromResourceDataSet(api, d.Get(tagsAllKey))

--- a/netbox/resource_netbox_device_type_test.go
+++ b/netbox/resource_netbox_device_type_test.go
@@ -32,6 +32,8 @@ resource "netbox_device_type" "test" {
   manufacturer_id = netbox_manufacturer.test.id
   is_full_depth = true
   subdevice_role = "parent"
+  description = "test description"
+  comments = "test comments"
 }`, testName, randomSlug),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_device_type.test", "model", testName),
@@ -41,6 +43,8 @@ resource "netbox_device_type" "test" {
 					resource.TestCheckResourceAttrPair("netbox_device_type.test", "manufacturer_id", "netbox_manufacturer.test", "id"),
 					resource.TestCheckResourceAttr("netbox_device_type.test", "is_full_depth", "true"),
 					resource.TestCheckResourceAttr("netbox_device_type.test", "subdevice_role", "parent"),
+					resource.TestCheckResourceAttr("netbox_device_type.test", "description", "test description"),
+					resource.TestCheckResourceAttr("netbox_device_type.test", "comments", "test comments"),
 				),
 			},
 			{
@@ -57,6 +61,8 @@ resource "netbox_device_type" "test" {
   manufacturer_id = netbox_manufacturer.test.id
   is_full_depth = false
   subdevice_role = "child"
+  description = "test description changed"
+  comments = "test comments changed"
 }`, testName, randomSlug),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_device_type.test", "model", testName),
@@ -66,6 +72,8 @@ resource "netbox_device_type" "test" {
 					resource.TestCheckResourceAttrPair("netbox_device_type.test", "manufacturer_id", "netbox_manufacturer.test", "id"),
 					resource.TestCheckResourceAttr("netbox_device_type.test", "is_full_depth", "false"),
 					resource.TestCheckResourceAttr("netbox_device_type.test", "subdevice_role", "child"),
+					resource.TestCheckResourceAttr("netbox_device_type.test", "description", "test description changed"),
+					resource.TestCheckResourceAttr("netbox_device_type.test", "comments", "test comments changed"),
 				),
 			},
 			{


### PR DESCRIPTION
### Description

NetBox's `DeviceType` has both `description` and `comments`, and `models.WritableDeviceType` in the generated client already carries them, but `netbox_device_type` never exposed either. The result is that they cannot be managed, and a configuration that sets them has them silently dropped on write.

This adds both as optional strings, wired through create, read and update following the same pattern as `netbox_device`.

### Changes

- `netbox/resource_netbox_device_type.go`: `description` and `comments` in the schema, set in create and update, read back in read.
- `netbox/resource_netbox_device_type_test.go`: `TestAccNetboxDeviceType_basic` now sets both in the first step and changes both in the second, so the update path is covered too.
- `docs/resources/device_type.md`: regenerated with `make docs`.

28 added lines, no behaviour change for configurations that do not set the new attributes.

### Notes

- No changelog entry: recent feature PRs leave `CHANGELOG.md` to the maintainers.
- `go build ./...` and `go vet ./netbox/` are clean. `gofmt -l` reports nothing for the two files touched (it does flag some pre-existing `vpn_tunnel` files, untouched here).
- I have not been able to run the acceptance tests against a live NetBox from my current network, so `TestAccNetboxDeviceType_basic` is unverified end to end. The attribute plumbing mirrors `netbox_device` exactly, but a maintainer run would be worth having.