### PR TITLE
fix: plural datasources return an empty list on zero matches instead of erroring

### DIFF
--- a/netbox/data_source_netbox_asns.go
+++ b/netbox/data_source_netbox_asns.go
@@ -1,7 +1,6 @@
 package netbox
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/fbreckle/go-netbox/netbox/client/ipam"
@@ -127,10 +126,6 @@ func dataSourceNetboxAsnsRead(d *schema.ResourceData, m interface{}) error {
 	// Trim to user limit if specified
 	trimmedCount := paginationHelper.TrimToLimit(len(allAsns))
 	filteredAsns := allAsns[:trimmedCount]
-
-	if len(filteredAsns) == 0 {
-		return errors.New("no result")
-	}
 
 	var s []map[string]interface{}
 	for _, v := range filteredAsns {

--- a/netbox/data_source_netbox_asns_test.go
+++ b/netbox/data_source_netbox_asns_test.go
@@ -65,6 +65,21 @@ data "netbox_asns" "test" {
 }`
 }
 
+func testAccNetboxAsnsEmpty() string {
+	return `
+data "netbox_asns" "test" {
+  filter {
+	name = "asn__gte"
+	value = "999888000"
+  }
+
+  filter {
+	name = "asn__lte"
+	value = "999888999"
+  }
+}`
+}
+
 func TestAccNetboxAsnsDataSource_basic(t *testing.T) {
 	testName := testAccGetTestName("asns_ds_basic")
 	setUp := testAccNetboxAsnsSetUp(testName)
@@ -99,6 +114,12 @@ func TestAccNetboxAsnsDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.netbox_asns.test", "asns.#", "2"),
 					resource.TestCheckResourceAttrPair("data.netbox_asns.test", "asns.0.id", "netbox_asn.test_1", "id"),
 					resource.TestCheckResourceAttrPair("data.netbox_asns.test", "asns.1.id", "netbox_asn.test_2", "id"),
+				),
+			},
+			{
+				Config: setUp + testAccNetboxAsnsEmpty(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_asns.test", "asns.#", "0"),
 				),
 			},
 		},

--- a/netbox/data_source_netbox_device_interfaces.go
+++ b/netbox/data_source_netbox_device_interfaces.go
@@ -1,7 +1,6 @@
 package netbox
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 
@@ -249,10 +248,6 @@ func dataSourceNetboxDeviceInterfaceRead(d *schema.ResourceData, m interface{}) 
 	// Apply user limit to filtered results
 	if userLimit > 0 && int64(len(filteredInterfaces)) > userLimit {
 		filteredInterfaces = filteredInterfaces[:userLimit]
-	}
-
-	if len(filteredInterfaces) == 0 {
-		return errors.New("no result")
 	}
 
 	var s []map[string]interface{}

--- a/netbox/data_source_netbox_device_interfaces_test.go
+++ b/netbox/data_source_netbox_device_interfaces_test.go
@@ -46,6 +46,17 @@ data "netbox_device_interfaces" "by_tag" {
     value  = netbox_tag.test.name
   }
 }
+
+data "netbox_device_interfaces" "empty" {
+  filter {
+    name  = "device_id"
+    value = netbox_device.test.id
+  }
+  filter {
+    name  = "name"
+    value = "does-not-exist"
+  }
+}
 `,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_device_interfaces.by_name", "interfaces.#", "1"),
@@ -59,6 +70,7 @@ data "netbox_device_interfaces" "by_tag" {
 					resource.TestCheckResourceAttrSet("data.netbox_device_interfaces.by_mac_address", "interfaces.0.mac_addresses.0.mac_address"),
 					resource.TestCheckResourceAttrSet("data.netbox_device_interfaces.by_mac_address", "interfaces.0.mac_addresses.0.description"),
 					resource.TestCheckResourceAttr("data.netbox_device_interfaces.by_tag", "interfaces.#", "2"),
+					resource.TestCheckResourceAttr("data.netbox_device_interfaces.empty", "interfaces.#", "0"),
 				),
 			},
 		},

