### PR TITLE
fix(prefixes): accumulate repeated tag filters instead of overwriting

### DIFF
--- a/docs/data-sources/prefixes.md
+++ b/docs/data-sources/prefixes.md
@@ -30,7 +30,7 @@ description: |-
 
 Required:
 
-- `name` (String) The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `tenant_id`, `site_id`, `role_id`, `region_id`, `description` & `tag`.
+- `name` (String) The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `tenant_id`, `site_id`, `role_id`, `region_id`, `description` & `tag`. `tag` may be repeated to filter on multiple tags; NetBox requires prefixes to match ALL specified tags (logical AND), not any of them.
 - `value` (String) The value to pass to the specified filter.
 
 

--- a/netbox/data_source_netbox_prefixes.go
+++ b/netbox/data_source_netbox_prefixes.go
@@ -25,7 +25,7 @@ func dataSourceNetboxPrefixes() *schema.Resource {
 						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `tenant_id`, `site_id`, `role_id`, `region_id`, `description` & `tag`.",
+							Description: "The name of the field to filter on. Supported fields are: `prefix`, `contains`, `vlan_vid`, `vrf_id`, `vlan_id`, `status`, `tenant_id`, `site_id`, `role_id`, `region_id`, `description` & `tag`. `tag` may be repeated to filter on multiple tags; NetBox requires prefixes to match ALL specified tags (logical AND), not any of them.",
 						},
 						"value": {
 							Type:        schema.TypeString,
@@ -159,7 +159,7 @@ func dataSourceNetboxPrefixesRead(d *schema.ResourceData, m interface{}) error {
 			case "description":
 				params.Description = &vString
 			case "tag":
-				params.Tag = []string{vString}
+				params.Tag = append(params.Tag, vString)
 			default:
 				return fmt.Errorf("'%s' is not a supported filter parameter", k)
 			}

--- a/netbox/data_source_netbox_prefixes_test.go
+++ b/netbox/data_source_netbox_prefixes_test.go
@@ -23,7 +23,7 @@ resource "netbox_prefix" "test_prefix1" {
   description = "my-description"
   vrf_id      = netbox_vrf.test_vrf.id
   vlan_id     = netbox_vlan.test_vlan1.id
-  tags        = [netbox_tag.test_tag1.slug]
+  tags        = [netbox_tag.test_tag1.slug, netbox_tag.test_tag3.slug]
 }
 
 resource "netbox_prefix" "test_prefix2" {
@@ -112,6 +112,10 @@ resource "netbox_tag" "test_tag2" {
   name = "tag-with-no-associations"
 }
 
+resource "netbox_tag" "test_tag3" {
+  name = "%[1]s_tag3"
+}
+
 data "netbox_prefixes" "by_vrf" {
   depends_on = [netbox_prefix.test_prefix1, netbox_prefix.test_prefix2]
   filter {
@@ -153,6 +157,37 @@ data "netbox_prefixes" "no_results" {
   filter {
     name  = "tag"
     value = netbox_tag.test_tag2.name
+  }
+}
+
+# test_prefix1 carries both test_tag1 and test_tag3, so requiring both tags
+# (repeated "tag" filter blocks) should still match it: NetBox ANDs repeated
+# tag filters together, and the provider must forward every value, not just
+# the last one seen.
+data "netbox_prefixes" "by_multiple_tags_and" {
+  depends_on = [netbox_prefix.test_prefix1]
+  filter {
+    name  = "tag"
+    value = netbox_tag.test_tag1.slug
+  }
+  filter {
+    name  = "tag"
+    value = netbox_tag.test_tag3.slug
+  }
+}
+
+# test_prefix1 does not carry test_tag2, so ANDing it with test_tag1 must
+# yield no matches. If the provider only forwarded one of the two "tag"
+# filters (the historical bug), this would incorrectly return test_prefix1.
+data "netbox_prefixes" "by_tag_and_unrelated_tag" {
+  depends_on = [netbox_prefix.test_prefix1]
+  filter {
+    name  = "tag"
+    value = netbox_tag.test_tag1.slug
+  }
+  filter {
+    name  = "tag"
+    value = netbox_tag.test_tag2.slug
   }
 }
 
@@ -223,6 +258,9 @@ data "netbox_prefixes" "find_prefix_with_description" {
 					resource.TestCheckResourceAttr("data.netbox_prefixes.by_status", "prefixes.#", "1"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.by_status", "prefixes.0.description", "my-description"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.no_results", "prefixes.#", "0"),
+					resource.TestCheckResourceAttr("data.netbox_prefixes.by_multiple_tags_and", "prefixes.#", "1"),
+					resource.TestCheckResourceAttr("data.netbox_prefixes.by_multiple_tags_and", "prefixes.0.description", "my-description"),
+					resource.TestCheckResourceAttr("data.netbox_prefixes.by_tag_and_unrelated_tag", "prefixes.#", "0"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_tenant_id", "prefixes.#", "1"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_tenant_id", "prefixes.0.prefix", "10.0.7.0/24"),
 					resource.TestCheckResourceAttr("data.netbox_prefixes.find_prefix_with_site_id", "prefixes.#", "1"),


### PR DESCRIPTION
## Problem

`data_source_netbox_prefixes.go` only kept the last `tag` filter block:

    case "tag":
        params.Tag = []string{vString}

Each repeated `filter { name = "tag" ... }` block overwrote the previous
one instead of accumulating, so a data source like:

    data "netbox_prefixes" "this" {
      filter { name = "status" value = "active" }
      filter { name = "tag"    value = "foo" }
      filter { name = "tag"    value = "bar" }
      filter { name = "tag"    value = "baz" }
    }

silently dropped two of the three tag filters before the request was ever
sent to NetBox — only one tag (not deterministically the last one written,
since `filter` is a `TypeSet`) reached the API.

NetBox's `TagFilter` is `conjoined=True` by default (see
`netbox/extras/filters.py`), meaning repeated `tag` query params are meant
to be ANDed — matches must carry *all* listed tags. The provider was
defeating that entirely by never forwarding more than one value.

## Fix

- Accumulate instead of overwrite: `params.Tag = append(params.Tag, vString)`.
- Updated the `filter.name` schema description (and the generated docs in
  `docs/data-sources/prefixes.md`) to document that repeated `tag` filters
  are ANDed, not ORed.
- Added acceptance test coverage:
  - `by_multiple_tags_and`: a prefix carrying two tags is matched when
    both are filtered on.
  - `by_tag_and_unrelated_tag`: ANDing with a tag the prefix doesn't have
    returns zero results — this case would have false-passed before the
    fix, since only one of the two tag filters was ever reaching the API.

## Testing

- Reviewed the diff by hand; no Go toolchain was available in the sandbox
  used to prepare this change, so `go build ./...` was not run here.
- Acceptance tests (`TestAccNetboxPrefixesDataSource_basic`) require
  `TF_ACC=1` and a live NetBox instance — **please run these before
  merging**.

## Compatibility

Behavior change: any existing config relying on the (buggy) "last tag
wins" behavior will now get stricter AND filtering across all listed
tags. This matches NetBox's actual filter semantics and the documented
intent of the `filter` block, but flagging in case anyone's data source
was inadvertently depending on the old behavior.