### PR TITLE
fix: stop sending the removed is_staff field on users

### DIFF
--- a/netbox/resource_netbox_user.go
+++ b/netbox/resource_netbox_user.go
@@ -78,7 +78,6 @@ func resourceNetboxUserCreate(d *schema.ResourceData, m interface{}) error {
 	firstName := d.Get("first_name").(string)
 	lastName := d.Get("last_name").(string)
 	active := d.Get("active").(bool)
-	staff := d.Get("staff").(bool)
 	groupIDs := toInt64List(d.Get("group_ids"))
 
 	data.Username = &username
@@ -87,7 +86,6 @@ func resourceNetboxUserCreate(d *schema.ResourceData, m interface{}) error {
 	data.FirstName = firstName
 	data.LastName = lastName
 	data.IsActive = active
-	data.IsStaff = staff
 	data.Groups = groupIDs
 	data.DateJoined = strfmt.DateTime(time.Now())
 
@@ -127,7 +125,6 @@ func resourceNetboxUserRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("first_name", res.GetPayload().FirstName)
 	d.Set("last_name", res.GetPayload().LastName)
 
-	d.Set("staff", res.GetPayload().IsStaff)
 	d.Set("active", res.GetPayload().IsActive)
 	d.Set("group_ids", getIDsFromNestedGroup(res.GetPayload().Groups))
 
@@ -147,7 +144,6 @@ func resourceNetboxUserUpdate(d *schema.ResourceData, m interface{}) error {
 	firstName := d.Get("first_name").(string)
 	lastName := d.Get("last_name").(string)
 	active := d.Get("active").(bool)
-	staff := d.Get("staff").(bool)
 	groupIDs := toInt64List(d.Get("group_ids"))
 
 	data.Username = &username
@@ -156,7 +152,6 @@ func resourceNetboxUserUpdate(d *schema.ResourceData, m interface{}) error {
 	data.FirstName = firstName
 	data.LastName = lastName
 	data.IsActive = active
-	data.IsStaff = staff
 	data.Groups = groupIDs
 	data.DateJoined = strfmt.DateTime(time.Now())
 


### PR DESCRIPTION
The `staff` attribute is already marked deprecated here, but the provider still sends `is_staff` on create and update and reads it back. NetBox removed the field in 4.5, so the value is silently ignored on the way out and always reads back as false. This stops sending and reading it; the deprecated attribute stays in the schema so existing configurations keep planning.

Blocked on fbreckle/go-netbox#105, which removes `IsStaff` from the bindings; CI will not compile until that merges and a go-netbox release is tagged.