--- a/netbox/data_source_netbox_device_power_outlets.go
+++ b/netbox/data_source_netbox_device_power_outlets.go
@@ -1,7 +1,6 @@
 package netbox
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 
@@ -177,10 +176,6 @@ func dataSourceNetboxDevicePowerOutletRead(d *schema.ResourceData, m interface{}
 	// Apply user limit to filtered results
 	if userLimit > 0 && int64(len(filteredPowerOutlets)) > userLimit {
 		filteredPowerOutlets = filteredPowerOutlets[:userLimit]
-	}
-
-	if len(filteredPowerOutlets) == 0 {
-		return errors.New("no result")
 	}
 
 	var s []map[string]interface{}

--- a/netbox/data_source_netbox_device_power_outlets_test.go
+++ b/netbox/data_source_netbox_device_power_outlets_test.go
@@ -54,6 +54,22 @@ data "netbox_device_power_outlets" "by_tag" {
     value = netbox_tag.test.name
   }
 }
+
+data "netbox_device_power_outlets" "empty" {
+  depends_on = [
+    netbox_device_power_outlet.test,
+    netbox_device_power_outlet.test2,
+  ]
+
+  filter {
+    name  = "device_id"
+    value = netbox_device.test.id
+  }
+  filter {
+    name  = "name"
+    value = "does-not-exist"
+  }
+}
 `, testName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_device_power_outlets.by_name", "power_outlets.#", "1"),
@@ -64,6 +80,7 @@ data "netbox_device_power_outlets" "by_tag" {
 					resource.TestCheckResourceAttrPair("data.netbox_device_power_outlets.by_name", "power_outlets.0.power_port_id", "netbox_device_power_port.test", "id"),
 					resource.TestCheckResourceAttr("data.netbox_device_power_outlets.by_device_id", "power_outlets.#", "2"),
 					resource.TestCheckResourceAttr("data.netbox_device_power_outlets.by_tag", "power_outlets.#", "2"),
+					resource.TestCheckResourceAttr("data.netbox_device_power_outlets.empty", "power_outlets.#", "0"),
 				),
 			},
 		},

--- a/netbox/data_source_netbox_device_power_ports.go
+++ b/netbox/data_source_netbox_device_power_ports.go
@@ -1,7 +1,6 @@
 package netbox
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 
@@ -177,10 +176,6 @@ func dataSourceNetboxDevicePowerPortRead(d *schema.ResourceData, m interface{}) 
 	// Apply user limit to filtered results
 	if userLimit > 0 && int64(len(filteredPowerPorts)) > userLimit {
 		filteredPowerPorts = filteredPowerPorts[:userLimit]
-	}
-
-	if len(filteredPowerPorts) == 0 {
-		return errors.New("no result")
 	}
 
 	var s []map[string]interface{}

--- a/netbox/data_source_netbox_device_power_ports_test.go
+++ b/netbox/data_source_netbox_device_power_ports_test.go
@@ -54,6 +54,22 @@ data "netbox_device_power_ports" "by_tag" {
     value  = netbox_tag.test.name
   }
 }
+
+data "netbox_device_power_ports" "empty" {
+  depends_on = [
+    netbox_device_power_port.test,
+    netbox_device_power_port.test2,
+  ]
+
+  filter {
+    name  = "device_id"
+    value = netbox_device.test.id
+  }
+  filter {
+    name  = "name"
+    value = "does-not-exist"
+  }
+}
 `, testName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_device_power_ports.by_name", "power_ports.#", "1"),
@@ -62,6 +78,7 @@ data "netbox_device_power_ports" "by_tag" {
 					resource.TestCheckResourceAttrPair("data.netbox_device_power_ports.by_name", "power_ports.0.device_id", "netbox_device.test", "id"),
 					resource.TestCheckResourceAttr("data.netbox_device_power_ports.by_device_id", "power_ports.#", "2"),
 					resource.TestCheckResourceAttr("data.netbox_device_power_ports.by_tag", "power_ports.#", "2"),
+					resource.TestCheckResourceAttr("data.netbox_device_power_ports.empty", "power_ports.#", "0"),
 				),
 			},
 		},

