### PR TITLE
feat: add tenant_id and comments to netbox_vlan_group

### DIFF
--- a/docs/resources/vlan_group.md
+++ b/docs/resources/vlan_group.md
@@ -42,10 +42,12 @@ resource "netbox_vlan_group" "example2" {
 
 ### Optional
 
+- `comments` (String)
 - `description` (String) Defaults to `""`.
 - `scope_id` (Number) Required when `scope_type` is set.
 - `scope_type` (String) Valid values are `dcim.location`, `dcim.site`, `dcim.sitegroup`, `dcim.region`, `dcim.rack`, `virtualization.cluster` and `virtualization.clustergroup`.
 - `tags` (Set of String)
+- `tenant_id` (Number)
 
 ### Read-Only
 

--- a/netbox/resource_netbox_vlan_group.go
+++ b/netbox/resource_netbox_vlan_group.go
@@ -48,6 +48,14 @@ func resourceNetboxVlanGroup() *schema.Resource {
 				Optional: true,
 				Default:  "",
 			},
+			"comments": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"tenant_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"vid_ranges": {
 				Type: schema.TypeList,
 				Elem: &schema.Schema{
@@ -88,6 +96,11 @@ func resourceNetboxVlanGroupCreate(d *schema.ResourceData, m interface{}) error 
 	data.Name = &name
 	data.Slug = &slug
 	data.Description = description
+	data.Comments = d.Get("comments").(string)
+
+	if tenantID, ok := d.GetOk("tenant_id"); ok {
+		data.Tenant = int64ToPtr(int64(tenantID.(int)))
+	}
 
 	if scopeType, ok := d.GetOk("scope_type"); ok {
 		data.ScopeType = strToPtr(scopeType.(string))
@@ -136,6 +149,13 @@ func resourceNetboxVlanGroupRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("name", vlanGroup.Name)
 	d.Set("slug", vlanGroup.Slug)
 	d.Set("description", vlanGroup.Description)
+	d.Set("comments", vlanGroup.Comments)
+
+	if vlanGroup.Tenant != nil {
+		d.Set("tenant_id", vlanGroup.Tenant)
+	} else {
+		d.Set("tenant_id", nil)
+	}
 	d.Set("vid_ranges", vlanGroup.VidRanges)
 	api.readTags(d, vlanGroup.Tags)
 
@@ -174,6 +194,11 @@ func resourceNetboxVlanGroupUpdate(d *schema.ResourceData, m interface{}) error 
 	data.Name = &name
 	data.Slug = &slug
 	data.Description = description
+	data.Comments = d.Get("comments").(string)
+
+	if tenantID, ok := d.GetOk("tenant_id"); ok {
+		data.Tenant = int64ToPtr(int64(tenantID.(int)))
+	}
 
 	if scopeType, ok := d.GetOk("scope_type"); ok {
 		data.ScopeType = strToPtr(scopeType.(string))

--- a/netbox/resource_netbox_vlan_group_test.go
+++ b/netbox/resource_netbox_vlan_group_test.go
@@ -20,6 +20,10 @@ resource "netbox_site" "test" {
   name   = "%[1]s"
   status = "active"
 }
+
+resource "netbox_tenant" "test" {
+  name = "%[1]s"
+}
 `, testName)
 }
 func TestAccNetboxVlanGroup_basic(t *testing.T) {
@@ -35,12 +39,16 @@ resource "netbox_vlan_group" "test_basic" {
   name       = "%s"
   slug       = "%s"
   vid_ranges  = [[1, 2], [3, 4]]
+  comments   = "Some comments"
+  tenant_id  = netbox_tenant.test.id
   tags       = []
 }`, testName, testSlug),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_vlan_group.test_basic", "name", testName),
 					resource.TestCheckResourceAttr("netbox_vlan_group.test_basic", "slug", testSlug),
 					resource.TestCheckResourceAttr("netbox_vlan_group.test_basic", "description", ""),
+					resource.TestCheckResourceAttr("netbox_vlan_group.test_basic", "comments", "Some comments"),
+					resource.TestCheckResourceAttrPair("netbox_vlan_group.test_basic", "tenant_id", "netbox_tenant.test", "id"),
 					resource.TestCheckResourceAttr("netbox_vlan_group.test_basic", "tags.#", "0"),
 					resource.TestCheckResourceAttr("netbox_vlan_group.test_basic", "vid_ranges.0.0", "1"),
 					resource.TestCheckResourceAttr("netbox_vlan_group.test_basic", "vid_ranges.0.1", "2"),


### PR DESCRIPTION
NetBox accepts `tenant` and `comments` on VLAN groups, but the resource exposes neither, so a VLAN group cannot be assigned to a tenant from Terraform. This adds both attributes across create, read and update, with acceptance test coverage.

Blocked on fbreckle/go-netbox#107, which adds the fields to the bindings; CI will not compile until that merges and a go-netbox release is tagged.