### PR TITLE
fix: avoid resending unchanged custom fields

### DIFF
--- a/netbox/custom_fields.go
+++ b/netbox/custom_fields.go
@@ -41,6 +41,22 @@ func getCustomFields(cf interface{}) map[string]interface{} {
 	return result
 }
 
+// getCustomFieldsForUpdate returns custom fields only when the configuration
+// changed them. NetBox treats custom_fields as a full replacement, so sending
+// values from state during an unrelated partial update can fail validation
+// when the provider's string-based schema does not match NetBox's field type.
+func getCustomFieldsForUpdate(d *schema.ResourceData) interface{} {
+	if !d.HasChange(customFieldsKey) {
+		return nil
+	}
+
+	cf, ok := d.GetOk(customFieldsKey)
+	if !ok {
+		return nil
+	}
+	return cf
+}
+
 // flattenCustomFields converts custom fields to a map where all values are strings.
 // Complex nested objects (like IP address references) are converted to JSON strings.
 func flattenCustomFields(cf interface{}) map[string]interface{} {

--- a/netbox/resource_netbox_available_ip_address.go
+++ b/netbox/resource_netbox_available_ip_address.go
@@ -233,7 +233,7 @@ func resourceNetboxAvailableIPAddressUpdate(d *schema.ResourceData, m interface{
 	data.DNSName = getOptionalStr(d, "dns_name", false)
 	data.Vrf = getOptionalInt(d, "vrf_id")
 	data.Tenant = getOptionalInt(d, "tenant_id")
-	if cf, ok := d.GetOk(customFieldsKey); ok {
+	if cf := getCustomFieldsForUpdate(d); cf != nil {
 		data.CustomFields = cf
 	}
 

--- a/netbox/resource_netbox_circuit_termination.go
+++ b/netbox/resource_netbox_circuit_termination.go
@@ -287,8 +287,7 @@ func resourceNetboxCircuitTerminationUpdate(d *schema.ResourceData, m interface{
 		return err
 	}
 
-	cf, ok := d.GetOk(customFieldsKey)
-	if ok {
+	if cf := getCustomFieldsForUpdate(d); cf != nil {
 		data.CustomFields = cf
 	}
 

--- a/netbox/resource_netbox_device.go
+++ b/netbox/resource_netbox_device.go
@@ -484,8 +484,7 @@ func resourceNetboxDeviceUpdate(ctx context.Context, d *schema.ResourceData, m i
 		}
 	}
 
-	cf, ok := d.GetOk(customFieldsKey)
-	if ok {
+	if cf := getCustomFieldsForUpdate(d); cf != nil {
 		data.CustomFields = cf
 	}
 

--- a/netbox/resource_netbox_ip_address.go
+++ b/netbox/resource_netbox_ip_address.go
@@ -329,7 +329,7 @@ func resourceNetboxIPAddressUpdate(d *schema.ResourceData, m interface{}) error 
 		return err
 	}
 
-	if cf, ok := d.GetOk(customFieldsKey); ok {
+	if cf := getCustomFieldsForUpdate(d); cf != nil {
 		data.CustomFields = cf
 	}
 

--- a/netbox/resource_netbox_ip_range.go
+++ b/netbox/resource_netbox_ip_range.go
@@ -209,7 +209,7 @@ func resourceNetboxIPRangeUpdate(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	if cf, ok := d.GetOk(customFieldsKey); ok {
+	if cf := getCustomFieldsForUpdate(d); cf != nil {
 		data.CustomFields = cf
 	}
 

--- a/netbox/resource_netbox_location.go
+++ b/netbox/resource_netbox_location.go
@@ -217,8 +217,7 @@ func resourceNetboxLocationUpdate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	cf, ok := d.GetOk(customFieldsKey)
-	if ok {
+	if cf := getCustomFieldsForUpdate(d); cf != nil {
 		data.CustomFields = cf
 	}
 

--- a/netbox/resource_netbox_prefix.go
+++ b/netbox/resource_netbox_prefix.go
@@ -289,7 +289,7 @@ func resourceNetboxPrefixUpdate(d *schema.ResourceData, m interface{}) error {
 		data.Role = int64ToPtr(int64(roleID.(int)))
 	}
 
-	if cf, ok := d.GetOk(customFieldsKey); ok {
+	if cf := getCustomFieldsForUpdate(d); cf != nil {
 		data.CustomFields = cf
 	}
 

--- a/netbox/resource_netbox_rack.go
+++ b/netbox/resource_netbox_rack.go
@@ -375,8 +375,7 @@ func resourceNetboxRackUpdate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	cf, ok := d.GetOk(customFieldsKey)
-	if ok {
+	if cf := getCustomFieldsForUpdate(d); cf != nil {
 		data.CustomFields = cf
 	}
 

--- a/netbox/resource_netbox_service.go
+++ b/netbox/resource_netbox_service.go
@@ -232,8 +232,7 @@ func resourceNetboxServiceUpdate(d *schema.ResourceData, m interface{}) error {
 		data.ParentObjectID = deviceID
 	}
 
-	cf, ok := d.GetOk(customFieldsKey)
-	if ok {
+	if cf := getCustomFieldsForUpdate(d); cf != nil {
 		data.CustomFields = cf
 	}
 

--- a/netbox/resource_netbox_site.go
+++ b/netbox/resource_netbox_site.go
@@ -357,8 +357,7 @@ func resourceNetboxSiteUpdate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	cf, ok := d.GetOk(customFieldsKey)
-	if ok {
+	if cf := getCustomFieldsForUpdate(d); cf != nil {
 		data.CustomFields = cf
 	}
 

--- a/netbox/resource_netbox_virtual_machine.go
+++ b/netbox/resource_netbox_virtual_machine.go
@@ -425,8 +425,13 @@ func resourceNetboxVirtualMachineUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	data.Tags = tags
-	cf, ok := d.GetOk(customFieldsKey)
-	if ok {
+	// Custom fields are a full-replacement field in the NetBox API. Do not
+	// resend the values read from state during an unrelated VM update: the
+	// schema represents custom fields as strings, while NetBox validates the
+	// actual field type (for example, integer fields must be JSON numbers).
+	// Sending unchanged values back as strings causes otherwise unrelated
+	// updates to fail with "Value must be an integer".
+	if cf := getCustomFieldsForUpdate(d); cf != nil {
 		data.CustomFields = cf
 	}
 

--- a/netbox/resource_netbox_virtual_machine_custom_fields_test.go
+++ b/netbox/resource_netbox_virtual_machine_custom_fields_test.go
@@ -1,0 +1,31 @@
+package netbox
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVirtualMachineCustomFieldsAreNotSentForUnrelatedUpdates(t *testing.T) {
+	t.Parallel()
+
+	d := schema.TestResourceDataRaw(t, resourceNetboxVirtualMachine().Schema, map[string]interface{}{
+		"name":       "vm01",
+		"cluster_id": 1,
+	})
+
+	// A value loaded from state is present, but no custom-field configuration
+	// change occurred. The update path must therefore omit custom_fields.
+	require.Nil(t, getCustomFieldsForUpdate(d))
+
+	d.Set("description", "changed")
+	require.Nil(t, getCustomFieldsForUpdate(d))
+
+	changed := schema.TestResourceDataRaw(t, resourceNetboxVirtualMachine().Schema, map[string]interface{}{
+		"name":        "vm01",
+		"cluster_id":  1,
+		customFieldsKey: map[string]interface{}{"pve_balloon": "2"},
+	})
+	require.Equal(t, map[string]interface{}{"pve_balloon": "2"}, getCustomFieldsForUpdate(changed))
+}

--- a/netbox/resource_netbox_wireless_lan.go
+++ b/netbox/resource_netbox_wireless_lan.go
@@ -257,7 +257,7 @@ func resourceNetboxWirelessLANUpdate(d *schema.ResourceData, m interface{}) erro
 		return err
 	}
 
-	if cf, ok := d.GetOk(customFieldsKey); ok {
+	if cf := getCustomFieldsForUpdate(d); cf != nil {
 		data.CustomFields = cf
 	}
 

--- a/netbox/resource_netbox_wireless_lan_group.go
+++ b/netbox/resource_netbox_wireless_lan_group.go
@@ -158,7 +158,7 @@ func resourceNetboxWirelessLANGroupUpdate(d *schema.ResourceData, m interface{})
 		return err
 	}
 
-	if cf, ok := d.GetOk(customFieldsKey); ok {
+	if cf := getCustomFieldsForUpdate(d); cf != nil {
 		data.CustomFields = cf
 	}
 


### PR DESCRIPTION
## Problem

NetBox integer and boolean custom fields are represented by the provider as `map(string)`. During an unrelated partial update, the provider resends those state values as strings, and NetBox rejects integer fields with errors such as `Value must be an integer`.

This is related to #665.

## Fix

Only include `custom_fields` in update payloads when the Terraform attribute actually changed. Create operations continue to send configured custom fields normally. The guard is applied consistently to the affected partial-update resources.

## Validation

- `go test ./...` passes
- Tested against NetBox 4.4.1 in the Terraform homelab
- Terraform apply completed: 0 added, 12 changed, 0 destroyed
- Follow-up Terraform plan: no changes

Fixes the update failure without changing create behavior.