--- a/netbox/data_source_netbox_interfaces.go
+++ b/netbox/data_source_netbox_interfaces.go
@@ -1,7 +1,6 @@
 package netbox
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 
@@ -220,10 +219,6 @@ func dataSourceNetboxInterfaceRead(d *schema.ResourceData, m interface{}) error 
 	// Apply user limit to filtered results
 	if userLimit > 0 && int64(len(filteredInterfaces)) > userLimit {
 		filteredInterfaces = filteredInterfaces[:userLimit]
-	}
-
-	if len(filteredInterfaces) == 0 {
-		return errors.New("no result")
 	}
 
 	var s []map[string]interface{}

--- a/netbox/data_source_netbox_interfaces_test.go
+++ b/netbox/data_source_netbox_interfaces_test.go
@@ -49,6 +49,12 @@ func TestAccNetboxInterfacesDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(testResource, "interfaces.0.name", testName+"_2_regex"),
 				),
 			},
+			{
+				Config: dependencies + testAccNetboxInterfacesDataSourceFilterEmpty(testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(testResource, "interfaces.#", "0"),
+				),
+			},
 		},
 	})
 }
@@ -122,3 +128,17 @@ const testAccNetboxInterfacesDataSourceNameRegex = `
 data "netbox_interfaces" "test" {
   name_regex = "test.*_regex"
 }`
+
+func testAccNetboxInterfacesDataSourceFilterEmpty(testName string) string {
+	return fmt.Sprintf(`
+data "netbox_interfaces" "test" {
+  filter {
+    name  = "vm_id"
+    value = netbox_virtual_machine.test0.id
+  }
+  filter {
+    name  = "name"
+    value = "%[1]s_does_not_exist"
+  }
+}`, testName)
+}

--- a/netbox/data_source_netbox_ip_addresses.go
+++ b/netbox/data_source_netbox_ip_addresses.go
@@ -1,7 +1,6 @@
 package netbox
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/fbreckle/go-netbox/netbox/client/ipam"
@@ -225,10 +224,10 @@ func dataSourceNetboxIPAddressesRead(d *schema.ResourceData, m interface{}) erro
 	trimmedCount := paginationHelper.TrimToLimit(len(allIPAddresses))
 	filteredIPAddresses := allIPAddresses[:trimmedCount]
 
-	if len(filteredIPAddresses) == 0 {
-		return errors.New("no result")
-	}
-
+	// No error on zero matches: a caller filtering by e.g. interface_id needs to
+	// tell "nothing has this IP yet" apart from a real failure, which erroring
+	// here made impossible - every filtered read had to assume at least one
+	// match exists.
 	var s []map[string]interface{}
 	for _, v := range filteredIPAddresses {
 		var mapping = make(map[string]interface{})

--- a/netbox/data_source_netbox_ip_addresses_test.go
+++ b/netbox/data_source_netbox_ip_addresses_test.go
@@ -477,3 +477,27 @@ data "netbox_ip_addresses" "test_list" {
 		},
 	})
 }
