### PR TITLE
feat: add qinq_role and qinq_svlan_id to netbox_vlan

### DIFF
--- a/docs/resources/vlan.md
+++ b/docs/resources/vlan.md
@@ -48,6 +48,8 @@ resource "netbox_vlan" "example2" {
 - `custom_fields` (Map of String)
 - `description` (String) Defaults to `""`.
 - `group_id` (Number)
+- `qinq_role` (String) Q-in-Q role of this VLAN. Valid values are `svlan` and `cvlan`.
+- `qinq_svlan_id` (Number) ID of the service VLAN this customer VLAN belongs to.
 - `role_id` (Number)
 - `site_id` (Number)
 - `status` (String) Valid values are `active`, `reserved` and `deprecated`. Defaults to `active`.

--- a/netbox/resource_netbox_vlan.go
+++ b/netbox/resource_netbox_vlan.go
@@ -51,6 +51,17 @@ func resourceNetboxVlan() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"qinq_role": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"svlan", "cvlan"}, false),
+				Description:  "Q-in-Q role of this VLAN. Valid values are `svlan` and `cvlan`.",
+			},
+			"qinq_svlan_id": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "ID of the service VLAN this customer VLAN belongs to.",
+			},
 
 			"site_id": {
 				Type:     schema.TypeInt,
@@ -98,6 +109,14 @@ func resourceNetboxVlanCreate(d *schema.ResourceData, m interface{}) error {
 
 	if roleID, ok := d.GetOk("role_id"); ok {
 		data.Role = int64ToPtr(int64(roleID.(int)))
+	}
+
+	if qinqRole, ok := d.GetOk("qinq_role"); ok {
+		data.QinqRole = strToPtr(qinqRole.(string))
+	}
+
+	if qinqSvlanID, ok := d.GetOk("qinq_svlan_id"); ok {
+		data.QinqSvlan = int64ToPtr(int64(qinqSvlanID.(int)))
 	}
 	if cf, ok := d.GetOk(customFieldsKey); ok {
 		data.CustomFields = getCustomFields(cf)
@@ -163,6 +182,12 @@ func resourceNetboxVlanRead(d *schema.ResourceData, m interface{}) error {
 	if vlan.Role != nil {
 		d.Set("role_id", vlan.Role.ID)
 	}
+	if vlan.QinqRole != nil {
+		d.Set("qinq_role", vlan.QinqRole.Value)
+	}
+	if vlan.QinqSvlan != nil {
+		d.Set("qinq_svlan_id", vlan.QinqSvlan.ID)
+	}
 
 	return nil
 }
@@ -195,6 +220,14 @@ func resourceNetboxVlanUpdate(d *schema.ResourceData, m interface{}) error {
 
 	if roleID, ok := d.GetOk("role_id"); ok {
 		data.Role = int64ToPtr(int64(roleID.(int)))
+	}
+
+	if qinqRole, ok := d.GetOk("qinq_role"); ok {
+		data.QinqRole = strToPtr(qinqRole.(string))
+	}
+
+	if qinqSvlanID, ok := d.GetOk("qinq_svlan_id"); ok {
+		data.QinqSvlan = int64ToPtr(int64(qinqSvlanID.(int)))
 	}
 	if cf, ok := d.GetOk(customFieldsKey); ok {
 		data.CustomFields = getCustomFields(cf)

--- a/netbox/resource_netbox_vlan_test.go
+++ b/netbox/resource_netbox_vlan_test.go
@@ -190,3 +190,35 @@ func init() {
 		},
 	})
 }
+
+func TestAccNetboxVlan_qinq(t *testing.T) {
+	testSlug := "vlan_qinq"
+	testName := testAccGetTestName(testSlug)
+	resource.ParallelTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "netbox_vlan" "test_svlan" {
+  name      = "%[1]s-svlan"
+  vid       = 100
+  status    = "active"
+  qinq_role = "svlan"
+}
+
+resource "netbox_vlan" "test_cvlan" {
+  name          = "%[1]s-cvlan"
+  vid           = 200
+  status        = "active"
+  qinq_role     = "cvlan"
+  qinq_svlan_id = netbox_vlan.test_svlan.id
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("netbox_vlan.test_svlan", "qinq_role", "svlan"),
+					resource.TestCheckResourceAttr("netbox_vlan.test_cvlan", "qinq_role", "cvlan"),
+					resource.TestCheckResourceAttrPair("netbox_vlan.test_cvlan", "qinq_svlan_id", "netbox_vlan.test_svlan", "id"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
NetBox 4.5 added Q-in-Q support to VLANs, but the resource exposes neither `qinq_role` nor `qinq_svlan`, so service and customer VLANs cannot be modelled from Terraform. This adds both attributes across create, read and update, with an acceptance test covering an SVLAN paired to a CVLAN.

Blocked on fbreckle/go-netbox#109, which adds the fields to the bindings; CI will not compile until that merges and a go-netbox release is tagged.