### PR TITLE
fix: stop sending mac_address and wireless_link on interfaces

### DIFF
--- a/netbox/resource_netbox_device_interface_primary_mac_address.go
+++ b/netbox/resource_netbox_device_interface_primary_mac_address.go
@@ -164,10 +164,6 @@ func resourceNetboxDeviceInterfacePrimaryMACAddressUpdate(d *schema.ResourceData
 		data.Vrf = &iface.Vrf.ID
 	}
 
-	if iface.WirelessLink != nil {
-		data.WirelessLink = &iface.WirelessLink.ID
-	}
-
 	for _, vdc := range iface.Vdcs {
 		data.Vdcs = append(data.Vdcs, vdc.ID)
 	}

--- a/netbox/resource_netbox_interface.go
+++ b/netbox/resource_netbox_interface.go
@@ -215,10 +215,6 @@ func resourceNetboxInterfaceUpdate(ctx context.Context, d *schema.ResourceData, 
 		VirtualMachine: &virtualMachineID,
 	}
 
-	if d.HasChange("mac_address") {
-		macAddress := d.Get("mac_address").(string)
-		data.MacAddress = &macAddress
-	}
 	if d.HasChange("mtu") {
 		mtu := int64(d.Get("mtu").(int))
 		data.Mtu = &mtu

--- a/netbox/resource_netbox_virtual_machine_interface_primary_mac_address.go
+++ b/netbox/resource_netbox_virtual_machine_interface_primary_mac_address.go
@@ -90,7 +90,6 @@ func resourceNetboxVirtualMachineInterfacePrimaryMACAddressUpdate(d *schema.Reso
 		Description:    iface.Description,
 		Enabled:        iface.Enabled,
 		ID:             iface.ID,
-		MacAddress:     iface.MacAddress,
 		Mtu:            iface.Mtu,
 		Tags:           iface.Tags,
 		URL:            iface.URL,


### PR DESCRIPTION
NetBox 4.6 moved MAC addresses onto their own object: interfaces are written with `primary_mac_address` and no longer accept `mac_address`, and `wireless_link` is read-only. The provider still copies both into update payloads, where NetBox silently ignores them. The `mac_address` attribute is already `Computed`-only in the schema, so no configuration changes are needed and nothing is removed from the schema here.

Blocked on fbreckle/go-netbox#106, which drops these fields from the writable interface models; CI will not compile until that merges and a go-netbox release is tagged.