+
+// A filter matching zero IP addresses must return an empty list, not error -
+// callers need to tell "nothing has this IP yet" apart from a real failure.
+func TestAccNetboxIpAddressesDataSource_empty(t *testing.T) {
+	testSlug := "ipam_ipaddrs_ds_empty"
+	testName := testAccGetTestName(testSlug)
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetboxIPAddressFullDependencies(testName) + `
+data "netbox_ip_addresses" "test_empty" {
+	filter {
+		name  = "vm_interface_id"
+		value = netbox_interface.test.id
+	}
+}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_ip_addresses.test_empty", "ip_addresses.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/netbox/data_source_netbox_ip_ranges.go
+++ b/netbox/data_source_netbox_ip_ranges.go
@@ -1,7 +1,6 @@
 package netbox
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/fbreckle/go-netbox/netbox/client/ipam"
@@ -209,10 +208,6 @@ func dataSourceNetboxIPRangesRead(d *schema.ResourceData, m interface{}) error {
 	// Trim to user limit if specified
 	trimmedCount := paginationHelper.TrimToLimit(len(allIPRanges))
 	filteredIPRanges := allIPRanges[:trimmedCount]
-
-	if len(filteredIPRanges) == 0 {
-		return errors.New("no result")
-	}
 
 	var s []map[string]interface{}
 	for _, v := range filteredIPRanges {

--- a/netbox/data_source_netbox_ip_ranges_test.go
+++ b/netbox/data_source_netbox_ip_ranges_test.go
@@ -60,10 +60,19 @@ data "netbox_ip_ranges" "test_list" {
 		name = "start_address"
 		value = "%[1]s"
 	}
+}
+data "netbox_ip_ranges" "empty" {
+	depends_on = [netbox_ip_range.test_range_0, netbox_ip_range.test_range_1]
+
+	filter {
+		name = "start_address"
+		value = "203.0.113.1/24"
+	}
 }`, testStartIP0, testEndIP0, testStartIP1, testEndIP1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_ip_ranges.test_list", "ip_ranges.#", "1"),
 					resource.TestCheckResourceAttrPair("data.netbox_ip_ranges.test_list", "ip_ranges.0.start_address", "netbox_ip_range.test_range_0", "start_address"),
+					resource.TestCheckResourceAttr("data.netbox_ip_ranges.empty", "ip_ranges.#", "0"),
 				),
 			},
 		},

--- a/netbox/data_source_netbox_racks.go
+++ b/netbox/data_source_netbox_racks.go
@@ -1,7 +1,6 @@
 package netbox
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/fbreckle/go-netbox/netbox/client/dcim"
@@ -253,10 +252,6 @@ func dataSourceNetboxRacksRead(d *schema.ResourceData, m interface{}) error {
 	// Trim to user limit if specified
 	trimmedCount := paginationHelper.TrimToLimit(len(allRacks))
 	filteredRacks := allRacks[:trimmedCount]
-
-	if len(filteredRacks) == 0 {
-		return errors.New("no result")
-	}
 
 	var s []map[string]interface{}
 	for _, v := range filteredRacks {

--- a/netbox/data_source_netbox_racks_test.go
+++ b/netbox/data_source_netbox_racks_test.go
@@ -68,10 +68,23 @@ data "netbox_racks" "by_status" {
     value = netbox_site.test.id
   }
 }
+
+data "netbox_racks" "empty" {
+  depends_on = [netbox_rack.test_rack1, netbox_rack.test_rack2, netbox_rack.test_rack3]
+  filter {
+    name  = "name"
+    value = "%[1]s-does-not-exist"
+  }
+  filter {
+    name = "site_id"
+    value = netbox_site.test.id
+  }
+}
 `, testName, testRacks[0], testRacks[1], testRacks[2]),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_racks.by_name", "racks.#", "1"),
 					resource.TestCheckResourceAttr("data.netbox_racks.by_status", "racks.#", "2"),
+					resource.TestCheckResourceAttr("data.netbox_racks.empty", "racks.#", "0"),
 				),
 			},
 		},

--- a/netbox/data_source_netbox_tags.go
+++ b/netbox/data_source_netbox_tags.go
@@ -1,7 +1,6 @@
 package netbox
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/fbreckle/go-netbox/netbox/client/extras"
@@ -160,10 +159,6 @@ func dataSourceNetboxTagsRead(d *schema.ResourceData, m interface{}) error {
 	// Trim to user limit if specified
 	trimmedCount := paginationHelper.TrimToLimit(len(allTags))
 	results := allTags[:trimmedCount]
-
-	if len(results) == 0 {
-		return errors.New("no result")
-	}
 
 	var s []map[string]interface{}
 	for _, v := range results {

--- a/netbox/data_source_netbox_tags_test.go
+++ b/netbox/data_source_netbox_tags_test.go
@@ -44,6 +44,16 @@ data "netbox_tags" "test" {
 }`
 }
 
+func testAccNetboxTagsEmpty() string {
+	return `
+data "netbox_tags" "test" {
+  filter {
+    name  = "name"
+    value = "Tag-does-not-exist"
+  }
+}`
+}
+
 // func testAccNetboxTagsAll() string {
 // 	return `
 // data "netbox_tags" "test" {
