### PR TITLE
feat: add role_id and site_ids to netbox_asn

### DIFF
--- a/docs/resources/asn.md
+++ b/docs/resources/asn.md
@@ -43,6 +43,8 @@ resource "netbox_asn" "test" {
 
 - `comments` (String) Comments field for the AS Number record.
 - `description` (String) Description field for the AS Number record.
+- `role_id` (Number) ID of the role assigned to the AS Number record.
+- `site_ids` (Set of Number) IDs of the sites the AS Number record is assigned to.
 - `tags` (Set of String)
 
 ### Read-Only

--- a/netbox/resource_netbox_asn.go
+++ b/netbox/resource_netbox_asn.go
@@ -41,6 +41,17 @@ func resourceNetboxAsn() *schema.Resource {
 				Optional:    true,
 				Description: "Comments field for the AS Number record",
 			},
+			"role_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "ID of the role assigned to the AS Number record",
+			},
+			"site_ids": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeInt},
+				Description: "IDs of the sites the AS Number record is assigned to",
+			},
 			tagsKey: tagsSchema,
 		},
 		Importer: &schema.ResourceImporter{
@@ -62,6 +73,13 @@ func resourceNetboxAsnCreate(d *schema.ResourceData, m interface{}) error {
 
 	data.Description = d.Get("description").(string)
 	data.Comments = d.Get("comments").(string)
+
+	if roleID, ok := d.GetOk("role_id"); ok {
+		data.Role = int64ToPtr(int64(roleID.(int)))
+	}
+
+	data.Sites = toInt64List(d.Get("site_ids"))
+
 	var err error
 	data.Tags, err = getNestedTagListFromResourceDataSet(api, d.Get(tagsAllKey))
 	if err != nil {
@@ -104,6 +122,18 @@ func resourceNetboxAsnRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("rir_id", asn.Rir.ID)
 	d.Set("description", asn.Description)
 	d.Set("comments", asn.Comments)
+
+	if asn.Role != nil {
+		d.Set("role_id", asn.Role.ID)
+	} else {
+		d.Set("role_id", nil)
+	}
+
+	siteIDs := make([]int64, len(asn.Sites))
+	for i, site := range asn.Sites {
+		siteIDs[i] = site.ID
+	}
+	d.Set("site_ids", siteIDs)
 	api.readTags(d, asn.Tags)
 
 	return nil
@@ -123,6 +153,13 @@ func resourceNetboxAsnUpdate(d *schema.ResourceData, m interface{}) error {
 
 	data.Description = d.Get("description").(string)
 	data.Comments = d.Get("comments").(string)
+
+	if roleID, ok := d.GetOk("role_id"); ok {
+		data.Role = int64ToPtr(int64(roleID.(int)))
+	}
+
+	data.Sites = toInt64List(d.Get("site_ids"))
+
 	var err error
 	data.Tags, err = getNestedTagListFromResourceDataSet(api, d.Get(tagsAllKey))
 	if err != nil {

--- a/netbox/resource_netbox_asn_test.go
+++ b/netbox/resource_netbox_asn_test.go
@@ -26,6 +26,16 @@ resource "netbox_rir" "test" {
   name = "%[1]s"
 }
 
+resource "netbox_ipam_role" "test" {
+  name = "%[1]s"
+  slug = "%[1]s"
+}
+
+resource "netbox_site" "test" {
+  name   = "%[1]s"
+  status = "active"
+}
+
 resource "netbox_asn" "test" {
   asn    = 1337
   rir_id = netbox_rir.test.id
@@ -33,12 +43,17 @@ resource "netbox_asn" "test" {
   description = "test"
   comments = "test"
 
+  role_id  = netbox_ipam_role.test.id
+  site_ids = [netbox_site.test.id]
+
   tags = [netbox_tag.test.name]
 }`, testName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("netbox_asn.test", "asn", "1337"),
 					resource.TestCheckResourceAttr("netbox_asn.test", "description", "test"),
 					resource.TestCheckResourceAttr("netbox_asn.test", "comments", "test"),
+					resource.TestCheckResourceAttrPair("netbox_asn.test", "role_id", "netbox_ipam_role.test", "id"),
+					resource.TestCheckResourceAttr("netbox_asn.test", "site_ids.#", "1"),
 					resource.TestCheckResourceAttr("netbox_asn.test", "tags.#", "1"),
 					resource.TestCheckResourceAttr("netbox_asn.test", "tags.0", testName+"a"),
 				),


### PR DESCRIPTION
NetBox accepts `role` and `sites` on ASNs, but the resource exposes neither, so an AS Number cannot be given a role or attached to sites from Terraform. This adds both attributes across create, read and update, with acceptance test coverage.

Blocked on fbreckle/go-netbox#108, which adds the fields to the bindings; CI will not compile until that merges and a go-netbox release is tagged.