### PR TITLE
feat: add NetBox 4.6.8 to the supported and tested versions

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -62,6 +62,7 @@ jobs:
           - v4.6.3
           - v4.6.4
           - v4.6.5
+          - v4.6.8
     steps:
       - uses: actions/checkout@v7
       - name: Set up Go

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ TEST_FUNC?=TestAccNetboxMACAddr*
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 DOCKER_COMPOSE=docker compose
 
-export NETBOX_VERSION=v4.6.5
+export NETBOX_VERSION=v4.6.8
 export NETBOX_SERVER_URL=http://localhost:8001
 SUPERUSER_API_TOKEN := Iw2JZtpMdYjBuIVIZLItd4lB2RYEiv6xhY23W0tQ
 SUPERUSER_API_KEY   := mrcLJrER9ves

--- a/netbox/provider.go
+++ b/netbox/provider.go
@@ -405,7 +405,7 @@ func providerConfigure(ctx context.Context, data *schema.ResourceData) (interfac
 			return nil, diag.FromErr(fmt.Errorf("error extracting netbox version. try using the `skip_version_check` provider parameter to bypass this error. original error: %w", err))
 		}
 
-		supportedVersions := []string{"4.3.0", "4.3.2", "4.3.3", "4.3.4", "4.3.5", "4.3.6", "4.3.7", "4.4.0", "4.4.1", "4.4.2", "4.4.4", "4.4.5", "4.4.6", "4.4.7", "4.4.8", "4.4.9", "4.4.10", "4.5.1", "4.5.2", "4.5.3", "4.5.4", "4.5.5", "4.5.6", "4.5.7", "4.5.8", "4.5.9", "4.5.10", "4.6.0", "4.6.1", "4.6.2", "4.6.3", "4.6.4", "4.6.5"}
+		supportedVersions := []string{"4.3.0", "4.3.2", "4.3.3", "4.3.4", "4.3.5", "4.3.6", "4.3.7", "4.4.0", "4.4.1", "4.4.2", "4.4.4", "4.4.5", "4.4.6", "4.4.7", "4.4.8", "4.4.9", "4.4.10", "4.5.1", "4.5.2", "4.5.3", "4.5.4", "4.5.5", "4.5.6", "4.5.7", "4.5.8", "4.5.9", "4.5.10", "4.6.0", "4.6.1", "4.6.2", "4.6.3", "4.6.4", "4.6.5", "4.6.8"}
 
 		if !slices.Contains(supportedVersions, netboxVersion) {
 			// Currently, there is no way to test these warnings. There is an issue to track this: https://github.com/hashicorp/terraform-plugin-sdk/issues/864


### PR DESCRIPTION
Adds NetBox 4.6.8 to `supportedVersions`, the acceptance-test matrix, and the default `NETBOX_VERSION` used by the Makefile. This is the version bump on its own, with no new resources attached.

Split out of #965.