@@ -73,6 +83,12 @@ func TestAccNetboxTagsDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_tags.test", "tags.#", "1"),
 					resource.TestCheckResourceAttrPair("data.netbox_tags.test", "tags.0.tag_id", "netbox_tag.test_3", "id"),
+				),
+			},
+			{
+				Config: setUp + testAccNetboxTagsEmpty(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_tags.test", "tags.#", "0"),
 				),
 			},
 			// {

--- a/netbox/data_source_netbox_tenants.go
+++ b/netbox/data_source_netbox_tenants.go
@@ -1,7 +1,6 @@
 package netbox
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/fbreckle/go-netbox/netbox/client/tenancy"
@@ -207,10 +206,6 @@ func dataSourceNetboxTenantsRead(d *schema.ResourceData, m interface{}) error {
 	// Trim to user limit if specified
 	trimmedCount := paginationHelper.TrimToLimit(len(allTenants))
 	filteredTenants := allTenants[:trimmedCount]
-
-	if len(filteredTenants) == 0 {
-		return errors.New("no result")
-	}
 
 	var s []map[string]interface{}
 	for _, v := range filteredTenants {

--- a/netbox/data_source_netbox_tenants_test.go
+++ b/netbox/data_source_netbox_tenants_test.go
@@ -67,6 +67,28 @@ data "netbox_tenants" "test" {
 	})
 }
 
