### PR TITLE
fix: align netbox_token with the NetBox 4.6 token API

### DIFF
--- a/docs/resources/token.md
+++ b/docs/resources/token.md
@@ -23,8 +23,7 @@ resource "netbox_user" "test" {
 
 resource "netbox_token" "test_basic" {
   user_id       = netbox_user.test.id
-  key           = "0123456789012345678901234567890123456789"
-  allowed_ips   = ["2.4.8.16/32"]
+  token         = "0123456789012345678901234567890123456789"
   write_enabled = false
   expires       = "2036-01-02T15:04:05.000Z"
 }
@@ -39,10 +38,12 @@ resource "netbox_token" "test_basic" {
 
 ### Optional
 
-- `allowed_ips` (List of String)
+- `allowed_ips` (List of String, Deprecated)
 - `description` (String)
+- `enabled` (Boolean) Defaults to `true`.
 - `expires` (String)
-- `key` (String, Sensitive)
+- `key` (String, Sensitive, Deprecated)
+- `token` (String, Sensitive)
 - `write_enabled` (Boolean)
 
 ### Read-Only

--- a/examples/resources/netbox_token/resource.tf
+++ b/examples/resources/netbox_token/resource.tf
@@ -5,8 +5,7 @@ resource "netbox_user" "test" {
 
 resource "netbox_token" "test_basic" {
   user_id       = netbox_user.test.id
-  key           = "0123456789012345678901234567890123456789"
-  allowed_ips   = ["2.4.8.16/32"]
+  token         = "0123456789012345678901234567890123456789"
   write_enabled = false
   expires       = "2036-01-02T15:04:05.000Z"
 }

--- a/netbox/resource_netbox_token.go
+++ b/netbox/resource_netbox_token.go
@@ -32,7 +32,21 @@ func resourceNetboxToken() *schema.Resource {
 				Type:         schema.TypeString,
 				Sensitive:    true,
 				Optional:     true,
+				Computed:     true,
 				ValidateFunc: validation.StringLenBetween(40, 256),
+				Deprecated:   "NetBox 4.6 made `key` read-only. Set `token` instead; this value is no longer sent.",
+			},
+			"token": {
+				Type:         schema.TypeString,
+				Sensitive:    true,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringLenBetween(40, 256),
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
 			},
 			"allowed_ips": {
 				Type:     schema.TypeList,
@@ -41,6 +55,7 @@ func resourceNetboxToken() *schema.Resource {
 					Type:         schema.TypeString,
 					ValidateFunc: validation.IsCIDR,
 				},
+				Deprecated: "NetBox 4.6 removed `allowed_ips` from the API. This value is no longer sent and has no effect.",
 			},
 			"write_enabled": {
 				Type:     schema.TypeBool,
@@ -72,17 +87,15 @@ func resourceNetboxTokenCreate(ctx context.Context, d *schema.ResourceData, m in
 
 	userid := int64(d.Get("user_id").(int))
 
-	key := d.Get("key").(string)
-	allowedIps := d.Get("allowed_ips").([]interface{})
-
 	data.User = &userid
-	data.Key = key
 
-	data.AllowedIps = make([]models.IPNetwork, len(allowedIps))
-	for i, v := range allowedIps {
-		data.AllowedIps[i] = v
+	// NetBox 4.6 made `key` read-only and dropped `allowed_ips`; `token` is
+	// the write field. `key` is still read back for pre-4.6 servers.
+	if token, ok := d.GetOk("token"); ok {
+		data.Token = token.(string)
 	}
 
+	data.Enabled = d.Get("enabled").(bool)
 	data.WriteEnabled = d.Get("write_enabled").(bool)
 	data.Description = d.Get("description").(string)
 
@@ -129,14 +142,17 @@ func resourceNetboxTokenRead(ctx context.Context, d *schema.ResourceData, m inte
 
 	// Since NetBox 4.3.0, ALLOW_TOKEN_RETRIEVAL is disabled by default
 	// This means we will usually not get a Key value from the API
-	if token.Key != "" {
-		d.Set("key", token.Key)
+	if token.Key != nil && *token.Key != "" {
+		d.Set("key", *token.Key)
 	}
+	if token.Token != "" {
+		d.Set("token", token.Token)
+	}
+	d.Set("enabled", token.Enabled)
 	d.Set("last_used", token.LastUsed)
 	if token.Expires != nil {
 		d.Set("expires", token.Expires.String())
 	}
-	d.Set("allowed_ips", token.AllowedIps)
 	d.Set("write_enabled", token.WriteEnabled)
 	d.Set("description", token.Description)
 
@@ -149,17 +165,14 @@ func resourceNetboxTokenUpdate(ctx context.Context, d *schema.ResourceData, m in
 	data := models.WritableToken{}
 
 	userid := int64(d.Get("user_id").(int))
-	key := d.Get("key").(string)
-	allowedIps := d.Get("allowed_ips").([]interface{})
 
 	data.User = &userid
-	data.Key = key
 
-	data.AllowedIps = make([]models.IPNetwork, len(allowedIps))
-	for i, v := range allowedIps {
-		data.AllowedIps[i] = v
+	if token, ok := d.GetOk("token"); ok {
+		data.Token = token.(string)
 	}
 
+	data.Enabled = d.Get("enabled").(bool)
 	data.WriteEnabled = d.Get("write_enabled").(bool)
 	data.Description = d.Get("description").(string)
 

--- a/netbox/resource_netbox_token_test.go
+++ b/netbox/resource_netbox_token_test.go
@@ -32,16 +32,13 @@ resource "netbox_user" "test" {
 
 resource "netbox_token" "test_basic" {
   user_id       = netbox_user.test.id
-  key           = "%s"
-  allowed_ips   = ["2.4.8.16/32"]
+  token         = "%s"
   write_enabled = false
   description   = "Netbox Test Basic Token"
   expires       = "2036-01-02T15:04:05.000Z"
 }`, testName, testToken),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("netbox_token.test_basic", "key", testToken),
-					resource.TestCheckResourceAttr("netbox_token.test_basic", "allowed_ips.#", "1"),
-					resource.TestCheckResourceAttr("netbox_token.test_basic", "allowed_ips.0", "2.4.8.16/32"),
+					resource.TestCheckResourceAttr("netbox_token.test_basic", "token", testToken),
 					resource.TestCheckResourceAttr("netbox_token.test_basic", "write_enabled", "false"),
 					resource.TestCheckResourceAttr("netbox_token.test_basic", "description", "Netbox Test Basic Token"),
 					resource.TestCheckResourceAttr("netbox_token.test_basic", "expires", "2036-01-02T15:04:05.000Z"),
@@ -51,7 +48,7 @@ resource "netbox_token" "test_basic" {
 				ResourceName:            "netbox_token.test_basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"key"},
+				ImportStateVerifyIgnore: []string{"key", "token"},
 			},
 		},
 	})
@@ -77,15 +74,12 @@ resource "netbox_user" "test" {
 
 resource "netbox_token" "test_without_expires" {
   user_id       = netbox_user.test.id
-  key           = "%s"
-  allowed_ips   = ["2.4.8.16/32"]
+  token         = "%s"
   write_enabled = false
   description   = "Netbox Token Without Expires"
 }`, testName, testToken),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "key", testToken),
-					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "allowed_ips.#", "1"),
-					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "allowed_ips.0", "2.4.8.16/32"),
+					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "token", testToken),
 					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "write_enabled", "false"),
 					resource.TestCheckResourceAttr("netbox_token.test_without_expires", "description", "Netbox Token Without Expires"),
 					resource.TestCheckNoResourceAttr("netbox_token.test_without_expires", "expires"),
@@ -95,7 +89,7 @@ resource "netbox_token" "test_without_expires" {
 				ResourceName:            "netbox_token.test_without_expires",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"key"},
+				ImportStateVerifyIgnore: []string{"key", "token"},
 			},
 		},
 	})


### PR DESCRIPTION
NetBox 4.6 reworked API tokens: `key` became read-only, the write field is now `token`, and `allowed_ips` was removed. The provider still sends both, and because the NetBox request schema ignores unknown fields rather than rejecting them, anyone setting `key` today silently gets a server-generated token instead — no error, no warning. This adds `token` and `enabled`, stops sending the removed fields, and marks `key` and `allowed_ips` as deprecated rather than removing them so existing configurations keep planning.

Blocked on fbreckle/go-netbox#104, which adds the v2 token fields to the bindings; CI will not compile until that merges and a go-netbox release is tagged.