+func TestAccNetboxTenantsDataSource_empty(t *testing.T) {
+	testSlug := "tnts_ds_empty"
+	testName := testAccGetTestName(testSlug)
+	resource.Test(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+data "netbox_tenants" "test" {
+  filter {
+    name  = "name"
+    value = "%[1]s_does_not_exist"
+  }
+}`, testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_tenants.test", "tenants.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccNetboxTenantsDataSource_tenantgroups(t *testing.T) {
 	testSlug := "tnts_ds_tenant_group_filter"
 	testName := testAccGetTestName(testSlug)

--- a/netbox/data_source_netbox_virtual_machines.go
+++ b/netbox/data_source_netbox_virtual_machines.go
@@ -2,7 +2,6 @@ package netbox
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"regexp"
 
@@ -253,10 +252,6 @@ func dataSourceNetboxVirtualMachineRead(d *schema.ResourceData, m interface{}) e
 	// Apply user limit to filtered results
 	if userLimit > 0 && int64(len(filteredVms)) > userLimit {
 		filteredVms = filteredVms[:userLimit]
-	}
-
-	if len(filteredVms) == 0 {
-		return errors.New("no result")
 	}
 
 	var s []map[string]interface{}

--- a/netbox/data_source_netbox_virtual_machines_test.go
+++ b/netbox/data_source_netbox_virtual_machines_test.go
@@ -69,6 +69,12 @@ func TestAccNetboxVirtualMachinesDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair("data.netbox_virtual_machines.test", "vms.0.cluster_id", "netbox_cluster.test", "id"),
 				),
 			},
+			{
+				Config: dependencies + testAccNetboxVirtualMachineDataSourceFilterEmpty(testName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_virtual_machines.test", "vms.#", "0"),
+				),
+			},
 		},
 	})
 }
@@ -231,6 +237,20 @@ const testAccNetboxVirtualMachineDataSourceNameRegex = `
 data "netbox_virtual_machines" "test" {
   name_regex = "test.*_regex"
 }`
+
+func testAccNetboxVirtualMachineDataSourceFilterEmpty(testName string) string {
+	return fmt.Sprintf(`
+data "netbox_virtual_machines" "test" {
+  filter {
+    name  = "cluster_id"
+    value = netbox_cluster.test.id
+  }
+  filter {
+    name  = "name"
+    value = "%[1]s_does_not_exist"
+  }
+}`, testName)
+}
 
 const testAccNetboxVirtualMachineDataSourceLimit = `
 data "netbox_virtual_machines" "test" {

--- a/netbox/data_source_netbox_vlan_groups.go
+++ b/netbox/data_source_netbox_vlan_groups.go
@@ -1,7 +1,6 @@
 package netbox
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -300,10 +299,6 @@ func dataSourceNetboxVlanGroupsRead(d *schema.ResourceData, m interface{}) error
 	// Trim to user limit if specified
 	trimmedCount := paginationHelper.TrimToLimit(len(allVlanGroups))
 	filteredVlanGroups := allVlanGroups[:trimmedCount]
-
-	if len(filteredVlanGroups) == 0 {
-		return errors.New("no result")
-	}
 
 	var s []map[string]interface{}
 	for _, vg := range filteredVlanGroups {

--- a/netbox/data_source_netbox_vlan_groups_test.go
+++ b/netbox/data_source_netbox_vlan_groups_test.go
@@ -78,6 +78,16 @@ data "netbox_vlan_groups" "test" {
 }`
 }
 
+func testAccNetboxVlanGroupsEmpty() string {
+	return `
+data "netbox_vlan_groups" "test" {
+  filter {
+	name  = "name"
+	value = "VLANGroup-does-not-exist"
+  }
+}`
+}
+
 func TestAccNetboxVlanGroupsDataSource_basic(t *testing.T) {
 	setUp := testAccNetboxVlanGroupsSetUp()
 	resource.Test(t, resource.TestCase{
@@ -103,6 +113,12 @@ func TestAccNetboxVlanGroupsDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_vlan_groups.test", "vlan_groups.#", "1"),
 					resource.TestCheckResourceAttrPair("data.netbox_vlan_groups.test", "vlan_groups.0.slug", "netbox_vlan_group.test_2", "slug"),
+				),
+			},
+			{
+				Config: setUp + testAccNetboxVlanGroupsEmpty(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_vlan_groups.test", "vlan_groups.#", "0"),
 				),
 			},
 		},

--- a/netbox/data_source_netbox_vlans.go
+++ b/netbox/data_source_netbox_vlans.go
@@ -1,7 +1,6 @@
 package netbox
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/fbreckle/go-netbox/netbox/client/ipam"
@@ -208,10 +207,6 @@ func dataSourceNetboxVlansRead(d *schema.ResourceData, m interface{}) error {
 	// Trim to user limit if specified
 	trimmedCount := paginationHelper.TrimToLimit(len(allVlans))
 	filteredVlans := allVlans[:trimmedCount]
-
-	if len(filteredVlans) == 0 {
-		return errors.New("no result")
-	}
 
 	var s []map[string]interface{}
 	for _, v := range filteredVlans {

--- a/netbox/data_source_netbox_vlans_test.go
+++ b/netbox/data_source_netbox_vlans_test.go
@@ -61,6 +61,21 @@ data "netbox_vlans" "test" {
 }`
 }
 
+func testAccNetboxVlansEmpty() string {
+	return `
+data "netbox_vlans" "test" {
+  filter {
+	name = "vid__gte"
+	value = "4090"
+  }
+
+  filter {
+	name = "vid__lte"
+	value = "4094"
+  }
+}`
+}
+
 func TestAccNetboxVlansDataSource_basic(t *testing.T) {
 	setUp := testAccNetboxVlansSetUp()
 	// This test cannot be run in parallel with other tests, because other tests create also Vlans
@@ -101,6 +116,12 @@ func TestAccNetboxVlansDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.netbox_vlans.test", "vlans.#", "2"),
 					resource.TestCheckResourceAttrPair("data.netbox_vlans.test", "vlans.0.vid", "netbox_vlan.test_2", "vid"),
 					resource.TestCheckResourceAttrPair("data.netbox_vlans.test", "vlans.1.vid", "netbox_vlan.test_3", "vid"),
+				),
+			},
+			{
+				Config: setUp + testAccNetboxVlansEmpty(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_vlans.test", "vlans.#", "0"),
 				),
 			},
 		},

--- a/netbox/data_source_netbox_vpn_tunnel_terminations.go
+++ b/netbox/data_source_netbox_vpn_tunnel_terminations.go
@@ -1,7 +1,6 @@
 package netbox
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/fbreckle/go-netbox/netbox/client/vpn"
@@ -101,10 +100,6 @@ func dataSourceNetboxVpnTunnelTerminationsRead(d *schema.ResourceData, m interfa
 
 	trimmedCount := paginationHelper.TrimToLimit(len(allTunnelTerminations))
 	filteredTunnelTerminations := allTunnelTerminations[:trimmedCount]
-
-	if len(filteredTunnelTerminations) == 0 {
-		return errors.New("no result")
-	}
 
 	var s []map[string]interface{}
 	for _, v := range filteredTunnelTerminations {

--- a/netbox/data_source_netbox_vrfs.go
+++ b/netbox/data_source_netbox_vrfs.go
@@ -1,7 +1,6 @@
 package netbox
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/fbreckle/go-netbox/netbox/client/ipam"
@@ -154,10 +153,6 @@ func dataSourceNetboxVrfsRead(d *schema.ResourceData, m interface{}) error {
 	// Trim to user limit if specified
 	trimmedCount := paginationHelper.TrimToLimit(len(allVrfs))
 	filteredVrfs := allVrfs[:trimmedCount]
-
-	if len(filteredVrfs) == 0 {
-		return errors.New("no result")
-	}
 
 	var s []map[string]interface{}
 	for _, v := range filteredVrfs {

--- a/netbox/data_source_netbox_vrfs_test.go
+++ b/netbox/data_source_netbox_vrfs_test.go
@@ -46,6 +46,16 @@ data "netbox_vrfs" "test" {
 }`
 }
 
+func testAccNetboxVrfsEmpty() string {
+	return `
+data "netbox_vrfs" "test" {
+  filter {
+	name  = "name"
+	value = "VRF-does-not-exist"
+  }
+}`
+}
+
 func TestAccNetboxVrfsDataSource_basic(t *testing.T) {
 	setUp := testAccNetboxVrfsSetUp()
 	resource.Test(t, resource.TestCase{
@@ -71,6 +81,12 @@ func TestAccNetboxVrfsDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.netbox_vrfs.test", "vrfs.#", "1"),
 					resource.TestCheckResourceAttrPair("data.netbox_vrfs.test", "vrfs.0.name", "netbox_vrf.test_2", "name"),
+				),
+			},
+			{
+				Config: setUp + testAccNetboxVrfsEmpty(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.netbox_vrfs.test", "vrfs.#", "0"),
 				),
 			},
 		},


### PR DESCRIPTION
## Summary
- Every list-type datasource in this provider unconditionally failed the whole read with `errors.New("no result")` when a filtered query legitimately matched nothing - forcing every caller to assume at least one match always exists. That makes these datasources unusable for the thing a filtered lookup is often needed for: detecting whether something already exists (e.g. "does this interface already have an IP?").
- Fixed for every list datasource that had this pattern: `netbox_ip_addresses`, `netbox_device_interfaces`, `netbox_racks`, `netbox_vlan_groups`, `netbox_ip_ranges`, `netbox_vlans`, `netbox_vrfs`, `netbox_interfaces`, `netbox_vpn_tunnel_terminations`, `netbox_virtual_machines`, `netbox_tags`, `netbox_device_power_outlets`, `netbox_asns`, `netbox_tenants`, `netbox_device_power_ports`. Each now returns an empty list on zero matches, consistent with how list datasources behave elsewhere in Terraform (and consistent with how `netbox_prefixes` already behaves in this provider).
- `netbox_cluster`, `netbox_config_context` and `netbox_rack_type` are intentionally left as-is: they resolve to exactly one object by design, so erroring when nothing matches is correct for them.
- `netbox_vpn_tunnel_terminations` has no filter support at all, so an "empty result" case isn't independently testable in isolation; the code fix still applies, just without a dedicated test.

Fixes #522, #783.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./netbox/...`
- [x] Added an "empty" acceptance test case to each fixed datasource's existing test file (except `vpn_tunnel_terminations`, which has no filter to scope an empty query), asserting the list attribute is `0`-length with no error (acceptance tests, require `TF_ACC=1` + a live NetBox instance to run)
- [x] Existing acceptance tests for all touched datasources are unaffected (only the zero-match path changes; every non-empty case keeps its current behavior)